### PR TITLE
Add support for GNGGA and GNRMC sentences

### DIFF
--- a/src/gps.c
+++ b/src/gps.c
@@ -363,9 +363,9 @@ int decode_gps_rmc( char *data,
 // $GPGGA,170834,4124.8963,N,08151.6838,W,1,05,1.5,280.2,M,-34.0,M,,,*75 
 // $GPGGA,104438.833,4301.1439,N,08803.0338,W,1,05,1.8,185.8,M,-34.2,M,0.0,0000*40
 
-// NOTE:  GLONASS receivers can output GNGGA strings that are identical in
-// form to GPGGA, but with the second character being different (N instead of P)
-// Let's try to support those, too.
+// NOTE:  while the above specifically refers to $GP strings for the GPS
+// receivers, there are others such as GNSS, GLONASS, Beidou, and Gallileo
+// that differ only in the third character.  We support those, too.
 //
 int decode_gps_gga( char *data,
                     char *long_pos,

--- a/src/interface.c
+++ b/src/interface.c
@@ -1474,7 +1474,7 @@ void channel_data(int port, unsigned char *string, volatile int length) {
                 // GPRMC and GPGGA strings into global variables.
                 // Drop other GPS strings on the floor.
                 //
-                if ( (length > 7) && (strncmp((char *)string,"$GPRMC,",7) == 0) ) {
+              if ( (length > 7) && ((strncmp((char *)string,"$GPRMC,",7) == 0) || (strncmp((char *)string,"$GNRMC,",7) == 0)) ) {
                     xastir_snprintf(gprmc_save_string,
                         sizeof(gprmc_save_string),
                         "%s",
@@ -1482,7 +1482,7 @@ void channel_data(int port, unsigned char *string, volatile int length) {
                     gps_port_save = port;
                     process_it = 0;
                 }
-                else if ( (length > 7) && (strncmp((char *)string,"$GPGGA,",7) == 0) ) {
+              else if ( (length > 7) && ((strncmp((char *)string,"$GPGGA,",7) == 0)||(strncmp((char *)string,"$GNGGA,",7) == 0)) ) {
                     xastir_snprintf(gpgga_save_string,
                         sizeof(gpgga_save_string),
                         "%s",

--- a/src/interface.c
+++ b/src/interface.c
@@ -1474,7 +1474,7 @@ void channel_data(int port, unsigned char *string, volatile int length) {
                 // GPRMC and GPGGA strings into global variables.
                 // Drop other GPS strings on the floor.
                 //
-              if ( (length > 7) && (isRMC(string))) {
+                if ( (length > 7) && (isRMC(string))) {
                     xastir_snprintf(gprmc_save_string,
                         sizeof(gprmc_save_string),
                         "%s",
@@ -1482,7 +1482,7 @@ void channel_data(int port, unsigned char *string, volatile int length) {
                     gps_port_save = port;
                     process_it = 0;
                 }
-              else if ( (length > 7) && (isGGA(string))) {
+                else if ( (length > 7) && (isGGA(string))) {
                     xastir_snprintf(gpgga_save_string,
                         sizeof(gpgga_save_string),
                         "%s",

--- a/src/interface.c
+++ b/src/interface.c
@@ -1474,7 +1474,7 @@ void channel_data(int port, unsigned char *string, volatile int length) {
                 // GPRMC and GPGGA strings into global variables.
                 // Drop other GPS strings on the floor.
                 //
-              if ( (length > 7) && ((strncmp((char *)string,"$GPRMC,",7) == 0) || (strncmp((char *)string,"$GNRMC,",7) == 0)) ) {
+              if ( (length > 7) && (isRMC(string))) {
                     xastir_snprintf(gprmc_save_string,
                         sizeof(gprmc_save_string),
                         "%s",
@@ -1482,7 +1482,7 @@ void channel_data(int port, unsigned char *string, volatile int length) {
                     gps_port_save = port;
                     process_it = 0;
                 }
-              else if ( (length > 7) && ((strncmp((char *)string,"$GPGGA,",7) == 0)||(strncmp((char *)string,"$GNGGA,",7) == 0)) ) {
+              else if ( (length > 7) && (isGGA(string))) {
                     xastir_snprintf(gpgga_save_string,
                         sizeof(gpgga_save_string),
                         "%s",

--- a/src/main.c
+++ b/src/main.c
@@ -11729,7 +11729,7 @@ fprintf(stderr,"main, initializing connections");
 
                                     xastir_snprintf(temp,
                                         sizeof(temp),
-                                        "GPS:GPRMC,GPGGA ");
+                                        "GPS:GxRMC,GxGGA ");
                                     strncat(temp,
                                         report_gps_status(),
                                         sizeof(temp) - 1 - strlen(temp));
@@ -11740,7 +11740,7 @@ fprintf(stderr,"main, initializing connections");
  
                                     xastir_snprintf(temp,
                                         sizeof(temp),
-                                        "GPS:GPRMC ");
+                                        "GPS:GxRMC ");
                                     strncat(temp,
                                         report_gps_status(),
                                         sizeof(temp) - 1 - strlen(temp));
@@ -11751,7 +11751,7 @@ fprintf(stderr,"main, initializing connections");
 
                                     xastir_snprintf(temp,
                                         sizeof(temp), 
-                                        "GPS:GPGGA ");
+                                        "GPS:GxGGA ");
                                     strncat(temp,
                                         report_gps_status(),
                                         sizeof(temp) - 1 - strlen(temp));


### PR DESCRIPTION
GLONASS receivers send $GNGGA sentences instead of $GPGGA sentences, and
$GNRMC instead of $GPRMC.  But the only difference between these
sentences is the GN instead of GP --- the data is identical.

This appears to be the reason that users of the DRAWS hat are unable
to use this device with Xastir, even though it appears to work with
all other programs that consume NMEA sentences.

This commit attempts to recognize GGA and RMC sentences irrespective
of whether they begin with "$GP" or "$GN".  It is tested so far only
with GPS receivers, and it doesn't break those.  I'm adding this on a
branch so that users of the DRAWS hat can test it out before we
actually merge into master.

If it works, this closes #53