### PR TITLE
Remove hack for Xorg 1.7.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,14 +92,6 @@ AC_ARG_WITH(errorpopups,[  --with-errorpopups        Send error popups to stderr
 
 AC_ARG_WITH(lsb,[  --with-lsb                Enable Linux Standard Base.],use_lsb=$withval)
 
-AC_ARG_WITH([xorg_175_workaround], 
-            [AS_HELP_STRING([--with-xorg_175_workaround],[Employ workaround for broken Xorg 1.7.5 server])],
-            [],
-            [with_xorg_175_workaround=no])
-AS_IF([test "x$with_xorg_175_workaround" != xno],
-             [AC_DEFINE([XASTIR_XORG_SERVER_175_BUG], [1],
-                       [Define if you need to work with the broken Xorg server 1.7.5])])
-
 # Now that all the various "use_" variables are set, probe for binaries.
 XASTIR_DETECT_BINARIES
 

--- a/src/main.c
+++ b/src/main.c
@@ -9044,21 +9044,6 @@ fprintf(stderr,"Setting up widget's X/Y position at X:%d  Y:%d\n",
             "create_appshell Menu Popup",
             al,
             ac);
-#ifdef XASTIR_XORG_SERVER_175_BUG
-    // This hack is to deal with a bug that was introduced in Xorg server 
-    // version 1.7.5 and promptly fixed right after several distros adopted
-    // that version as their long-term supported version.  This server version
-    // was common in 2010, but should no longer be in the wild much.
-    
-#if XmVersion >= 2000
-    XtVaSetValues(right_menu_popup, XmNpopupEnabled, XmPOPUP_DISABLED, NULL);
-    XtUngrabButton(da, AnyButton, AnyModifier);
-#else
-    XtVaSetValues(right_menu_popup, XmNpopupEnabled, False, NULL);
-#endif
-#endif
-    //XtVaSetValues(right_menu_popup, XmNwhichButton, 3, NULL);
-
     ac = 0;
     XtSetArg(al[ac], XmNforeground, MY_FG_COLOR); ac++;
     XtSetArg(al[ac], XmNbackground, MY_BG_COLOR); ac++;


### PR DESCRIPTION
Xorg 1.7.5 had a bug in the X server that broke pop-up menus in Motif
programs.  This bug was fixed very quickly, but not before Xorg 1.7.5
made it into some Long Term Support distros.  Thus, we had to hack in
a workaround that tested XmVersion and did different things.

All distros that had this broken server have long since passed their
end of life.  I am now removing this hack.

Should not be merged until pull request #48 is merged, at which point this branch should be rebased onto that fix.  remove "WIP" tag when that happens.

Closes issue #27.