### PR TITLE
update OSM README and add map tile info

### DIFF
--- a/README.OSM_maps
+++ b/README.OSM_maps
@@ -30,30 +30,41 @@ Copyright (C) 2000-2018 The Xastir Group
 
   Map Types
   ---------
-    Xastir can use two different map types based on OSM; static and
+    Xastir can use two different map types based on OSM: static and
     tiled. Static maps are bitmaps that are least as large as the Xastir
     window. Tiled maps are built up from 256x256 pixel images.
 
     Static maps are also assembled from tiles, but the assembly occurs
     at the server and the full size image is downloaded to Xastir. There
-    is a major disadvantage to static maps- even slight changes in map
+    is a major disadvantage to static maps: even slight changes in map
     position requires a new map download.
 
-    Tiles have become the standard for bitmap map images. Their small
-    size allows for short download times and easy reuse. Tiles are the
-    basis of the 'slippy map' implementations on web sites,
-    applications, and portable devices. Note that Xastir is not a
-    'slippy map' application and map motions and refresh times are not
-    as smooth or quick as you can find in other applications (Xastir's
-    strengths lie in other areas).
+    Most online maps, includng OSM, use map tiles that follow the "Web
+    Mercator" projection and tiling scheme. The Web Mercator
+    projection was first popularized by Google Maps. It is a modified
+    Mercator projection, using a hybrid spheroid/ellipsoid model that
+    is faster to compute. Wikipedia has a nice description:
+    https://en.wikipedia.org/wiki/Web_Mercator.
 
+    Map tiles are referred to by their zoom level, and row and column
+    number. Major providers (such as OSM, Google, Apple, Mapbox, and
+    Bing) and open source projects (such as Open Layers and
+    openmaptiles.org) use the same general tile numbering scheme,
+    although they vary in the specific sequence of zoom/row/column
+    numbers, and the supporting parts of the URL. The URL for a
+    particular tile looks something like this:
+    https://a.tile.openstreetmap.org/11/329/715.png
+    (tile server a, zoom level 11, column 329, row 715).
+    You can see more in this Wikiepedia article:
+    https://en.wikipedia.org/wiki/Tiled_web_map. 
+    
     Bitmap images, whether static or tiled, are available for only a
     limited number of zoom levels. There are 18 possible zoom levels.
     It takes 2^zoom tiles to represent 360 degrees. Since the tiles are
     256 pixel squares, there are 2^(zoom + 8) pixels in 360 degrees.
 
-    When the Xastir scale does not equate to one of the 18 OSM zoom
-    levels, the bitmap image is scaled. However, scaled bitmaps tend to
+    When the Xastir scale is different from a bitmap image's zoom
+    level, the bitmap image is scaled. However, scaled bitmaps tend to
     look ugly. The scaled bitmap can have jagged lines, unequal pixel
     sizes, and/or missing information. At best a scaled bitmap looks
     blurred, but more typically some pixels will be enlarged into visible
@@ -70,20 +81,8 @@ Copyright (C) 2000-2018 The Xastir Group
     easiest place to view and compare the styles is at
     http://ojw.dev.openstreetmap.org/StaticMap/?mode=Style&
 
-    Tiles can be retreived from a number of servers. The supplied map
-    definitions will download tiles from:
-        http://tile.openstreetmap.org/
-        http://tah.openstreetmap.org/Tiles/tile/
-        http://tiles.openpistemap.org/tiles/contours/
-        http://andy.sandbox.cloudmade.com/tiles/cycle/
-
-    The CloudMade tiles are also available, but a user account and a key
-    are required. Register at http://www.cloudmade.com/ and then create
-    new OSM map definition files (GEO) by copying an existing file and
-    changing the URL variable. The CloudMade tile URLs have this form:
-
-        http://tile.cloudmade.com/<key>/<style#>/256/
-
+    Tiles can be retrieved from a number of servers. The supplied map
+    definitions will download tiles from http://tile.openstreetmap.org/
 
   Map Cache
   ---------


### PR DESCRIPTION
Remove references to no-longer-available tile sources. Add description of web Mercator projection and tiling scheme, with Wikipedia links. Correct minor punctuation errors. Note: Cloudmade has been out of the map tile business for at least 5 years.