### PR TITLE
Fix use after free bug in Station_List_fill

### DIFF
--- a/src/list_gui.c
+++ b/src/list_gui.c
@@ -617,7 +617,13 @@ begin_critical_section(&station_list_dialog_lock, "list_gui.c:Station_List_fill"
                 XtVaSetValues(SL_da[type][row],XmNlabelPixmap, SL_icon[type][row],NULL);
                 XtManageChild(SL_da[type][row]);
 
-                if (SL_callback[type][row]) XtFree(SL_callback[type][row]);
+                if (SL_callback[type][row]) {
+                    XtRemoveCallback((XtPointer)SL_da[type][row],
+                                     XmNactivateCallback,
+                                     Call_locate_station,
+                                     SL_callback[type][row]);
+                    XtFree(SL_callback[type][row]);
+                }
                 SL_callback[type][row] = XmTextFieldGetString(SL_call[type][row]);
 
                 // Pressing the icon button centers the map on the station.


### PR DESCRIPTION
Station_List_fill gets called repeatedly. Each run it
would add a callback to the icon button. On the next run
it would free the string that was passed to the callback
but not delete the old callback. Over time we would develop
a stack of old callbacks on the icon button that would
point to freed strings.

Add logic to remove the existing callback before we free
the string from the previous run.

Fixes #88