### PR TITLE
Fix deprecated GetIndexes usage

### DIFF
--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -2060,7 +2060,19 @@ void draw_geo_image_map (Widget w,
                             &exception, &da, &pixmap, &gc, screen_width, screen_height))
             return;
 
+#if defined(HAVE_GRAPHICSMAGICK)
+  #if (MagickLibVersion < 0x201702)
         index_pack = GetIndexes(image);
+  #else
+        index_pack = AccessMutableIndexes(image);
+  #endif
+#else
+  #if (MagickLibVersion < 0x0669)
+        index_pack = GetIndexes(image);
+#else
+        index_pack = GetAuthenticIndexQueue(image);
+  #endif
+#endif
         if (image->storage_class == PseudoClass && !index_pack) {
             fprintf(stderr,"PseudoClass && index_pack == NULL!!!");
             if (image)


### PR DESCRIPTION
In commits b071954 and 7815dd9 (and possibly others associated with
PR #40), the GetIndexes function (present in both ImageMagick and
GraphicsMagick, and deprecated in both) was coded around so that if
we've got newer versions of the library, we use the new API, and if we
have an older version, we use the older API.

But #40 only fixed these deprecated uses in a few files, and mised the
one usage in map_geo.c

This commit copies over the fix verbatim from map_OSM.c, and shuts up
the deprecation warning.

Fixes #81.  Also shuts up warnings per #24.
