### PR TITLE
Avoid write past end of string

### DIFF
--- a/src/popup_gui.c
+++ b/src/popup_gui.c
@@ -214,7 +214,7 @@ XmNminHeight, 80,
                                       XmNfontList, fontlist1,
                                       NULL);
 
-            sprintf(pw[i].name,"%d",i);
+            xastir_snprintf(pw[i].name,10,"%d",i);
 
             msg_str=XmStringCreateLtoR(message,XmFONTLIST_DEFAULT_TAG);
             XtVaSetValues(pw[i].popup_message_data,XmNlabelString,msg_str,NULL);


### PR DESCRIPTION
Change sprintf to xastir_snprintf to avoid warning: "may write a
terminating nul past the end of the destination". This results in
new warning: "output may be truncated", which is the same warning
we get again and again from use of the "xastir_snprintf" call.