### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,27 @@ matrix:
 
 
 
+    - os: osx
+      name: "OSX semi-light w/GraphicsMagick"
+      script:
+        - ./bootstrap.sh
+        - ./configure CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+      addons:
+        homebrew:
+          packages:
+            - berkeley-db
+            - graphicsmagick
+            - libgeotiff
+            - openmotif
+            - pcre
+            - proj
+            - shapelib
+            - wget
+
+
+
     - os: linux
       dist: xenial
       name: "Ubuntu-16.04 Exercise Configure Options"
@@ -150,7 +171,7 @@ matrix:
         - make
 #        - sudo make install
 
-        - ./configure --without-imagemagick --without-graphicsmagick --without-shapelib --without-pcre --without-dbfawk --without-rtree --without-map-caching --without-libcurl --without-ax25 --without-libproj --without-geotiff --without-festival --without-gpsman CPPFLAGS="-I/usr/include/geotiff"
+        - ./configure --without-imagemagick --without-graphicsmagick --without-shapelib --without-pcre --without-dbfawk --without-rtree --without-map-cache --without-libcurl --without-ax25 --without-libproj --without-geotiff --without-festival --without-gpsman CPPFLAGS="-I/usr/include/geotiff"
 #        - make clean
         - make
 #        - sudo make install
@@ -207,26 +228,5 @@ matrix:
             - gpsmanshp
             - libwebp-dev
             - libgc-dev
-
-
-
-    - os: osx
-      name: "OSX semi-light w/GraphicsMagick"
-      script:
-        - ./bootstrap.sh
-        - ./configure CPPFLAGS="-I/usr/include/geotiff"
-        - make
-        - sudo make install
-      addons:
-        homebrew:
-          packages:
-            - berkeley-db
-            - graphicsmagick
-            - libgeotiff
-            - openmotif
-            - pcre
-            - proj
-            - shapelib
-            - wget
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,11 +90,10 @@ matrix:
 #        - make
 #        - sudo make install
 
-# Error in make install here?
-        - ./configure --without-libcurl CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
-        - make
-        - sudo make install
+#        - ./configure --without-libcurl CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
+#        - make
+#        - sudo make install
 
 #        - ./configure --without-libproj CPPFLAGS="-I/usr/include/geotiff"
 #        - make clean
@@ -122,9 +121,9 @@ matrix:
 #        - sudo make install
  
         - ./configure --without-dbfawk CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
+#        - make clean
         - make
-        - sudo make install
+#        - sudo make install
  
 #        - ./configure --without-rtree CPPFLAGS="-I/usr/include/geotiff"
 #        - make clean
@@ -137,34 +136,39 @@ matrix:
 #        - sudo make install
  
         - ./configure --without-graphicsmagick CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
+#        - make clean
         - make
-        - sudo make install
+#        - sudo make install
  
         - ./configure --without-graphicsmagick --without-imagemagick CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
+#        - make clean
         - make
-        - sudo make install
+#        - sudo make install
 
         - ./configure --without-shapelib --without-graphicsmagick --without-imagemagick CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
+#        - make clean
         - make
-        - sudo make install
- 
+#        - sudo make install
+
+        - ./configure --without-imagemagick --without-graphicsmagick --without-shapelib --without-pcre --without-dbfawk --without-rtree --without-map-caching --without-libcurl --without-ax25 --without-libproj --without-geotiff --without-festival --without-gpsman CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
+        - make
+#        - sudo make install
+
 #        - ./configure --with-errorpopups CPPFLAGS="-I/usr/include/geotiff"
 #        - make clean
 #        - make
 #        - sudo make install
  
         - ./configure --with-libgc CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
+#        - make clean
         - make
-        - sudo make install
+#        - sudo make install
 
-        - ./configure --with-profiling CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
-        - make
-        - sudo make install
+#        - ./configure --with-profiling CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
+#        - make
+#        - sudo make install
 
 ##        - ./configure --with-lsb CPPFLAGS="-I/usr/include/geotiff"
 ##        - make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,51 @@
 language: c
 
-script:
-  - ./bootstrap.sh
-  - ./configure CPPFLAGS="-I/usr/include/geotiff"
-  - make
-  - sudo make install
-
 matrix:
 
-  exclude:
-    - compiler: gcc
+#  exclude:
+#    - compiler: gcc
 
-  include:
+#  include:
+
 
     - os: linux
       dist: xenial
-      name: "Ubuntu 16.04 light w/ImageMagick"
+      name: "Ubuntu-16.04 light w/ImageMagick"
       env:
         - MAGIC_BIN="/usr/lib/x86_64-linux-gnu/ImageMagick-6.8.9/bin-Q16/Magick-config"
