### PR TITLE
De-referencing pointer correctly to remove warning

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -1526,7 +1526,7 @@ int ui_connect( int port, char *to[]) {
     if (to == NULL)
         return(-1);
 
-    if (to[0] == '\0')
+    if (*to[0] == '\0')
         return(-1);
 
     /*


### PR DESCRIPTION
De-referencing a pointer to get rid of the warning: "comparison
between pointer and zero character constant" that shows up with
the gcc8 compiler.