### PR TITLE
Allow user-defined packets to be sent to APRS-IS

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -17546,7 +17546,6 @@ void decode_info_field(char *call,
         //
         if (!done && !ignore) {         // Other Packets        [APRS Reference, chapter 19]
             done = data_add(OTHER_DATA,call,path,message-1,from,port,origin,third_party, station_is_mine, 0);
-            ok_igate_net = 0;           // don't put data on internet       ????
             if (debug_level & 1)
                 fprintf(stderr,"decode_info_field: done with data_add(OTHER_DATA)\n");
         }


### PR DESCRIPTION
Hi,

I'm running some tests and use the APRS packet type "User-defined" therefore. Xastir however doesn't relay those packets to the Internet servers.

73 Sven DL7AD