### PR TITLE
Ensure x_spider children don't return

### DIFF
--- a/src/x_spider.c
+++ b/src/x_spider.c
@@ -833,8 +833,11 @@ extern char *__progname, *__progname_full;
 #endif  // __linux__
 static char *LastArgv = ((void *)0);
 static char **local_environ;
+#ifdef __linux__
+#ifndef __LSB__
 static char *old_progname, *old_progname_full;
-
+#endif  // __LSB__
+#endif  // __linux__
 
 
 void clear_proc_title(void)
@@ -1691,16 +1694,9 @@ int Fork_TCP_server(int argc, char *argv[], char *envp[]) {
             fprintf(stderr,"Could some processes still be running from a previous run of Xastir?\n");
         }
 
-        // Go into an infinite loop here which restarts the
-        // listening process whenever it dies.
-        //
-//        while (1) {
-//            fprintf(stderr,"Starting TCP_Server...\n");
-
-            TCP_Server(argc, argv, envp);
-
-//            fprintf(stderr,"TCP_Server process died.\n");
-//        }
+        TCP_Server(argc, argv, envp);
+        fprintf(stderr,"TCP_Server process died.\n");
+        exit(1);
     }
     //
     // Parent process
@@ -1810,16 +1806,9 @@ int Fork_UDP_server(int argc, char *argv[], char *envp[]) {
 //                "x_spider: Couldn't set read-end of pipe_xastir_to_udp_server non-blocking\n");
 //        }
 
-        // Go into an infinite loop here which restarts the
-        // listening process whenever it dies.
-        //
-//        while (1) {
-//            fprintf(stderr,"Starting UDP_Server...\n");
-
-	UDP_Server(argc, argv, envp);
-
-	fprintf(stderr,"UDP_Server process died.\n");
-//        }
+        UDP_Server(argc, argv, envp);
+        fprintf(stderr,"UDP_Server process died.\n");
+        exit(1);
     }
     //
     // Parent process


### PR DESCRIPTION
If the UDP x_spider server couldn't open any ports (such as due to
another xastir process having them open) the child would return to
the main control logic of xastir, leading to two copies of xastir
running and duplicate windows appearing. Add an exit(1) after the
call to UDP_Server() so this can't happen. This fixes #65.

The TCP server didn't use return, but I added an exit(1) after the
call to TCP_Server() just to be safe.

I also fixed some warnings on MacOS compiles. This helps with
issue #24.