### PR TITLE
Fix map_geo MAGICK/XPM ifdefs

### DIFF
--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -87,7 +87,7 @@
   #define NO_GRAPHICS 1
 #endif  // !(HAVE_LIBXPM || HAVE_LIBXPM_IN_XM || HAVE_MAGICK)
 
-#if !(defined(HAVE_LIBXPM) || defined(HAVE_LIBXPM_IN_XM))
+#if defined(HAVE_MAGICK) || !(defined(HAVE_LIBXPM) || defined(HAVE_LIBXPM_IN_XM))
   #define NO_XPM 1
 #endif  // !(HAVE_LIBXPM || HAVE_LIBXPM_IN_XM)
 
@@ -576,7 +576,7 @@ void draw_geo_image_map (Widget w,
     int width,height;
 #ifndef NO_XPM
     XpmAttributes atb;              // Map attributes after map's read into an XImage
-#endif  // HAVE_MAGICK
+#endif  // NO_XPM
 
     tiepoint tp[2];                 // Calibration points for map, read in from .geo file
     int n_tp;                       // Temp counter for number of tiepoints read

--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -89,7 +89,7 @@
 
 #if defined(HAVE_MAGICK) || !(defined(HAVE_LIBXPM) || defined(HAVE_LIBXPM_IN_XM))
   #define NO_XPM 1
-#endif  // !(HAVE_LIBXPM || HAVE_LIBXPM_IN_XM)
+#endif  // HAVE_MAGICK ||  !(HAVE_LIBXPM || HAVE_LIBXPM_IN_XM)
 
 
 #ifdef HAVE_MAGICK

--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -2211,8 +2211,9 @@ void draw_geo_image_map (Widget w,
 #else   // HAVE_MAGICK
 
         // We don't have ImageMagick libs compiled in, so use the
-        // XPM library instead.
+        // XPM library instead, but only if we HAVE XPM.
 
+#ifndef NO_XPM
         HandlePendingEvents(app_context);
         if (interrupt_drawing_now) {
             // Update to screen
@@ -2284,7 +2285,9 @@ void draw_geo_image_map (Widget w,
 
         width  = atb.width;
         height = atb.height;
-
+#else // NO_XPM
+        fprintf(stderr,"Xastir was configured with neither XPM library nor (Image/Graphics)Magick, cannot display map %s\n",filenm);
+#endif // NO_XPM
 #endif  // HAVE_MAGICK
 
         // draw the image from the file out to the map screen


### PR DESCRIPTION
map_geo.c was throwing a warning about a set-but-unused variable, atb on my BSD box and on Rasbian (gcc 8 and gcc 6, respectively):
```
../../Xastir/src/map_geo.c:578:19: warning: variable 'atb' set but not used [-Wunused-but-set-variable]
     XpmAttributes atb;              // Map attributes after map's read into an XImage
                   ^~~
```

This variable is wrapped in an ifdef:
```
#ifndef NO_XPM
    XpmAttributes atb;              // Map attributes after map's read into an XImage
#endif  // NO_XPM
```

and NO_XPM is set like this:

```
#if !(defined(HAVE_LIBXPM) || defined(HAVE_LIBXPM_IN_XM)
)
  #define NO_XPM 1
#endif  // !(HAVE_LIBXPM || HAVE_LIBXPM_IN_XM)
```
That is, if configure did not find libxpm, NO_XPM is defined to 1 and the atb variable is not declared or set, and if xpm is found, it is declared and set.

However the only USE of atb is when HAVE_MAGICK is not defined, in which case Xastir falls back to XPM for map display of a much limited set of image types.

I fixed the warning by making the define of NO_XPM depend also on the setting of HAVE_MAGICK: if HAVE_MAGICK is set, it doesn't matter if we found XPM libraries, we're not going to USE them.

Unfortunately, I looked over the code that USED XPM library calls, and it was NOT wrapped in the right ifdef to assure it was only called if XPM was found by configure.  This would have led to link failures if anyone had tried to build Xastir with neither Magick nor XPM libraries present.

I have also fixed this problem in the second commit of this pull request.

This issue is not showing up in *any* of the Travis builds, and I'm not sure why.  It shows up on both my BSD and Rasbian builds, though.

This is all about #24, as everything else has been lately.