+      script:
+        - ./bootstrap.sh
+        - ./configure CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
       addons:
         apt:
           packages:
             - imagemagick
+            - libmagickcore-dev
             - libmotif-dev
             - libcurl4-openssl-dev
             - libpcre3-dev
             - libdb5.3-dev
             - shapelib
             - libshp-dev
-            - libmagickcore-dev
+
+
 
     - os: linux
       dist: xenial
-      name: "Ubuntu 16.04 gcc8 full-featured w/GraphicsMagick"
+      name: "Ubuntu-16.04 gcc8 full-featured w/GraphicsMagick"
       env:
         - CFLAGS="${CFLAGS} -Wno-format-truncation -Wno-stringop-truncation"
       before_script:
         - export CC="gcc-8"
         - echo ${CC}
         - ${CC} --version
+      script:
+        - ./bootstrap.sh
+        - ./configure CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
       addons:
         apt:
           sources:
@@ -63,8 +70,128 @@ matrix:
             - gpsmanshp
             - libwebp-dev
 
+
+
+    - os: linux
+      dist: xenial
+      name: "Ubuntu-16.04 Exercise Configure Options"
+      env:
+        - MAGIC_BIN="/usr/lib/x86_64-linux-gnu/ImageMagick-6.8.9/bin-Q16/Magick-config"
+      script:
+        - ./bootstrap.sh
+
+        - ./configure CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+
+        - ./configure --without-festival CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+
+        - ./configure --without-gpsman CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+
+        - ./configure --without-libcurl CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+
+         - ./configure --without-libproj CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+ 
+        - ./configure --without-shapelib CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+ 
+        - ./configure --without-pcre CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+ 
+        - ./configure --without-geotiff CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+ 
+        - ./configure --without-ax25 CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+ 
+        - ./configure --without-dbfawk CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+ 
+        - ./configure --without-rtree CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+ 
+        - ./configure --without-map-cache CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+ 
+        - ./configure --without-graphicsmagick CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+ 
+        - ./configure --without-graphicsmagick --without-imagemagick CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+ 
+        - ./configure --with-errorpopups CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+ 
+        - ./configure --with-libgc CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+
+        - ./configure --with-profiling CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
+
+#        - ./configure --with-lsb CPPFLAGS="-I/usr/include/geotiff"
+#        - make
+#        - sudo make install
+
+#        - ./configure --with-postgis CPPFLAGS="-I/usr/include/geotiff"
+#        - make
+#        - sudo make install
+
+#        - ./configure --with-mysql CPPFLAGS="-I/usr/include/geotiff"
+#        - make
+#        - sudo make install
+ 
+      addons:
+        apt:
+          packages:
+            - imagemagick
+            - libmagickcore-dev
+            - graphicsmagick
+            - libmotif-dev
+            - libcurl4-openssl-dev
+            - libpcre3-dev
+            - libproj-dev
+            - libdb5.3-dev
+            - libax25-dev
+            - shapelib
+            - libshp-dev
+            - festival
+            - festival-dev
+            - libgeotiff-dev
+            - libgraphicsmagick1-dev
+            - gpsman
+            - gpsmanshp
+            - libwebp-dev
+            - libgc-dev
+
+
+
     - os: osx
       name: "OSX semi-light w/GraphicsMagick"
+      script:
+        - ./bootstrap.sh
+        - ./configure CPPFLAGS="-I/usr/include/geotiff"
+        - make
+        - sudo make install
       addons:
         homebrew:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,64 +80,61 @@ matrix:
       script:
         - ./bootstrap.sh
 
-        - ./configure CPPFLAGS="-I/usr/include/geotiff"
-        - make
-        - sudo make install
+#        - ./configure --without-festival CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
+#        - make
+#        - sudo make install
 
-        - ./configure --without-festival CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
-        - make
-        - sudo make install
+#        - ./configure --without-gpsman CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
+#        - make
+#        - sudo make install
 
-        - ./configure --without-gpsman CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
-        - make
-        - sudo make install
-
+# Error in make install here?
         - ./configure --without-libcurl CPPFLAGS="-I/usr/include/geotiff"
         - make clean
         - make
         - sudo make install
 
-         - ./configure --without-libproj CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
-        - make
-        - sudo make install
- 
-        - ./configure --without-shapelib CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
-        - make
-        - sudo make install
- 
-#        - ./configure --without-pcre CPPFLAGS="-I/usr/include/geotiff"
+#        - ./configure --without-libproj CPPFLAGS="-I/usr/include/geotiff"
 #        - make clean
 #        - make
 #        - sudo make install
  
