### PR TITLE
Libax25

### DIFF
--- a/src/interface_gui.c
+++ b/src/interface_gui.c
@@ -4807,8 +4807,8 @@ void Config_AX25( /*@unused@*/ Widget w, int config_type, int port) {
 #else
         // Need code to use button_ok variable to quiet a compiler warning
         //when we don't have LIBAX25 linked-in.
-        if (button_ok != null) {
-            // Do nothing
+        if (button_ok == button_ok) {
+            // Do nothing (to shut up a compiler warning)
         }
 #endif /* USE_AX25 */
         XtAddCallback(button_cancel, XmNactivateCallback, Config_AX25_destroy_shell, config_AX25_dialog);

--- a/src/interface_gui.c
+++ b/src/interface_gui.c
@@ -4804,6 +4804,12 @@ void Config_AX25( /*@unused@*/ Widget w, int config_type, int port) {
 
 #ifdef HAVE_LIBAX25
         XtAddCallback(button_ok, XmNactivateCallback, Config_AX25_change_data, config_AX25_dialog);
+#else
+        // Need code to use button_ok variable to quiet a compiler warning
+        //when we don't have LIBAX25 linked-in.
+        if (button_ok != null) {
+            // Do nothing
+        }
 #endif /* USE_AX25 */
         XtAddCallback(button_cancel, XmNactivateCallback, Config_AX25_destroy_shell, config_AX25_dialog);
 


### PR DESCRIPTION
Fixing another compiler warning (variable set but not used) that shows up on the minimal Ubuntu-14.04 build when libax25 is not present. This is part of the fixes for issue #24.