### PR TITLE
Add Travis-ci configuration and fix install bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+language: c
+
+script:
+  - ./bootstrap.sh
+  - ./configure CPPFLAGS="-I/usr/include/geotiff"
+  - make
+  - sudo make install
+
+matrix:
+  include:
+    - os: linux
+      name: "Linux full featured with GraphicsMagick"
+      addons:
+        apt:
+          packages:
+            - graphicsmagick
+            - libmotif-dev
+            - libcurl4-openssl-dev
+            - libpcre3-dev
+            - libproj-dev
+            - libdb5.3-dev
+            - libax25-dev
+            - shapelib
+            - libshp-dev
+            - festival
+            - festival-dev
+            - libgeotiff-dev
+            - libgraphicsmagick1-dev
+            - gpsman
+            - gpsmanshp
+    - os: linux
+      name: "Linux light with ImageMagick"
+      addons:
+        apt:
+          packages:
+            - imagemagick
+            - libmotif-dev
+            - libcurl4-openssl-dev
+            - libpcre3-dev
+            - libdb5.3-dev
+            - shapelib
+            - libshp-dev
+            - libmagickcore-dev
+    - os: osx
+      name: "MacOS"
+      addons:
+        homebrew:
+          packages:
+            - berkeley-db
+            - graphicsmagick
+            - libgeotiff
+            - openmotif
+            - pcre
+            - proj
+            - shapelib
+            - wget

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -47,4 +47,4 @@ dist_scripts_DATA = \
 
 install-data-hook:
 	cd $(DESTDIR)$(scriptsdir) && \
-	chmod a+x *.sh *.pl *.py get-* gpx2* *.bash
+	chmod a+x *.pl *.py get-* gpx2* *.bash


### PR DESCRIPTION
Add a .travis.yml that builds for Linux (two iterations) and MacOS.

Fix a bug where now that there is no *.sh files in the scripts
directory a chmod in "make install" was failing.

(This is a small enough mod that the only reason I am doing a pull request is to test the Travis-CI integration.)