-        - ./configure --without-geotiff CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
-        - make
-        - sudo make install
+#        - ./configure --without-shapelib CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
+#        - make
+#        - sudo make install
  
-        - ./configure --without-ax25 CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
-        - make
-        - sudo make install
+##        - ./configure --without-pcre CPPFLAGS="-I/usr/include/geotiff"
+##        - make clean
+##        - make
+##        - sudo make install
+ 
+#        - ./configure --without-geotiff CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
+#        - make
+#        - sudo make install
+ 
+#        - ./configure --without-ax25 CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
+#        - make
+#        - sudo make install
  
         - ./configure --without-dbfawk CPPFLAGS="-I/usr/include/geotiff"
         - make clean
         - make
         - sudo make install
  
-        - ./configure --without-rtree CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
-        - make
-        - sudo make install
+#        - ./configure --without-rtree CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
+#        - make
+#        - sudo make install
  
-        - ./configure --without-map-cache CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
-        - make
-        - sudo make install
+#        - ./configure --without-map-cache CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
+#        - make
+#        - sudo make install
  
         - ./configure --without-graphicsmagick CPPFLAGS="-I/usr/include/geotiff"
         - make clean
@@ -154,10 +151,10 @@ matrix:
         - make
         - sudo make install
  
-        - ./configure --with-errorpopups CPPFLAGS="-I/usr/include/geotiff"
-        - make clean
-        - make
-        - sudo make install
+#        - ./configure --with-errorpopups CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
+#        - make
+#        - sudo make install
  
         - ./configure --with-libgc CPPFLAGS="-I/usr/include/geotiff"
         - make clean
@@ -169,20 +166,20 @@ matrix:
         - make
         - sudo make install
 
-#        - ./configure --with-lsb CPPFLAGS="-I/usr/include/geotiff"
-#        - make clean
-#        - make
-#        - sudo make install
+##        - ./configure --with-lsb CPPFLAGS="-I/usr/include/geotiff"
+##        - make clean
+##        - make
+##        - sudo make install
 
-#        - ./configure --with-postgis CPPFLAGS="-I/usr/include/geotiff"
-#        - make clean
-#        - make
-#        - sudo make install
+##        - ./configure --with-postgis CPPFLAGS="-I/usr/include/geotiff"
+##        - make clean
+##        - make
+##        - sudo make install
 
-#        - ./configure --with-mysql CPPFLAGS="-I/usr/include/geotiff"
-#        - make clean
-#        - make
-#        - sudo make install
+##        - ./configure --with-mysql CPPFLAGS="-I/usr/include/geotiff"
+##        - make clean
+##        - make
+##        - sudo make install
  
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: c
 
 matrix:
 
-#  exclude:
-#    - compiler: gcc
+  exclude:
+    - compiler: gcc
 
-#  include:
+  include:
 
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,78 +85,102 @@ matrix:
         - sudo make install
 
         - ./configure --without-festival CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
 
         - ./configure --without-gpsman CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
 
         - ./configure --without-libcurl CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
 
          - ./configure --without-libproj CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
  
         - ./configure --without-shapelib CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
  
-        - ./configure --without-pcre CPPFLAGS="-I/usr/include/geotiff"
-        - make
-        - sudo make install
+#        - ./configure --without-pcre CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
+#        - make
+#        - sudo make install
  
         - ./configure --without-geotiff CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
  
         - ./configure --without-ax25 CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
  
         - ./configure --without-dbfawk CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
  
         - ./configure --without-rtree CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
  
         - ./configure --without-map-cache CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
  
         - ./configure --without-graphicsmagick CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
  
         - ./configure --without-graphicsmagick --without-imagemagick CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
+        - make
+        - sudo make install
+
+        - ./configure --without-shapelib --without-graphicsmagick --without-imagemagick CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
  
         - ./configure --with-errorpopups CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
  
         - ./configure --with-libgc CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
 
         - ./configure --with-profiling CPPFLAGS="-I/usr/include/geotiff"
+        - make clean
         - make
         - sudo make install
 
 #        - ./configure --with-lsb CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
 #        - make
 #        - sudo make install
 
 #        - ./configure --with-postgis CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
 #        - make
 #        - sudo make install
 
 #        - ./configure --with-mysql CPPFLAGS="-I/usr/include/geotiff"
+#        - make clean
 #        - make
 #        - sudo make install
  


### PR DESCRIPTION
Adding Travis-CI config that runs through a bunch of "configure" flags, most of which are commented out as they're not (currently) causing any extra warnings or errors in the Linux build. We'll want them in there though as later we can uncomment blocks of them at a time to re-check the configure flags again. Leaving all of them uncommented makes the Travis-CI log too long so that's not an option either (plus would dramatically increase compile times).