### PR TITLE
Degrees

### DIFF
--- a/src/datum.c
+++ b/src/datum.c
@@ -187,7 +187,7 @@ const Datum gDatum[] = {
     { "Indian (Pakistan)",                                                E_EVR_PAK,    283,    682,    231 }, // 83
     { "Indian 1954 (Thailand)",                                        E_EVR_IND_30,    217,    823,    299 }, // 84
     { "Indian 1960 (Vietnam (Con Son Island))",                        E_EVR_IND_30,    182,    915,    344 }, // 85
-    { "Indian 1960 (Vietnam (Near 16°N))",                             E_EVR_IND_30,    198,    881,    317 }, // 86
+    { "Indian 1960 (Vietnam (Near 16N))",                              E_EVR_IND_30,    198,    881,    317 }, // 86
     { "Indian 1975 (Thailand)",                                        E_EVR_IND_30,    210,    814,    289 }, // 87
     { "Indonesian 1974 (Indonesia)",                                       E_IND_74,    -24,    -15,      5 }, // 88
     { "Ireland 1965 (Ireland)",                                          E_MOD_AIRY,    506,   -122,    611 }, // 89
@@ -217,8 +217,8 @@ const Datum gDatum[] = {
     { "Nahrwan (United Arab Emirates)",                                 E_CLARKE_80,   -249,   -156,    381 }, // 113
     { "Naparima BWI (Trinidad & Tobago)",                                  E_INT_24,    -10,    375,    165 }, // 114
     { "North American 1927 (Alaska (Excluding Aleutian Ids))",          E_CLARKE_66,     -5,    135,    172 }, // 115
-    { "North American 1927 (Alaska (Aleutian Ids East of 180°W))",      E_CLARKE_66,     -2,    152,    149 }, // 116
-    { "North American 1927 (Alaska (Aleutian Ids West of 180°W))",      E_CLARKE_66,      2,    204,    105 }, // 117
+    { "North American 1927 (Alaska (Aleutian Ids East of 180W))",       E_CLARKE_66,     -2,    152,    149 }, // 116
+    { "North American 1927 (Alaska (Aleutian Ids West of 180W))",       E_CLARKE_66,      2,    204,    105 }, // 117
     { "North American 1927 (Bahamas (Except San Salvador Id))",         E_CLARKE_66,     -4,    154,    178 }, // 118
     { "North American 1927 (Bahamas (San Salvador Island))",            E_CLARKE_66,      1,    140,    165 }, // 119
     { "North American 1927 (Canada (Alberta; British Columbia))",       E_CLARKE_66,     -7,    162,    188 }, // 120
@@ -262,15 +262,15 @@ const Datum gDatum[] = {
     { "Pointe Noire 1948 (Congo)",                                      E_CLARKE_80,   -148,     51,   -291 }, // 158
     { "Porto Santo 1936 (Porto Santo; Madeira Islands)",                   E_INT_24,   -499,   -249,    314 }, // 159
     { "Provisional South American 1956 (Bolivia)",                         E_INT_24,   -270,    188,   -388 }, // 160
-    { "Provisional South American 1956 (Chile (Northern; Near 19°S))",         E_INT_24,   -270,    183,   -390 }, // 161
-    { "Provisional South American 1956 (Chile (Southern; Near 43°S))",         E_INT_24,   -305,    243,   -442 }, // 162
+    { "Provisional South American 1956 (Chile (Northern; Near 19S))",          E_INT_24,   -270,    183,   -390 }, // 161
+    { "Provisional South American 1956 (Chile (Southern; Near 43S))",          E_INT_24,   -305,    243,   -442 }, // 162
     { "Provisional South American 1956 (Colombia)",                        E_INT_24,   -282,    169,   -371 }, // 163
     { "Provisional South American 1956 (Ecuador)",                         E_INT_24,   -278,    171,   -367 }, // 164
     { "Provisional South American 1956 (Guyana)",                          E_INT_24,   -298,    159,   -369 }, // 165
     { "Provisional South American 1956 (MEAN FOR Bolivia; Chile; Colombia; Ecuador; Guyana; Peru; Venezuela)",         E_INT_24,   -288,    175,   -376 }, // 166
     { "Provisional South American 1956 (Peru)",                            E_INT_24,   -279,    175,   -379 }, // 167
     { "Provisional South American 1956 (Venezuela)",                       E_INT_24,   -295,    173,   -371 }, // 168
-    { "Provisional South Chilean 1963 (Chile (Near 53°S) (Hito XVIII))",         E_INT_24,     16,    196,     93 }, // 169
+    { "Provisional South Chilean 1963 (Chile (Near 53S) (Hito XVIII))",          E_INT_24,     16,    196,     93 }, // 169
     { "Puerto Rico (Puerto Rico; Virgin Islands)",                      E_CLARKE_66,     11,     72,   -101 }, // 170
     { "Pulkovo 1942 (Russia)",                                           E_KRASS_40,     28,   -130,    -95 }, // 171
     { "Qatar National (Qatar)",                                            E_INT_24,   -128,   -283,     22 }, // 172

--- a/src/objects.c
+++ b/src/objects.c
@@ -9387,7 +9387,7 @@ else if (DF_object_enabled) {
         XtAddCallback(doption0,XmNvalueChangedCallback,Ob_directivity_toggle,"0");
 
         // 45 NE
-        doption1 = XtVaCreateManagedWidget("45°",
+        doption1 = XtVaCreateManagedWidget("45\xB0",
                 xmToggleButtonGadgetClass,
                 directivity_box,
                 MY_FOREGROUND_COLOR,
@@ -9397,7 +9397,7 @@ else if (DF_object_enabled) {
         XtAddCallback(doption1,XmNvalueChangedCallback,Ob_directivity_toggle,"1");
 
         // 90 E
-        doption2 = XtVaCreateManagedWidget("90°",
+        doption2 = XtVaCreateManagedWidget("90\xB0",
                 xmToggleButtonGadgetClass,
                 directivity_box,
                 MY_FOREGROUND_COLOR,
@@ -9407,7 +9407,7 @@ else if (DF_object_enabled) {
         XtAddCallback(doption2,XmNvalueChangedCallback,Ob_directivity_toggle,"2");
 
         // 135 SE
-        doption3 = XtVaCreateManagedWidget("135°",
+        doption3 = XtVaCreateManagedWidget("135\xB0",
                 xmToggleButtonGadgetClass,
                 directivity_box,
                 MY_FOREGROUND_COLOR,
@@ -9417,7 +9417,7 @@ else if (DF_object_enabled) {
         XtAddCallback(doption3,XmNvalueChangedCallback,Ob_directivity_toggle,"3");
 
         // 180 S
-        doption4 = XtVaCreateManagedWidget("180°",
+        doption4 = XtVaCreateManagedWidget("180\xB0",
                 xmToggleButtonGadgetClass,
                 directivity_box,
                 MY_FOREGROUND_COLOR,
@@ -9427,7 +9427,7 @@ else if (DF_object_enabled) {
         XtAddCallback(doption4,XmNvalueChangedCallback,Ob_directivity_toggle,"4");
 
         // 225 SW
-        doption5 = XtVaCreateManagedWidget("225°",
+        doption5 = XtVaCreateManagedWidget("225\xB0",
                 xmToggleButtonGadgetClass,
                 directivity_box,
                 MY_FOREGROUND_COLOR,
@@ -9437,7 +9437,7 @@ else if (DF_object_enabled) {
         XtAddCallback(doption5,XmNvalueChangedCallback,Ob_directivity_toggle,"5");
 
         // 270 W
-        doption6 = XtVaCreateManagedWidget("270°",
+        doption6 = XtVaCreateManagedWidget("270\xB0",
                 xmToggleButtonGadgetClass,
                 directivity_box,
                 MY_FOREGROUND_COLOR,
@@ -9447,7 +9447,7 @@ else if (DF_object_enabled) {
         XtAddCallback(doption6,XmNvalueChangedCallback,Ob_directivity_toggle,"6");
 
         // 315 NW
-        doption7 = XtVaCreateManagedWidget("315°",
+        doption7 = XtVaCreateManagedWidget("315\xB0",
                 xmToggleButtonGadgetClass,
                 directivity_box,
                 MY_FOREGROUND_COLOR,
@@ -9457,7 +9457,7 @@ else if (DF_object_enabled) {
         XtAddCallback(doption7,XmNvalueChangedCallback,Ob_directivity_toggle,"7");
 
         // 360 N
-        doption8 = XtVaCreateManagedWidget("360°",
+        doption8 = XtVaCreateManagedWidget("360\xB0",
                 xmToggleButtonGadgetClass,
                 directivity_box,
                 MY_FOREGROUND_COLOR,
@@ -9536,7 +9536,7 @@ else if (DF_object_enabled) {
         XtAddCallback(woption0,XmNvalueChangedCallback,Ob_width_toggle,"0");
 
         // < 240 Degrees
-        woption1 = XtVaCreateManagedWidget("<240°",
+        woption1 = XtVaCreateManagedWidget("<240\xB0",
                 xmToggleButtonGadgetClass,
                 width_box,
                 MY_FOREGROUND_COLOR,
@@ -9546,7 +9546,7 @@ else if (DF_object_enabled) {
         XtAddCallback(woption1,XmNvalueChangedCallback,Ob_width_toggle,"1");
 
         // < 120 Degrees
-        woption2 = XtVaCreateManagedWidget("<120°",
+        woption2 = XtVaCreateManagedWidget("<120\xB0",
                 xmToggleButtonGadgetClass,
                 width_box,
                 MY_FOREGROUND_COLOR,
@@ -9556,7 +9556,7 @@ else if (DF_object_enabled) {
         XtAddCallback(woption2,XmNvalueChangedCallback,Ob_width_toggle,"2");
 
         // < 64 Degrees
-        woption3 = XtVaCreateManagedWidget("<64°",
+        woption3 = XtVaCreateManagedWidget("<64\xB0",
                 xmToggleButtonGadgetClass,
                 width_box,
                 MY_FOREGROUND_COLOR,
@@ -9566,7 +9566,7 @@ else if (DF_object_enabled) {
         XtAddCallback(woption3,XmNvalueChangedCallback,Ob_width_toggle,"3");
 
         // < 32 Degrees
-        woption4 = XtVaCreateManagedWidget("<32°",
+        woption4 = XtVaCreateManagedWidget("<32\xB0",
                 xmToggleButtonGadgetClass,
                 width_box,
                 MY_FOREGROUND_COLOR,
@@ -9576,7 +9576,7 @@ else if (DF_object_enabled) {
         XtAddCallback(woption4,XmNvalueChangedCallback,Ob_width_toggle,"4");
 
         // < 16 Degrees
-        woption5 = XtVaCreateManagedWidget("<16°",
+        woption5 = XtVaCreateManagedWidget("<16\xB0",
                 xmToggleButtonGadgetClass,
                 width_box,
                 MY_FOREGROUND_COLOR,
@@ -9586,7 +9586,7 @@ else if (DF_object_enabled) {
         XtAddCallback(woption5,XmNvalueChangedCallback,Ob_width_toggle,"5");
 
         // < 8 Degrees
-        woption6 = XtVaCreateManagedWidget("<8°",
+        woption6 = XtVaCreateManagedWidget("<8\xB0",
                 xmToggleButtonGadgetClass,
                 width_box,
                 MY_FOREGROUND_COLOR,
@@ -9596,7 +9596,7 @@ else if (DF_object_enabled) {
         XtAddCallback(woption6,XmNvalueChangedCallback,Ob_width_toggle,"6");
 
         // < 4 Degrees
-        woption7 = XtVaCreateManagedWidget("<4°",
+        woption7 = XtVaCreateManagedWidget("<4\xB0",
                 xmToggleButtonGadgetClass,
                 width_box,
                 MY_FOREGROUND_COLOR,
@@ -9606,7 +9606,7 @@ else if (DF_object_enabled) {
         XtAddCallback(woption7,XmNvalueChangedCallback,Ob_width_toggle,"7");
 
         // < 2 Degrees
-        woption8 = XtVaCreateManagedWidget("<2°",
+        woption8 = XtVaCreateManagedWidget("<2\xB0",
                 xmToggleButtonGadgetClass,
                 width_box,
                 MY_FOREGROUND_COLOR,
@@ -9616,7 +9616,7 @@ else if (DF_object_enabled) {
         XtAddCallback(woption8,XmNvalueChangedCallback,Ob_width_toggle,"8");
 
         // < 1 Degrees
-        woption9 = XtVaCreateManagedWidget("<1°",
+        woption9 = XtVaCreateManagedWidget("<1\xB0",
                 xmToggleButtonGadgetClass,
                 width_box,
                 MY_FOREGROUND_COLOR,

--- a/src/util.c
+++ b/src/util.c
@@ -1385,19 +1385,23 @@ void bearing_decode(const char *langstr, const char *bearing_str,
         if (english_units) {
             xastir_snprintf(temp,
                 sizeof(temp),
-                "%i°, %s: %i°, %s: %i mi",
+                "%i%c, %s: %i%c, %s: %i mi",
                 bearing,
+                0xb0,                   // Degree symbol
                 langcode("WPUPSTI088"), // DF Beamwidth
                 width,
+                0xb0,                   // Degree symbol
                 langcode("WPUPSTI089"), // DF Length
                 range);
         } else {
             xastir_snprintf(temp,
                 sizeof(temp),
-                "%i°, %s: %i°, %s: %0.2f km",
+                "%i%c, %s: %i%c, %s: %0.2f km",
                 bearing,
+                0xb0,                   // Degree symbol
                 langcode("WPUPSTI088"), // DF Beamwidth
                 width,
+                0xb0,                   // Degree symbol
                 langcode("WPUPSTI089"), // DF Length
                 range*1.609344);
         }
@@ -2460,8 +2464,9 @@ void convert_lat_l2s(long lat, char *str, int str_len, int type) {
         case(CONVERT_DMS_NORMAL_FORMATED):
             xastir_snprintf(str,
                 str_len,
-                "%02d°%02d\'%04.1f%c",
+                "%02d%c%02d\'%04.1f%c",
                 ideg,
+                0xb0,       // Degree symbol
                 imin,
 //                sec+0.01, // Correct possible unbiased rounding
                 sec,
@@ -2471,8 +2476,9 @@ void convert_lat_l2s(long lat, char *str, int str_len, int type) {
         case(CONVERT_HP_NORMAL_FORMATED):
             xastir_snprintf(str,
                 str_len,
-                "%02d°%06.3f%c",
+                "%02d%c%06.3f%c",
                 ideg,
+                0xb0,         // Degree symbol
 //                min+0.0001, // Correct possible unbiased roundin
                 min,
                 ns);
@@ -2611,8 +2617,9 @@ void convert_lon_l2s(long lon, char *str, int str_len, int type) {
         case(CONVERT_DMS_NORMAL_FORMATED):
             xastir_snprintf(str,
                 str_len,
-                "%03d°%02d\'%04.1f%c",
+                "%03d%c%02d\'%04.1f%c",
                 ideg,
+                0xb0,       // Degree symbol
                 imin,
 //                sec+0.01, // Correct possible unbiased rounding
                 sec,
@@ -2622,8 +2629,9 @@ void convert_lon_l2s(long lon, char *str, int str_len, int type) {
         case(CONVERT_HP_NORMAL_FORMATED):
             xastir_snprintf(str,
                 str_len,
-                "%03d°%06.3f%c",
+                "%03d%c%06.3f%c",
                 ideg,
+                0xb0,         // Degree symbol
 //                min+0.0001, // Correct possible unbiased rounding
                 min,
                 ew);


### PR DESCRIPTION
This closes issue #131, where the degree symbol was causing warnings on the Travis-CI OSX build.
Note that we still have hard-coded degree symbols in there but they appear as either "0xb0" or "\xB0" in various places in the code. They don't trigger OSX compiler warnings now though.