### PR TITLE
Make Xastir build reproducible

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -87,7 +87,6 @@ testdbfawk_SOURCES = \
 
 compiledate.c: $(XASTIR_SRC)
 	rm -f compiledate.c compiledate.o
-	echo 'char compiledate[] = "'"Compiled: `date`"'";' > compiledate.c
 	echo 'char gitstring[] = "'"`$(top_srcdir)/scripts/XastirGitStamp.sh $(top_srcdir)`"'";' >> compiledate.c
 
 remove_compiledate:

--- a/src/main.c
+++ b/src/main.c
@@ -17496,16 +17496,10 @@ void Help_About( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@un
     float version;
     char string1[200];
     char string2[200];
-    extern char compiledate[];
     extern char gitstring[];
    
     xastir_snprintf(string2, sizeof(string2),"\nXastir V%s %s\n",xastir_version,gitstring);
-    xb = XmStringCreateLocalized(string2);
-    xa = XmStringCreateLocalized(compiledate);
-    xms = XmStringConcat(xb, xa);
-    XmStringFree(xa);
-    XmStringFree(xb);
-    //xms is still defined
+    xms = XmStringCreateLocalized(string2);
 
     xa = XmStringCreateLocalized("\n\n" ABOUT_MSG "\n\nLibraries used: " XASTIR_INSTALLED_LIBS "\n\n" ABOUT_OSM);  // Add some newlines
     xb = XmStringConcat(xms, xa);


### PR DESCRIPTION
Insertion of the compilation date and time into the Xastir binary
breaks binary reproducibility, a feature desired (maybe even demanded)
by some Linux package management systems.

This commit removes the compile date and time from the "compiledate.c"
and instead only inserts the git sha-1 (which it was already doing)
if, and only if, we're building out of a git repo.

Doing this makes the binary produced from any Xastir code base
identical (i.e. with the same MD5 checksum) to any other binary built
on the same system with the same libraries from the same code base.

This closes issue #51.