### PR TITLE
Fix erroneous AX25 socket arguments to clear kernel warnings

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -4027,11 +4027,15 @@ int ax25_init(int port) {
 //    if (port_data[port].channel == -1) {
 
     ENABLE_SETUID_PRIVILEGE;
-#if __GLIBC__ >= 2 && __GLIBC_MINOR >= 3
-    port_data[port].channel = socket(PF_INET, SOCK_DGRAM, htons(proto));   // proto = AF_AX25
-#else   // __GLIBC__ >= 2 && __GLIBC_MINOR >= 3
+#if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 3
+      // proto = AF_PACKET for GLIBC version 2.3 and later
+    port_data[port].channel = socket(AF_PACKET, SOCK_RAW, htons(proto));  
+#else   // __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 3
+      // Prior to that, PF_INET and SOCK_PACKET were the right thing to do
+      // This still works as recently as GLIBC 2.19,  but some systems
+      // spit warnings into the syslog about an obsolete usage.
     port_data[port].channel = socket(PF_INET, SOCK_PACKET, htons(proto));
-#endif      // __GLIBC__ >= 2 && __GLIBC_MINOR >= 3
+#endif      // __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 3
     DISABLE_SETUID_PRIVILEGE;
 
     if (port_data[port].channel == -1) {


### PR DESCRIPTION
In commit 6085237a1 on 8 Jan 2003, Chuck Byam added code to interface.c
in an attempt to work around the deprecation of sockets of address family
PF_INET and type SOCK_PACKET.  Unfortunately, the prepreocessor macros he
used to detect GLIBC version had an error in them and so have in fact never
been getting compiled in.  When I fixed that error, I discovered that Chuck's
code didn't work ---it would compile, but Xastir wouldn't get any of the data
from the socket.  He had used PF_INET/SOCK_DGRAM.

I found that using AF_PACKET and SOCK_DGRAM, however, DOES work for me, and
should not be throwing warnings about Xastir using obsolete socket options.

I am putting this pull request in place to make it easier for others to see and check the code, which can also be gotten by doing:
   git checkout master
   git checkout -b tvrusso-fix-ax25
   git pull https://github.com/tvrusso/Xastir.git fix-ax25

I would like to merge this pull request within the week, and solicit additional comments.
