### PR TITLE
Dlm threading

### DIFF
--- a/src/dlm.c
+++ b/src/dlm.c
@@ -44,7 +44,7 @@
 #include <strings.h>
 #endif  // HAVE_STRINGS_H
 
-#include <Xm/XmAll.h>
+//#include <Xm/XmAll.h>
 
 #ifdef HAVE_LIBCURL
 #include <curl/curl.h>
@@ -604,8 +604,8 @@ static void *DLM_transfer_thread(void *arg) {
                 //xastir_snprintf(map_it, sizeof(map_it), langcode("BBARSTA051"),
                 //         1, DLM_queue_len());  // Downloading tile %ls of %ls
                 xastir_snprintf(map_it, sizeof(map_it), "Fetch %s", tile->desc);
-                statusline(map_it,0);
-                XmUpdateDisplay(text);
+                //statusline(map_it,0);
+                //XmUpdateDisplay(text);
 
 #ifdef HAVE_LIBCURL
 #ifdef USE_CURL_MULTI

--- a/src/dlm.c
+++ b/src/dlm.c
@@ -501,7 +501,7 @@ static CURL *DLM_curl_init(char *errBuf) {
  * DLM_transfer_thread() - retrieve item queued for download
  **********************************************************/
 static void *DLM_transfer_thread(void *arg) {
-    char map_it[MAX_FILENAME];
+//    char map_it[MAX_FILENAME];
     struct DLM_queue_entry *tile;
 #ifdef DLM_QUEUE_THREADED
     int idleCnt;
@@ -603,7 +603,7 @@ static void *DLM_transfer_thread(void *arg) {
 
                 //xastir_snprintf(map_it, sizeof(map_it), langcode("BBARSTA051"),
                 //         1, DLM_queue_len());  // Downloading tile %ls of %ls
-                xastir_snprintf(map_it, sizeof(map_it), "Fetch %s", tile->desc);
+                //xastir_snprintf(map_it, sizeof(map_it), "Fetch %s", tile->desc);
                 //statusline(map_it,0);
                 //XmUpdateDisplay(text);
 

--- a/src/dlm.c
+++ b/src/dlm.c
@@ -44,8 +44,6 @@
 #include <strings.h>
 #endif  // HAVE_STRINGS_H
 
-//#include <Xm/XmAll.h>
-
 #ifdef HAVE_LIBCURL
 #include <curl/curl.h>
 #endif
@@ -501,7 +499,6 @@ static CURL *DLM_curl_init(char *errBuf) {
  * DLM_transfer_thread() - retrieve item queued for download
  **********************************************************/
 static void *DLM_transfer_thread(void *arg) {
-//    char map_it[MAX_FILENAME];
     struct DLM_queue_entry *tile;
 #ifdef DLM_QUEUE_THREADED
     int idleCnt;
@@ -600,12 +597,6 @@ static void *DLM_transfer_thread(void *arg) {
 #endif
                 end_critical_section(&(tile->lock), "DLM_transfer_thread: tile unlock");
                 //fprintf(stderr,"DLM_transfer_queue: started item %s, qlen=%d\n",tile->desc,DLM_queue_len());
-
-                //xastir_snprintf(map_it, sizeof(map_it), langcode("BBARSTA051"),
-                //         1, DLM_queue_len());  // Downloading tile %ls of %ls
-                //xastir_snprintf(map_it, sizeof(map_it), "Fetch %s", tile->desc);
-                //statusline(map_it,0);
-                //XmUpdateDisplay(text);
 
 #ifdef HAVE_LIBCURL
 #ifdef USE_CURL_MULTI


### PR DESCRIPTION
This should fix any GUI threading issues in dlm.c. I commented out the Xm function call, the write to the status line, the variable being used for the string and the xastir_snprintf() that set the variable.

Once this has undergone a bit of testing I can go in and remove those bits altogether. That can be the last step of the bug report before it is closed (assuming this attempt is successful).