### PR TITLE
Fix bugs in previous IPv6 update

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -4881,6 +4881,9 @@ static void* net_connect_thread(void *arg) {
         result = connect(port_data[port].channel, res->ai_addr, res->ai_addrlen);
         if (debug_level & 2)
             fprintf(stderr,"connect result was: %d\n", result);
+        if(result == 0 ) {
+            break;
+        }
         if(result == -1) {
             fprintf(stderr, "Socket connection for interface %d type (%d, %d, %d) failed: %s\n",
                     port, res->ai_family, res->ai_socktype, res->ai_protocol, strerror(errno) );

--- a/src/interface.c
+++ b/src/interface.c
@@ -4892,6 +4892,7 @@ static void* net_connect_thread(void *arg) {
                 fprintf(stderr, "This is OK since we have more to try.\n");
             }
             close(port_data[port].channel);
+            port_data[port].channel = -1;
             continue;
         }
     }


### PR DESCRIPTION
We weren't breaking out of connect() loop on success. This could either lead to the address with the lowest priority being used, or possibly failing to connect at all.

Make sure the channel FD is set to -1 when we close the socket. Otherwise we could try to close it again when the same FD number is being used by another interface.