### PR TITLE
Add "fallthrough" comments to switch cases

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2031,6 +2031,7 @@ APRS_Symbol *id_callsign(char *call_sign, char * to_call) {
             switch (hold[0]) {
                 case 'A':
                     symbol.aprs_type = '\\';
+                    /* Falls through. */
 
                 case 'P':
                     if (('0' <= hold[1] && hold[1] <= '9') || ('A' <= hold[1] && hold[1] <= 'Z'))
@@ -2040,6 +2041,7 @@ APRS_Symbol *id_callsign(char *call_sign, char * to_call) {
 
                 case 'O':
                     symbol.aprs_type = '\\';
+                    /* Falls through. */
 
                 case 'B':
                     switch (hold[1]) {
@@ -2093,6 +2095,7 @@ APRS_Symbol *id_callsign(char *call_sign, char * to_call) {
 
                 case 'D':
                     symbol.aprs_type = '\\';
+                    /* Falls through. */
 
                 case 'H':
                     switch (hold[1]) {
@@ -2119,6 +2122,7 @@ APRS_Symbol *id_callsign(char *call_sign, char * to_call) {
 
                 case 'N':
                     symbol.aprs_type = '\\';
+                    /* Falls through. */
 
                 case 'M':
                     switch (hold[1]) {
@@ -2148,6 +2152,7 @@ APRS_Symbol *id_callsign(char *call_sign, char * to_call) {
 
                 case 'Q':
                     symbol.aprs_type = '\\';
+                    /* Falls through. */
 
                 case 'J':
                     switch (hold[1]) {
@@ -2168,6 +2173,7 @@ APRS_Symbol *id_callsign(char *call_sign, char * to_call) {
 
                 case 'S':
                     symbol.aprs_type = '\\';
+                    /* Falls through. */
 
                 case 'L':
                     if ('A' <= hold[1] && hold[1] <= 'Z')

--- a/src/interface.c
+++ b/src/interface.c
@@ -541,42 +541,49 @@ void send_agwpe_packet(int xastir_interface,// Xastir interface port
             }
             else
                 return;
+	    /* Falls through. */
         case 7:
             if (ViaCall[6]) {
                 strncpy((char *)(&output_string[agwpe_header_size+1+60]), ViaCall[6], 10);
             }
             else
                 return;
+            /* Falls through. */
         case 6:
             if (ViaCall[5]) {
                 strncpy((char *)(&output_string[agwpe_header_size+1+50]), ViaCall[5], 10);
             }
             else
                 return;
+            /* Falls through. */
         case 5:
             if (ViaCall[4]) {
                 strncpy((char *)(&output_string[agwpe_header_size+1+40]), ViaCall[4], 10);
             }
             else
                 return;
+            /* Falls through. */
         case 4:
             if (ViaCall[3]) {
                 strncpy((char *)(&output_string[agwpe_header_size+1+30]), ViaCall[3], 10);
             }
             else
                 return;
+            /* Falls through. */
         case 3:
             if (ViaCall[2]) {
                 strncpy((char *)(&output_string[agwpe_header_size+1+20]), ViaCall[2], 10);
             }
             else
                 return;
+            /* Falls through. */
         case 2:
             if (ViaCall[1]) {
                 strncpy((char *)(&output_string[agwpe_header_size+1+10]), ViaCall[1], 10);
             }
             else
                 return;
+            /* Falls through. */
         case 1:
         default:
             if (ViaCall[0]) {
@@ -6372,6 +6379,7 @@ void output_my_aprs_data(void) {
             if (port_data[port].status == DEVICE_UP) {
                 port_dtr(port,0);
             }
+            /* Falls through. */
 
         case DEVICE_SERIAL_TNC_AUX_GPS:
         case DEVICE_SERIAL_KISS_TNC:
@@ -7167,6 +7175,7 @@ void output_my_data(char *message, int incoming_port, int type, int loopback_onl
                 if (port_data[port].status == DEVICE_UP && !loopback_only && !transmit_disable) {
                     port_dtr(port,0);           // make DTR normal (talk to TNC)
                 }
+                /* Falls through. */
 
             case DEVICE_SERIAL_TNC_AUX_GPS:
             case DEVICE_SERIAL_KISS_TNC:

--- a/src/main.c
+++ b/src/main.c
@@ -12349,9 +12349,11 @@ if (!skip_decode) {
                                 // next block to log and decode the
                                 // packet.
                             }
+                            /* Falls through. */
 
                         case DEVICE_SERIAL_TNC:
                             tnc_data_clean((char *)data_string);
+                            /* Falls through. */
 
                         case DEVICE_AX25_TNC:
                         case DEVICE_NET_AGWPE:

--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -3202,6 +3202,7 @@ void draw_shapefile_map (Widget w,
                         switch ( shape_ring_direction( object, ring) ) {
                             case  0:    // Error in trying to compute whether fill or hole
                                 fprintf(stderr,"Error in computing fill/hole ring\n");
+                                /* Falls through. */
                             case  1:    // It's a fill ring
                                 // Do nothing for these two cases
                                 // except clear the flag in our

--- a/src/util.c
+++ b/src/util.c
@@ -1567,12 +1567,15 @@ time_t time_from_aprsstring(char *aprs_time) {
     switch (sscanf(aprs_time, "%2d%2d%2d%19s", &day, &hour, &minute, tz)) {
         case 0:
             day = 0;
+            /* Falls through. */
 
         case 1:
             hour = 0;
+            /* Falls through. */
 
         case 2:
             minute = 0;
+            /* Falls through. */
  
         default:
             break;


### PR DESCRIPTION
Gcc7 emits a warning message if a switch case falls through to the
next case (unless it's the last case statement in the switch). By
adding specific comments the compiler is looking for, it shuts up
about the fall-through.  This is part of the solution for bug #24.
The proposed fixes only add comments: They don't change the
functionality of the switch case statements in any way.