### PR TITLE
Reorder bounds checking for while loop in draw_shapefile_map

### DIFF
--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -865,7 +865,7 @@ void draw_shapefile_map (Widget w,
 
     filename = filenm;
     i = strlen(filenm);
-    while ( (filenm[i] != '/') && (i >= 0) )
+    while ( (i >= 0) && (filenm[i] != '/') )
         filename = &filenm[i--];
         //fprintf(stderr,"draw_shapefile_map:filename:%s\ttitle:%s\n",filename,alert->title);    
 


### PR DESCRIPTION
I've started playing with using clang's "-fsanitize=address" feature
to look for bugs. When shapefile maps were enabled it crashed on a
read buffer overlow. We were reading the value from a char array
and then checking to see if the index was in bounds. Reverse it
so we check for in bounds first.