### PR TITLE
Move gcc8 stuff from install to before_script tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,7 @@ matrix:
       name: "Ubuntu 16.04 gcc8 full-featured w/GraphicsMagick"
       env:
         - CFLAGS="${CFLAGS} -Wno-format-truncation -Wno-stringop-truncation"
-      install:
-          # Can't put CC in "env:" section: It gets overwritten by Travis-CI
+      before_script:
         - export CC="gcc-8"
         - echo ${CC}
         - ${CC} --version


### PR DESCRIPTION
This was a suggestion by Tom Russo. Trying to get the Travis-CI config as clean and modular as possible. Compiles fine.