### PR TITLE
Make Xastir recognize GGA and RMC sentences from any talker

### DIFF
--- a/src/gps.c
+++ b/src/gps.c
@@ -879,7 +879,7 @@ void create_garmin_waypoint(long latitude,long longitude,char *call_sign) {
 // Beidou, or GNSS receivers, and multi-constellation receivers.
 int isGGA(char *gps_line_data) {
     int retval;
-    retval = (strncmp(gps_line_data,"$G",2)==0);
+    retval = (strncmp(gps_line_data,"$",1)==0);
     retval = retval && ((strlen(gps_line_data)>7)
                         && strncmp(&(gps_line_data[3]),"GGA,",4)==0);
     retval = retval && (strchr("PNALB",gps_line_data[2])!=0);
@@ -889,7 +889,7 @@ int isGGA(char *gps_line_data) {
 // Test if this is an RMC string.   See comments for isGGA.
 int isRMC(char *gps_line_data) {
     int retval;
-    retval = (strncmp(gps_line_data,"$G",2)==0);
+    retval = (strncmp(gps_line_data,"$",1)==0);
     retval = retval && ((strlen(gps_line_data)>7)
                         && strncmp(&(gps_line_data[3]),"RMC,",4)==0);
     retval = retval && (strchr("PNALB",gps_line_data[2])!=0);

--- a/src/main.c
+++ b/src/main.c
@@ -11782,7 +11782,7 @@ fprintf(stderr,"main, initializing connections");
 
                                     xastir_snprintf(temp,
                                         sizeof(temp),
-                                        "GPS:GxRMC,GxGGA ");
+                                        "GPS:RMC,GGA ");
                                     strncat(temp,
                                         report_gps_status(),
                                         sizeof(temp) - 1 - strlen(temp));
@@ -11793,7 +11793,7 @@ fprintf(stderr,"main, initializing connections");
  
                                     xastir_snprintf(temp,
                                         sizeof(temp),
-                                        "GPS:GxRMC ");
+                                        "GPS:RMC ");
                                     strncat(temp,
                                         report_gps_status(),
                                         sizeof(temp) - 1 - strlen(temp));
@@ -11804,7 +11804,7 @@ fprintf(stderr,"main, initializing connections");
 
                                     xastir_snprintf(temp,
                                         sizeof(temp), 
-                                        "GPS:GxGGA ");
+                                        "GPS:GGA ");
                                     strncat(temp,
                                         report_gps_status(),
                                         sizeof(temp) - 1 - strlen(temp));


### PR DESCRIPTION
NMEA sentences are:
  $\<talker\>\<sentencetype\>,...

where \<talker\> is a two-character identifier representing the device
type.  The rest of the string is defined in the standard and doesn't
depend on the talker id.

Until commit 2264a035 (which merged PR#58), Xastir only recognized the
GP talker (GPS).  PR #58 added support for GN, GA, GL and GB.  But
there are many other talker IDs out there, and issue #121 calls for
yet another, $II.

This commit simply makes Xastir ignore the talker ID and look only for
the pattern "$..GGA" or "$..RMC" (where "." is regexp-speak for "any
character").

Issue #121
Issue #53
PR #58