### PR TITLE
Fix buffer overflow in jump_sort()

### DIFF
--- a/src/location_gui.c
+++ b/src/location_gui.c
@@ -181,7 +181,7 @@ void jump_sort(void) {
     f=fopen(location_file_path,"r");
     if (f!=NULL) {
         while (!feof(f)) {
-            (void)get_line(f,temp,200);
+            (void)get_line(f,temp,sizeof(temp));
             if (!feof(f) && strlen(temp)>8) {
                 temp_ptr=strtok(temp,"|");  /* get the name */
                 if (temp_ptr!=NULL) {
@@ -189,7 +189,7 @@ void jump_sort(void) {
                         sizeof(name),
                         "%s",
                         temp);
-                    (void)sort_input_database(location_db_file_path,name,200);
+                    (void)sort_input_database(location_db_file_path,name,sizeof(name));
                 }
             }
         }


### PR DESCRIPTION
We were passing 200 into sort_input_database as the size of name,
which was only 100 in size. Switch the two hardcoded array sizes
in jump_sort() to use sizeof().