### PR TITLE
Fixing a print format string

### DIFF
--- a/src/maps.c
+++ b/src/maps.c
@@ -3887,7 +3887,8 @@ begin_critical_section(&print_postscript_dialog_lock, "maps.c:Print_postscript_d
             // Empty path
             xastir_snprintf(printer_program,
                 sizeof(printer_program),
-                "");
+                "%s",
+                "\0");
 #endif // LPR_PATH
         }
 


### PR DESCRIPTION
Small patch but gets rid of another compiler warning. Part of fixes for bug report #24. Please check this one carefully to make sure it's the correct way to fix it.