### PR TITLE
Gcc8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       dist: xenial
       name: "Ubuntu-16.04 gcc8 full-featured w/GraphicsMagick"
       env:
-        - CFLAGS="${CFLAGS} -Wno-format-truncation -Wno-stringop-truncation"
+#        - CFLAGS="${CFLAGS} -Wno-format-truncation -Wno-stringop-truncation"
       before_script:
         - export CC="gcc-8"
         - echo ${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,9 @@ matrix:
       env:
 #        - CFLAGS="${CFLAGS} -Wno-format-truncation -Wno-stringop-truncation"
 #        - CFLAGS="${CFLAGS} -Wno-format-truncation"
-        - CFLAGS="-Wall -O2"
+#        - CFLAGS="-Wall -O2"
+        - CFLAGS="${CFLAGS} -Wall -O2 -Wformat-truncation -Wstringop-truncation"
+
  
       before_script:
         - export CC="gcc-8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
       name: "Ubuntu-16.04 gcc8 full-featured w/GraphicsMagick"
       env:
 #        - CFLAGS="${CFLAGS} -Wno-format-truncation -Wno-stringop-truncation"
-        - CFLAGS="${CFLAGS} -Wno-format-truncation"
+#        - CFLAGS="${CFLAGS} -Wno-format-truncation"
  
       before_script:
         - export CC="gcc-8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
         - MAGIC_BIN="/usr/lib/x86_64-linux-gnu/ImageMagick-6.8.9/bin-Q16/Magick-config"
       script:
         - ./bootstrap.sh
-        - ./configure CFLAGS="-O2 -g" CPPFLAGS="-I/usr/include/geotiff"
+        - ./configure CFLAGS="-O2 -g -Wall -Wformat-truncation -Wstringop-truncation" CPPFLAGS="-I/usr/include/geotiff"
         - make
         - sudo make install
       addons:
@@ -40,7 +40,7 @@ matrix:
 #        - CFLAGS="${CFLAGS} -Wno-format-truncation -Wno-stringop-truncation"
 #        - CFLAGS="${CFLAGS} -Wno-format-truncation"
 #        - CFLAGS="-Wall -O2"
-        - CFLAGS="${CFLAGS} -Wall -O2 -Wformat-truncation -Wstringop-truncation"
+#        - CFLAGS="${CFLAGS} -Wall -O2 -Wformat-truncation -Wstringop-truncation"
 
  
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
         - MAGIC_BIN="/usr/lib/x86_64-linux-gnu/ImageMagick-6.8.9/bin-Q16/Magick-config"
       script:
         - ./bootstrap.sh
-        - ./configure CFLAGS="-O2 -g -Wall -Wformat-truncation -Wstringop-truncation" CPPFLAGS="-I/usr/include/geotiff"
+        - ./configure CPPFLAGS="-I/usr/include/geotiff"
         - make
         - sudo make install
       addons:
@@ -37,19 +37,15 @@ matrix:
       dist: xenial
       name: "Ubuntu-16.04 gcc8 full-featured w/GraphicsMagick"
       env:
-#        - CFLAGS="${CFLAGS} -Wno-format-truncation -Wno-stringop-truncation"
 #        - CFLAGS="${CFLAGS} -Wno-format-truncation"
-#        - CFLAGS="-Wall -O2"
-#        - CFLAGS="${CFLAGS} -Wall -O2 -Wformat-truncation -Wstringop-truncation"
-
- 
+#        - CFLAGS="${CFLAGS} -Wall -Wextra -O2 -Wformat-truncation -Wstringop-truncation"
       before_script:
         - export CC="gcc-8"
         - echo ${CC}
         - ${CC} --version
       script:
         - ./bootstrap.sh
-        - ./configure CFLAGS="-O2 -g" CPPFLAGS="-I/usr/include/geotiff"
+        - ./configure CPPFLAGS="-I/usr/include/geotiff"
         - make
         - sudo make install
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
       env:
 #        - CFLAGS="${CFLAGS} -Wno-format-truncation -Wno-stringop-truncation"
 #        - CFLAGS="${CFLAGS} -Wno-format-truncation"
+        - CFLAGS="-Wall -O2"
  
       before_script:
         - export CC="gcc-8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ matrix:
       name: "Ubuntu-16.04 gcc8 full-featured w/GraphicsMagick"
       env:
 #        - CFLAGS="${CFLAGS} -Wno-format-truncation -Wno-stringop-truncation"
+        - CFLAGS="${CFLAGS} -Wno-format-truncation"
+ 
       before_script:
         - export CC="gcc-8"
         - echo ${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
         - MAGIC_BIN="/usr/lib/x86_64-linux-gnu/ImageMagick-6.8.9/bin-Q16/Magick-config"
       script:
         - ./bootstrap.sh
-        - ./configure CPPFLAGS="-I/usr/include/geotiff"
+        - ./configure CFLAGS="-O2 -g" CPPFLAGS="-I/usr/include/geotiff"
         - make
         - sudo make install
       addons:
@@ -47,7 +47,7 @@ matrix:
         - ${CC} --version
       script:
         - ./bootstrap.sh
-        - ./configure CPPFLAGS="-I/usr/include/geotiff"
+        - ./configure CFLAGS="-O2 -g" CPPFLAGS="-I/usr/include/geotiff"
         - make
         - sudo make install
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,7 @@ matrix:
       dist: xenial
       name: "Ubuntu-16.04 gcc8 full-featured w/GraphicsMagick"
       env:
-#        - CFLAGS="${CFLAGS} -Wno-format-truncation"
-#        - CFLAGS="${CFLAGS} -Wall -Wextra -O2 -Wformat-truncation -Wstringop-truncation"
-# "-Wextra" gets us "-Wunused-parameter" warnings
-        - CFLAGS="${CFLAGS} -Wall -O2 -Wformat-truncation=2 -Wstringop-truncation"
+        - CFLAGS="${CFLAGS} -Wall -O2 -Wformat-truncation=2 -Wstringop-truncation -Wextra"
       before_script:
         - export CC="gcc-8"
         - echo ${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ matrix:
       env:
 #        - CFLAGS="${CFLAGS} -Wno-format-truncation"
 #        - CFLAGS="${CFLAGS} -Wall -Wextra -O2 -Wformat-truncation -Wstringop-truncation"
+# "-Wextra" gets us "-Wunused-parameter" warnings
+        - CFLAGS="${CFLAGS} -Wall -O2 -Wformat-truncation=2 -Wstringop-truncation"
       before_script:
         - export CC="gcc-8"
         - echo ${CC}

--- a/src/alert.c
+++ b/src/alert.c
@@ -2005,17 +2005,23 @@ void alert_build_list(Message *fill) {
                 if (is_num_chr(c)) {    // Found numeric char
                     temp[0] = '0';
                     temp[1] = c;
-                    temp[2] = '\0';
+                    temp[2] = '\0'; // Terminate the string
                 }
 
                 else if (c >= 'A' && c <= 'Z') {    // Found upper-case letter
                     // Need to take ord(c) - 55 to get the number
-                    xastir_snprintf(temp,sizeof(temp),"%02d",(int)c - 55);
+                    char temp_string[5];
+                    xastir_snprintf(temp_string, sizeof(temp_string), "%02d", (int)c - 55);
+                    memcpy(temp, &temp_string[2], 2);
+                    temp[2] = '\0'; // Terminate the string
                 }
 
                 else if (c >= 'a' && c <= 'z') {    // Found lower-case letter
                     // Need to take ord(c) - 61 to get the number
-                    xastir_snprintf(temp,sizeof(temp),"%02d",(int)c - 61);
+                    char temp_string[5];
+                    xastir_snprintf(temp_string, sizeof(temp_string), "%02d", (int)c - 61);
+                    memcpy(temp, &temp_string[2], 2);
+                    temp[2] = '\0'; // Terminate the string 
                 }
 
                 strncat(date_time,temp,sizeof(date_time)-strlen(date_time)-1);  // Concatenate the strings

--- a/src/alert.c
+++ b/src/alert.c
@@ -1066,6 +1066,7 @@ void alert_build_list(Message *fill) {
     int compressed_wx_packet = 0;
     char uncompressed_wx[10000];
     struct hashtable_itr *iterator;
+    int tmp_size;
 
 
     //fprintf(stderr,"Message_line:%s\n",fill->message_line);
@@ -1124,35 +1125,31 @@ void alert_build_list(Message *fill) {
 
                 switch (fill->seq[4]) {
                 case 'B':
-                    xastir_snprintf(list_ptr->desc0,
-                                    sizeof(list_ptr->desc0),
-                                    "%s",
-                                    fill->message_line);
+                    tmp_size = sizeof(list_ptr->desc0);
+                    memcpy(list_ptr->desc0, fill->message_line, tmp_size);
+                    list_ptr->desc0[tmp_size-1] = '\0'; // Terminate string
                     if (debug_level & 2)
                         fprintf(stderr,"Wrote into desc0: %s\n",fill->message_line);
                     break;
                 case 'C':
-                    xastir_snprintf(list_ptr->desc1,
-                                    sizeof(list_ptr->desc1),
-                                    "%s",
-                                    fill->message_line);
+                    tmp_size = sizeof(list_ptr->desc1);
+                    memcpy(list_ptr->desc1, fill->message_line, tmp_size);
+                    list_ptr->desc1[tmp_size-1] = '\0'; // Terminate string
                     if (debug_level & 2)
                         fprintf(stderr,"Wrote into desc1: %s\n",fill->message_line);
                     break;
                 case 'D':
-                    xastir_snprintf(list_ptr->desc2,
-                                    sizeof(list_ptr->desc2),
-                                    "%s",
-                                    fill->message_line);
+                    tmp_size = sizeof(list_ptr->desc2);
+                    memcpy(list_ptr->desc2, fill->message_line, tmp_size);
+                    list_ptr->desc2[tmp_size-1] = '\0'; // Terminate string
                     if (debug_level & 2)
                         fprintf(stderr,"Wrote into desc2: %s\n",fill->message_line);
                     break;
                 case 'E':
                 default:
-                    xastir_snprintf(list_ptr->desc3,
-                                    sizeof(list_ptr->desc3),
-                                    "%s",
-                                    fill->message_line);
+                    tmp_size = sizeof(list_ptr->desc3);
+                    memcpy(list_ptr->desc3, fill->message_line, tmp_size);
+                    list_ptr->desc3[tmp_size-1] = '\0'; // Terminate string
                     if (debug_level & 2)
                         fprintf(stderr,"Wrote into desc3: %s\n",fill->message_line);
                     break;
@@ -1980,7 +1977,8 @@ void alert_build_list(Message *fill) {
 
         // Copy the sequence (which contains issue_date_time and
         // message sequence) into the record.
-        xastir_snprintf(entry.seq,sizeof(entry.seq),"%s",fill->seq);
+        memcpy(entry.seq, fill->seq, sizeof(entry.seq));
+        entry.seq[sizeof(entry.seq)-1] = '\0';  // Terminate string
 
         if (debug_level & 2)
             fprintf(stderr,"5\n");
@@ -2141,10 +2139,8 @@ void alert_build_list(Message *fill) {
                             sizeof(entry.to),
                             "%s",
                             fill->call_sign);
-            xastir_snprintf(entry.seq,
-                            sizeof(entry.seq),
-                            "%s",
-                            fill->seq);
+            memcpy(entry.seq, fill->seq, sizeof(entry.seq));
+            entry.seq[sizeof(entry.seq)-1] = '\0';  // Terminate string
 
             // NWS_ADVIS or NWS_CANCL normally appear in the "to"
             // field.  ADVIS can appear in the alert_tag field on a

--- a/src/alert.c
+++ b/src/alert.c
@@ -840,7 +840,7 @@ int alert_expire(int curr_sec) {
 // 5 = G
 // 6 = C
 //
-int alert_active(alert_entry *alert, alert_match_level match_level) {
+int alert_active(alert_entry *alert, alert_match_level UNUSED (match_level) ) {
     alert_entry *a_ptr;
     char l_list[] = {"?RYBTGC"};
     int level = 0;

--- a/src/bulletin_gui.c
+++ b/src/bulletin_gui.c
@@ -166,12 +166,8 @@ void bulletin_message(char *call_sign, char *tag, char *packet_message, time_t s
         if ((Display_bulletins_dialog != NULL) && Display_bulletins_text != NULL) {   // Dialog is up
 
             eod = XmTextGetLastPosition(Display_bulletins_text);
-            xastir_snprintf(temp_text,
-                            sizeof(temp_text),
-                            "%s",
-                            temp);
-
-            temp_text[14] = '\0';
+            memcpy(temp_text, temp, 15);
+            temp_text[14] = '\0'; // Terminate string
 
             // Look for this bulletin ID.  "pos" will hold the first char position if found.
             if (XmTextFindString(Display_bulletins_text, 0, temp_text, XmTEXT_FORWARD, &pos)) {

--- a/src/bulletin_gui.c
+++ b/src/bulletin_gui.c
@@ -527,7 +527,7 @@ void check_for_new_bulletins(int curr_sec) {
 
 
 
-void Display_bulletins_destroy_shell(/*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Display_bulletins_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     char *temp_ptr;
 
@@ -589,7 +589,7 @@ void  Zero_Bulletin_Data_toggle( /*@unused@*/ Widget widget, XtPointer clientDat
 
 
  
-void Bulletins(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Bulletins(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget pane, form, button_range, button_close, dist, dist_units;
     unsigned int n;
     Arg args[50];

--- a/src/color.c
+++ b/src/color.c
@@ -77,11 +77,12 @@ int load_color_file(void) {
                         }
                     }
                     if (ok) {
-                       
-                        xastir_snprintf(color_choice[colors_loaded].colorname,
-                                        MAX_COLORNAME,
-                                        "%s",
-                                        colorname);
+                      
+                        memcpy(color_choice[colors_loaded].colorname,
+                            colorname,
+                            sizeof(color_choice[colors_loaded].colorname)); 
+                        // Terminate string
+                        color_choice[colors_loaded].colorname[sizeof(color_choice[colors_loaded].colorname)-1] = '\0';
 
                         // Do we really want to assign to unsigned short int's here?
                         color_choice[colors_loaded].color.red=(unsigned short)(r*257);

--- a/src/db.c
+++ b/src/db.c
@@ -399,7 +399,7 @@ int is_tracked_station(char *call_sign) {
     }
     else {
         memcpy(call_find, tracking_station_call, sizeof(call_find));
-        call_find[sizeof(call_find-1)] = '\0';  // Terminate string
+        call_find[sizeof(call_find)-1] = '\0';  // Terminate string
     }
 
     if (debug_level & 256) {

--- a/src/db.c
+++ b/src/db.c
@@ -3998,7 +3998,7 @@ void display_file(Widget w) {
 /*
  *  Delete Station Info PopUp
  */
-void Station_data_destroy_shell(/*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Station_data_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -4018,7 +4018,7 @@ void Station_data_destroy_shell(/*@unused@*/ Widget widget, XtPointer clientData
 /*
  *  Store track data for current station
  */
-void Station_data_store_track(Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Station_data_store_track(Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     DataRow *p_station = clientData;
 
     //busy_cursor(XtParent(w));
@@ -4046,7 +4046,7 @@ void Station_data_store_track(Widget w, XtPointer clientData, /*@unused@*/ XtPoi
 /*
  *  Delete tracklog for current station
  */
-void Station_data_destroy_track( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Station_data_destroy_track( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     DataRow *p_station = clientData;
 
     if (delete_trail(p_station))
@@ -4061,7 +4061,7 @@ void Station_data_destroy_track( /*@unused@*/ Widget widget, XtPointer clientDat
 // call wx_alert_double_click_action, which expects the parameter in
 // calldata instead of in clientData.
 //
-void Station_data_wx_alert(Widget w, XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Station_data_wx_alert(Widget w, XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
     //fprintf(stderr, "Station_data_wx_alert start\n");
     wx_alert_finger_output( w, clientData);
     //fprintf(stderr, "Station_data_wx_alert end\n");
@@ -4071,7 +4071,7 @@ void Station_data_wx_alert(Widget w, XtPointer clientData, /*@unused@*/ XtPointe
 
 
 
-void Station_data_add_fcc(Widget w, XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Station_data_add_fcc(Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
     char temp[500];
     FccAppl my_data;
     char *station = (char *) clientData;
@@ -4099,7 +4099,7 @@ void Station_data_add_fcc(Widget w, XtPointer clientData, /*@unused@*/ XtPointer
 
 
 
-void Station_data_add_rac(Widget w, XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Station_data_add_rac(Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
     char temp[512];
     char club[512];
     rac_record my_data;
@@ -4163,7 +4163,7 @@ void Station_data_add_rac(Widget w, XtPointer clientData, /*@unused@*/ XtPointer
 
 
 
-void Station_query_trace(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Station_query_trace(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
     char *station = (char *) clientData;
     char temp[50];
     char call[25];
@@ -4181,7 +4181,7 @@ void Station_query_trace(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@
 
 
 
-void Station_query_messages(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Station_query_messages(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
     char *station = (char *) clientData;
     char temp[50];
     char call[25];
@@ -4199,7 +4199,7 @@ void Station_query_messages(/*@unused@*/ Widget w, XtPointer clientData, /*@unus
 
 
 
-void Station_query_direct(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Station_query_direct(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
     char *station = (char *) clientData;
     char temp[50];
     char call[25];
@@ -4217,7 +4217,7 @@ void Station_query_direct(/*@unused@*/ Widget w, XtPointer clientData, /*@unused
 
 
 
-void Station_query_version(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Station_query_version(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
     char *station = (char *) clientData;
     char temp[50];
     char call[25];
@@ -4235,7 +4235,7 @@ void Station_query_version(/*@unused@*/ Widget w, XtPointer clientData, /*@unuse
 
 
 
-void General_query(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void General_query(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
     char *location = (char *) clientData;
     char temp[50];
 
@@ -4247,7 +4247,7 @@ void General_query(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtP
 
 
 
-void IGate_query(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void IGate_query(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     output_my_data("?IGATE?",-1,0,0,0,NULL); // Not igating
 }
 
@@ -4255,7 +4255,7 @@ void IGate_query(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@un
 
 
 
-void WX_query(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void WX_query(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     output_my_data("?WX?",-1,0,0,0,NULL);    // Not igating
 }
 
@@ -4269,7 +4269,7 @@ Widget tactical_text = (Widget)NULL;
 DataRow *tactical_pointer = NULL;
 
 
-void Change_tactical_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Change_tactical_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -4330,7 +4330,7 @@ void Change_tactical_change_data(Widget widget, XtPointer clientData, XtPointer 
 
 
 
-void Change_tactical(Widget w, XtPointer clientData, XtPointer callData) {
+void Change_tactical(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget pane, my_form, button_ok, button_close, label;
     Atom delw;
     Arg al[50];                     // Arg List
@@ -4492,7 +4492,7 @@ void Change_tactical(Widget w, XtPointer clientData, XtPointer callData) {
 /*
  *  Assign a tactical call to a station
  */
-void Assign_Tactical_Call( Widget w, XtPointer clientData, XtPointer calldata) {
+void Assign_Tactical_Call( Widget w, XtPointer clientData, XtPointer UNUSED(calldata) ) {
     DataRow *p_station = clientData;
 
     //fprintf(stderr,"Object Name: %s\n", p_station->call_sign);
@@ -4507,7 +4507,7 @@ void Assign_Tactical_Call( Widget w, XtPointer clientData, XtPointer calldata) {
 /*
  *  Change the trail color for a station
  */
-void Change_trail_color( Widget w, XtPointer clientData, XtPointer calldata) {
+void Change_trail_color( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     DataRow *p_station = clientData;
     int temp;
 
@@ -4530,7 +4530,7 @@ void Change_trail_color( Widget w, XtPointer clientData, XtPointer calldata) {
 
 
 
-static void PosTestExpose(Widget parent, XtPointer clientData, XEvent *event, Boolean * continueToDispatch) {
+static void PosTestExpose(Widget parent, XtPointer UNUSED(clientData), XEvent * UNUSED(event), Boolean * UNUSED(continueToDispatch) ) {
     Position x, y;
 
     XtVaGetValues(parent, XmNx, &x, XmNy, &y, NULL);
@@ -4599,7 +4599,7 @@ void compute_decorations( void ) {
 
 
 // Enable/disable auto-update of Station_data dialog
-void station_data_auto_update_toggle ( /*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, XtPointer callData) {
+void station_data_auto_update_toggle ( /*@unused@*/ Widget UNUSED(widget), /*@unused@*/ XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
     if(state->set)
@@ -5543,7 +5543,7 @@ void station_data_fill_in ( /*@unused@*/ Widget w, XtPointer clientData, XtPoint
  * Called by Station_data function below from the Track Station
  * button in Station Info.
  */
-void Track_from_Station_data(/*@unused@*/ Widget w, XtPointer clientData, XtPointer calldata) {
+void Track_from_Station_data(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     DataRow *p_station = clientData;
  
     if (p_station->call_sign[0] != '\0') {
@@ -5564,7 +5564,7 @@ void Track_from_Station_data(/*@unused@*/ Widget w, XtPointer clientData, XtPoin
  * Called by Station_data function below from the Clear DF Bearing
  * button in Station Info.
  */
-void Clear_DF_from_Station_data(/*@unused@*/ Widget w, XtPointer clientData, XtPointer calldata) {
+void Clear_DF_from_Station_data(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     DataRow *p_station = clientData;
  
     if (strlen(p_station->bearing) == 3) {
@@ -6302,7 +6302,7 @@ void update_station_info(Widget w) {
 /*
  *  Station Info Selection PopUp window: Canceled
  */
-void Station_info_destroy_shell(/*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Station_info_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
 
     // We used to close the detailed Station Info dialog here too, which
@@ -6343,7 +6343,7 @@ XtPointer station_info_select_global = NULL;
 /*
  *  Station Info Selection PopUp window: Quit with selected station
  */
-void Station_info_select_destroy_shell(Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Station_info_select_destroy_shell(Widget widget, /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     int i,x;
     char *temp;
     char temp2[50];
@@ -6417,7 +6417,7 @@ void Station_info_select_destroy_shell(Widget widget, /*@unused@*/ XtPointer cli
  *             "3"  = Assign Tactical Call
  *             "4"  = Send Message To
  */
-void Station_info(Widget w, /*@unused@*/ XtPointer clientData, XtPointer calldata) {
+void Station_info(Widget w, /*@unused@*/ XtPointer clientData, XtPointer UNUSED(calldata) ) {
     DataRow *p_station;
     DataRow *p_found;
     int num_found = 0;
@@ -7134,7 +7134,7 @@ int extract_weather(DataRow *p_station, char *data, int compr) {
 // The symbol will be either "\@" for current position, or "/@" for
 // predicted position.
 //
-int extract_storm(DataRow *p_station, char *data, int compr) {
+int extract_storm(DataRow *p_station, char *data, int UNUSED(compr) ) {
     char time_data[MAX_TIME];
     int  ok = 1;
     WeatherRow *weather;
@@ -7312,7 +7312,7 @@ int extract_storm(DataRow *p_station, char *data, int compr) {
 
 static void extract_multipoints(DataRow *p_station,
                                 char *data,
-                                int type,
+                                int UNUSED(type),
                                 int remove_string) {
     // If they're in there, the multipoints start with the
     // sequence <space><rbrace><lower><digit> and end with a <lbrace>.
@@ -7640,7 +7640,7 @@ int delete_multipoints(DataRow *fill) { // delete multipoint storage, if allocat
 /*
  *  See if current color is defined as active trail color
  */
-int trail_color_active(int color_index) {
+int trail_color_active(int UNUSED(color_index)) {
 
     // this should be made configurable...
     // to select trail colors to use
@@ -10347,7 +10347,7 @@ int extract_position(DataRow *p_station, char **info, int type) {
  * Returns 0 if the packet is NOT a properly compressed position
  * packet, returns 1 if ok.
  */
-int extract_comp_position(DataRow *p_station, char **info, /*@unused@*/ int type) {
+int extract_comp_position(DataRow *p_station, char **info, /*@unused@*/ int UNUSED(type) ) {
     int ok;
     int x1, x2, x3, x4, y1, y2, y3, y4;
     int c = 0;
@@ -11114,7 +11114,7 @@ void extract_area(DataRow *p_station, char *data) {
  * If a time string is found in "data", it is deleted from the
  * beginning of the string.
  */
-int extract_time(DataRow *p_station, char *data, int type) {
+int extract_time(DataRow * UNUSED(p_station), char *data, int type) {
     int len, i;
     int ok = 0;
 
@@ -11173,7 +11173,7 @@ int extract_time(DataRow *p_station, char *data, int type) {
 //  T../C..  Area Object Descriptor
 
 /* Extract one of several possible APRS Data Extensions */
-void process_data_extension(DataRow *p_station, char *data, /*@unused@*/ int type) {
+void process_data_extension(DataRow *p_station, char *data, /*@unused@*/ int UNUSED(type) ) {
     char temp1[7+1];
     char temp2[3+1];
     char temp3[10+1];
@@ -11354,7 +11354,7 @@ void process_data_extension(DataRow *p_station, char *data, /*@unused@*/ int typ
 
 
 /* extract all available information from info field */
-void process_info_field(DataRow *p_station, char *info, /*@unused@*/ int type) {
+void process_info_field(DataRow *p_station, char *info, /*@unused@*/ int UNUSED(type) ) {
     char temp_data[6+1];
     //    char time_data[MAX_TIME];
 
@@ -14163,7 +14163,7 @@ void compute_smart_beacon(char *current_course, char *current_speed) {
 
 
 // Speed is in knots
-void my_station_gps_change(char *pos_long, char *pos_lat, char *course, char *speed, /*@unused@*/ char speedu, char *alt, char *sats) {
+void my_station_gps_change(char *pos_long, char *pos_lat, char *course, char *speed, /*@unused@*/ char UNUSED(speedu), char *alt, char *sats) {
     long pos_long_temp, pos_lat_temp;
     char temp_data[40];   // short term string storage
     char temp_lat[12];
@@ -15408,7 +15408,7 @@ int process_directed_query(char *call,char *path,char *message,char from) {
 // NOTE:  We may end up sending these to RF when the query came in
 // over the internet.  We should check that.
 //
-int process_query( /*@unused@*/ char *call_sign, /*@unused@*/ char *path,char *message,char from,int port, /*@unused@*/ int third_party) {
+int process_query( /*@unused@*/ char *call_sign, /*@unused@*/ char * UNUSED(path), char *message,char from,int port, /*@unused@*/ int UNUSED(third_party) ) {
     char temp[100];
     int ok = 0;
     float randomize;
@@ -15545,7 +15545,7 @@ int process_query( /*@unused@*/ char *call_sign, /*@unused@*/ char *path,char *m
 /*
  *  Status Reports                              [APRS Reference, chapter 16]
  */
-int process_status( /*@unused@*/ char *call_sign, /*@unused@*/ char *path, /*@unused@*/ char *message, /*@unused@*/ char from, /*@unused@*/ int port, /*@unused@*/ int third_party) {
+int process_status( /*@unused@*/ char * UNUSED(call_sign), /*@unused@*/ char * UNUSED(path), /*@unused@*/ char * UNUSED(message), /*@unused@*/ char UNUSED(from), /*@unused@*/ int UNUSED(port), /*@unused@*/ int UNUSED(third_party) ) {
 
     //    popup_message(langcode("POPEM00018"),message);  // What is it ???
     return(1);
@@ -15845,7 +15845,7 @@ int fill_in_tactical_callsign(char *call, char *tactical_call) {
 //
 //  '=' or ';' characters can not be in the TAC callsign.
 // 
-int tactical_data_add(char *call, char *message, char from) {
+int tactical_data_add(char *call, char *message, char UNUSED(from) ) {
     char *temp_ptr;
 
 
@@ -18939,7 +18939,7 @@ void  read_file_line(FILE *f) {
 /*
  *  Center map to new position
  */
-void set_map_position(Widget w, long lat, long lon) {
+void set_map_position(Widget UNUSED(w), long lat, long lon) {
     // see also map_pos() in location.c
 
     // Set interrupt_drawing_now because conditions have changed
@@ -19116,7 +19116,7 @@ void search_tracked_station(DataRow **p_tracked) {
  *  Change map position if neccessary while tracking a station
  *      we call it with defined station call and position
  */
-void track_station(Widget w, char *call_tracked, DataRow *p_station) {
+void track_station(Widget w, char * UNUSED(call_tracked), DataRow *p_station) {
     long x_ofs, y_ofs;
     long new_lat, new_lon;
 
@@ -19404,7 +19404,7 @@ void calc_aloha(int secs_now)    {
 
 
 // popup window on menu request
-void Show_Aloha_Stats(Widget w, XtPointer clientData, XtPointer callData)  {
+void Show_Aloha_Stats(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )  {
 
     char temp[2000];
     char format[1000];

--- a/src/db.c
+++ b/src/db.c
@@ -4619,7 +4619,7 @@ void station_data_fill_in ( /*@unused@*/ Widget w, XtPointer clientData, XtPoint
     char temp[300];
     int pos, last_pos;
     char temp_my_distance[20];
-    char temp_my_course[20];
+    char temp_my_course[25];
     char temp1_my_course[20];
     float temp_out_C, e, humidex;
     long l_lat, l_lon;
@@ -18448,6 +18448,7 @@ int decode_ax25_line(char *line, char from, int port, int dbadd) {
     int third_party;
     char backup[MAX_LINE_SIZE+1];
     char tmp_line[MAX_LINE_SIZE+1];
+    char tmp_line2[630];
     char tmp_path[100+1];
     char *ViaCalls[10];
 
@@ -18831,13 +18832,15 @@ int decode_ax25_line(char *line, char from, int port, int dbadd) {
             // Here's where we inject our own callsign like this:
             // "WE7U-15,I" in order to provide injection ID for our
             // igate.
-            xastir_snprintf(tmp_line,
-                            sizeof(tmp_line),
+            xastir_snprintf(tmp_line2,
+                            sizeof(tmp_line2),
                             "%s>%s,%s,I:%s",
                             call_sign,
                             path,
                             my_callsign,
                             info_copy);
+            memcpy(tmp_line, tmp_line2, sizeof(tmp_line));
+            tmp_line[sizeof(tmp_line)-1] = '\0';  // Terminate line
 
             //fprintf(stderr,"decode_ax25_line: IGATE>NET %s\n",tmp_line);
             //fprintf(stderr,"call: %s\tcall_sign: %s\n", call, call_sign);

--- a/src/db.c
+++ b/src/db.c
@@ -398,10 +398,8 @@ int is_tracked_station(char *call_sign) {
         call_find[ii] = '\0';
     }
     else {
-        xastir_snprintf(call_find,
-                        sizeof(call_find),
-                        "%s",
-                        tracking_station_call);
+        memcpy(call_find, tracking_station_call, sizeof(call_find));
+        call_find[sizeof(call_find-1)] = '\0';  // Terminate string
     }
 
     if (debug_level & 256) {
@@ -14226,14 +14224,12 @@ void my_station_gps_change(char *pos_long, char *pos_lat, char *course, char *sp
                     temp_data[7], temp_data[8],temp_data[9]);
 
     /* fill the data in */    // ???????????????
-    xastir_snprintf(my_lat,
-                    sizeof(my_lat),
-                    "%s",
-                    temp_lat);
-    xastir_snprintf(my_long,
-                    sizeof(my_long),
-                    "%s",
-                    temp_long);
+    memcpy(my_lat, temp_lat, sizeof(my_lat));
+    my_lat[sizeof(my_lat)-1] = '\0';  // Terminate string
+
+    memcpy(my_long, temp_long, sizeof(my_long));
+    my_long[sizeof(my_long)-1] = '\0';  // Terminate string
+
     p_station->coord_lat = convert_lat_s2l(my_lat);
     p_station->coord_lon = convert_lon_s2l(my_long);
 
@@ -14634,10 +14630,8 @@ void packet_data_add(char *from, char *line, int data_port) {
         char short_call[MAX_CALLSIGN];
         char *p;
 
-        xastir_snprintf(short_call,
-                        sizeof(short_call),
-                        "%s",
-                        my_callsign);
+        memcpy(short_call, my_callsign, sizeof(short_call));
+        short_call[sizeof(short_call)-1] = '\0';  // Terminate string
         if ( (p = index(short_call,'-')) ) {
             *p = '\0';  // Terminate it
         }
@@ -18058,10 +18052,8 @@ int decode_ax25_header(unsigned char *data_string, int *length) {
     // truncate our string.  Make sure the data_string variable is
     // MAX_LINE_SIZE or bigger.
     //
-    xastir_snprintf((char *)data_string,
-                    MAX_LINE_SIZE,
-                    "%s",
-                    result);
+    memcpy(data_string, result, MAX_LINE_SIZE);
+    data_string[MAX_LINE_SIZE-1] = '\0';  // Terminate string
 
     // Write out the new length
     *length = strlen(result); 
@@ -18914,14 +18906,11 @@ void  read_file_line(FILE *f) {
                     // previous string.  Used for debugging
                     // purposes.  If we get a segfault, we can print
                     // out the last two messages received.
-                    xastir_snprintf((char *)incoming_data_copy_previous,
-                                    MAX_LINE_SIZE,
-                                    "%s",
-                                    incoming_data_copy);
-                    xastir_snprintf((char *)incoming_data_copy,
-                                    MAX_LINE_SIZE,
-                                    "%s",
-                                    line);
+                    memcpy(incoming_data_copy_previous, incoming_data_copy, MAX_LINE_SIZE);
+                    incoming_data_copy_previous[MAX_LINE_SIZE-1] = '\0';  // Terminate string
+
+                    memcpy(incoming_data_copy, line, MAX_LINE_SIZE);
+                    incoming_data_copy[MAX_LINE_SIZE-1] = '\0'; // Terminate string
 
                     if (line[0] != '#') {
                         decode_ax25_line(line,'F',-1, 1);   // Decode the packet

--- a/src/db.c
+++ b/src/db.c
@@ -6895,14 +6895,10 @@ int extract_weather(DataRow *p_station, char *data, int compr) {
             // already extracted speed/course from the compressed
             // packet.  extract_comp_position() extracts
             // course/speed as well.
-            xastir_snprintf(speed,
-                            sizeof(speed),
-                            "%s",
-                            p_station->speed);
-            xastir_snprintf(course,
-                            sizeof(course),
-                            "%s",
-                            p_station->course);
+            memcpy(speed, p_station->speed, sizeof(speed));
+            speed[sizeof(speed)-1] = '\0';  // Terminate string
+            memcpy(course, p_station->course, sizeof(course));
+            course[sizeof(course)-1] = '\0';  // Terminate string
             in_knots = 1;
 
             //fprintf(stderr,"Found compressed wx\n");
@@ -6918,14 +6914,10 @@ int extract_weather(DataRow *p_station, char *data, int compr) {
             // already extracted speed/course from the compressed
             // packet.  extract_comp_position() extracts
             // course/speed as well.
-            xastir_snprintf(speed,
-                            sizeof(speed),
-                            "%s",
-                            p_station->speed);
-            xastir_snprintf(course,
-                            sizeof(course),
-                            "%s",
-                            p_station->course);
+            memcpy(speed, p_station->speed, sizeof(speed));
+            speed[sizeof(speed)-1] = '\0';  // Terminate string
+            memcpy(course, p_station->course, sizeof(course));
+            course[sizeof(course)-1] = '\0';  // Terminate string
             in_knots = 1;
 
             //fprintf(stderr,"Found compressed WX in non-fixed locations! %s:%s\n",

--- a/src/db.c
+++ b/src/db.c
@@ -7242,7 +7242,7 @@ int extract_storm(DataRow *p_station, char *data, int UNUSED(compr) ) {
             xastir_snprintf(weather->wx_speed,
                             sizeof(weather->wx_speed),
                             "%0.1f",
-                            (float)(atoi(weather->wx_speed)) * 1.1508);
+                            atof(weather->wx_speed) * 1.1508);
 
         //fprintf(stderr,"%s\n",data);
 
@@ -7252,7 +7252,7 @@ int extract_storm(DataRow *p_station, char *data, int UNUSED(compr) ) {
             xastir_snprintf(weather->wx_gust,
                             sizeof(weather->wx_gust),
                             "%0.1f",
-                            (float)(atoi(weather->wx_gust)) * 1.1508);
+                            atof(weather->wx_gust) * 1.1508);
 
         //fprintf(stderr,"%s\n",data);
 
@@ -7262,7 +7262,7 @@ int extract_storm(DataRow *p_station, char *data, int UNUSED(compr) ) {
             xastir_snprintf(weather->wx_baro,
                             sizeof(weather->wx_baro),
                             "%0.1f",
-                            (float)(atoi(weather->wx_baro)));
+                            atof(weather->wx_baro));
 
         //fprintf(stderr,"%s\n",data);
 
@@ -14290,7 +14290,7 @@ void my_station_gps_change(char *pos_long, char *pos_lat, char *course, char *sp
     my_last_course=atoi(course);
 
     /* get my last speed in knots */
-    my_last_speed=(int)(atof(speed));
+    my_last_speed = atoi(speed);
     xastir_snprintf(p_station->sats_visible,
                     sizeof(p_station->sats_visible),
                     "%s",

--- a/src/dlm.c
+++ b/src/dlm.c
@@ -409,8 +409,10 @@ static size_t DLM_curl_fwrite_callback(void *buffer, size_t size, size_t nmemb, 
  * DLM_curl_progress_callback() - callback for curl_multi
  **********************************************************/
 static int DLM_curl_progress_callback(void *p,
-                                      double dltotal, double dlnow,
-                                      double ultotal, double ulnow) {
+                                      double UNUSED(dltotal),
+                                      double UNUSED(dlnow),
+                                      double UNUSED(ultotal),
+                                      double UNUSED(ulnow) ) {
     struct DLM_queue_entry *tile = (struct DLM_queue_entry *)p;
     if (!tile) return 0;
 
@@ -498,7 +500,7 @@ static CURL *DLM_curl_init(char *errBuf) {
 /**********************************************************
  * DLM_transfer_thread() - retrieve item queued for download
  **********************************************************/
-static void *DLM_transfer_thread(void *arg) {
+static void *DLM_transfer_thread(void * UNUSED(arg) ) {
     struct DLM_queue_entry *tile;
 #ifdef DLM_QUEUE_THREADED
     int idleCnt;

--- a/src/draw_symbols.c
+++ b/src/draw_symbols.c
@@ -233,7 +233,7 @@ void draw_WP_line(DataRow *p_station,
                   long ambiguity_coord_lon,
                   long ambiguity_coord_lat,
                   Pixmap where,
-                  Widget w) {
+                  Widget UNUSED(w) ) {
     DataRow *transmitting_station = NULL;
     int my_course;
     long x_long, y_lat;
@@ -452,7 +452,7 @@ void draw_pod_circle(long x_long, long y_lat, double range, int color, Pixmap wh
 //
 void draw_precision_rectangle(long x_long,
                               long y_lat,
-                              double range, // Not implemented yet
+                              double UNUSED(range), // Not implemented yet
                               unsigned int lat_precision,
                               unsigned int lon_precision,
                               int color,
@@ -977,7 +977,7 @@ void set_barb_parameters(void) {
 
 
 
-void draw_half_barbs(int *i, int quantity, float bearing_radians, long x, long y, char *course, Pixmap where) {
+void draw_half_barbs(int *i, int quantity, float bearing_radians, long x, long y, char * UNUSED(course), Pixmap where) {
     float barb_radians = bearing_radians + ( (45/360.0) * 2.0 * M_PI);
     int j;
     long start_x, start_y, off_x, off_y;
@@ -1016,7 +1016,7 @@ void draw_half_barbs(int *i, int quantity, float bearing_radians, long x, long y
 
 
 
-void draw_full_barbs(int *i, int quantity, float bearing_radians, long x, long y, char *course, Pixmap where) {
+void draw_full_barbs(int *i, int quantity, float bearing_radians, long x, long y, char * UNUSED(course), Pixmap where) {
     float barb_radians = bearing_radians + ( (45/360.0) * 2.0 * M_PI);
     int j;
     long start_x, start_y, off_x, off_y;
@@ -1055,7 +1055,7 @@ void draw_full_barbs(int *i, int quantity, float bearing_radians, long x, long y
 
 
 
-void draw_triangle_flags(int *i, int quantity, float bearing_radians, long x, long y, char *course, Pixmap where) {
+void draw_triangle_flags(int *i, int quantity, float bearing_radians, long x, long y, char * UNUSED(course), Pixmap where) {
     float barb_radians = bearing_radians + ( (45/360.0) * 2.0 * M_PI);
     int j;
     long start_x, start_y, off_x, off_y, off_x2, off_y2;
@@ -1096,7 +1096,7 @@ void draw_triangle_flags(int *i, int quantity, float bearing_radians, long x, lo
 
 
 
-void draw_square_flags(int *i, int quantity, float bearing_radians, long x, long y, char *course, Pixmap where) {
+void draw_square_flags(int *i, int quantity, float bearing_radians, long x, long y, char * UNUSED(course), Pixmap where) {
     float barb_radians = bearing_radians + ( (90/360.0) * 2.0 * M_PI);
     int j;
     long start_x, start_y, off_x, off_y, off_x2, off_y2;
@@ -1350,7 +1350,7 @@ void draw_wind_barb(long x_long, long y_lat, char *speed,
 // The angle is what is important here.
 //
 void draw_bearing(long x_long, long y_lat, char *course,
-                  char *bearing, char *NRQ, int color, int draw_beamwidth, 
+                  char *bearing, char *NRQ, int UNUSED(color), int draw_beamwidth, 
                   int draw_bearing,
                   time_t sec_heard, Pixmap where) {
     double range = 0;
@@ -1500,7 +1500,7 @@ void draw_bearing(long x_long, long y_lat, char *course,
 // then add 1/2 the rectangle offsets in order to get the symbol
 // placed in the middle of the rectangle.
 //
-void draw_ambiguity(long x_long, long y_lat, char amb, long *amb_x_long, long *amb_y_lat, time_t sec_heard, Pixmap where) {
+void draw_ambiguity(long x_long, long y_lat, char amb, long *amb_x_long, long *amb_y_lat, time_t sec_heard, Pixmap UNUSED(where) ) {
     unsigned long left, right, top, bottom;
     long offset_lat, offset_long;
     int scale_limit;
@@ -2869,7 +2869,7 @@ static int getLineStyle(char styleChar) {
  * Draw the other points associated with the station.
  * KG4NBB
  */
-void draw_multipoints(long x_long, long y_lat, int numpoints, long mypoints[][2], char type, char style, time_t sec_heard, Pixmap where) {
+void draw_multipoints(long UNUSED(x_long), long UNUSED(y_lat), int numpoints, long mypoints[][2], char type, char style, time_t sec_heard, Pixmap where) {
     int ghost;
     int skip_duplicates;
 
@@ -3041,7 +3041,7 @@ void draw_multipoints(long x_long, long y_lat, int numpoints, long mypoints[][2]
 
 
 
-void Select_symbol_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Select_symbol_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     int i;
 
@@ -3113,7 +3113,7 @@ void Select_symbol_change_data(Widget widget, XtPointer clientData, XtPointer ca
 
 
 
-void Select_symbol( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Select_symbol( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, my_form2, my_form3, button_cancel,
             frame, frame2, b1;
     int i;

--- a/src/fcc_data.c
+++ b/src/fcc_data.c
@@ -311,7 +311,7 @@ int search_fcc_data_appl(char *callsign, FccAppl *data) {
         // the alphabet than the current index, snag the next index.
         while (!feof(fndx) && strncmp(callsign,index,6) > 0) {
             memcpy(char_offset, &index[6], sizeof(char_offset));
-            char_offset[sizeof(char_offset-1)] = '\0';  // Terminate string
+            char_offset[sizeof(char_offset)-1] = '\0';  // Terminate string
             if (fgets(index,(int)sizeof(index),fndx) == NULL) {
                 // Error occurred
                 fprintf(stderr,"Search:Could not read FCC database index(2): %s\n", appl_file_path );

--- a/src/fcc_data.c
+++ b/src/fcc_data.c
@@ -303,13 +303,15 @@ int search_fcc_data_appl(char *callsign, FccAppl *data) {
             return(0);
         }
 
-        xastir_snprintf(char_offset,sizeof(char_offset),"%s",&index[6]);
+        memcpy(char_offset, &index[6], sizeof(char_offset));
+        char_offset[sizeof(char_offset)-1] = '\0';  // Terminate string
 
         // Search through the indexes looking for a callsign which is
         // close to the callsign of interest.  If callsign is later in
         // the alphabet than the current index, snag the next index.
         while (!feof(fndx) && strncmp(callsign,index,6) > 0) {
-            xastir_snprintf(char_offset,sizeof(char_offset),"%s",&index[6]);
+            memcpy(char_offset, &index[6], sizeof(char_offset));
+            char_offset[sizeof(char_offset-1)] = '\0';  // Terminate string
             if (fgets(index,(int)sizeof(index),fndx) == NULL) {
                 // Error occurred
                 fprintf(stderr,"Search:Could not read FCC database index(2): %s\n", appl_file_path );

--- a/src/forked_getaddrinfo.c
+++ b/src/forked_getaddrinfo.c
@@ -80,7 +80,7 @@
 /* (see  setjmp below).                                                  */
 /*************************************************************************/
 
-static void host_time_out( /*@unused@*/ int sig) {
+static void host_time_out( /*@unused@*/ int UNUSED(sig) ) {
 #ifndef __LCLINT__
     siglongjmp(ret_place,0);
 #endif // __LCLINT__

--- a/src/geocoder_gui.c
+++ b/src/geocoder_gui.c
@@ -85,7 +85,7 @@ void geocoder_gui_init(void)
 
 /**** GEOCODER FIND PLACE ******/
 
-void Geocoder_place_destroy_shell(/*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Geocoder_place_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -248,7 +248,7 @@ fprintf(stderr,"%s\n%s\n%s\n%s\n%s\n",
 
 
 
-void  Show_dest_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Show_dest_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -264,7 +264,7 @@ void  Show_dest_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoin
 
 
 
-void Geocoder_place(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Geocoder_place(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget pane, form, button_ok, button_cancel, sep,
         zip, state, locality, address, map_file, show_dest_toggle;
     Atom delw;

--- a/src/gps.c
+++ b/src/gps.c
@@ -863,11 +863,10 @@ void create_garmin_waypoint(long latitude,long longitude,char *call_sign) {
 
     nmea_checksum(out_string);
 
-    xastir_snprintf(out_string2,
-        sizeof(out_string2),
-        "%s%s",
-        out_string,
-        checksum);
+    strncpy(out_string2, out_string, sizeof(out_string2));
+    out_string2[sizeof(out_string2)-1] = '\0';  // Terminate string
+
+    strcat(out_string2, checksum);
 
     output_waypoint_data(out_string2);
 

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -61,7 +61,7 @@ create_hashtable(unsigned int minsize,
     h->entrycount   = 0;
     h->hashfn       = hashf;
     h->eqfn         = eqf;
-    h->loadlimit    = (unsigned int) ceil(size * max_load_factor);
+    h->loadlimit    = ceil(size * max_load_factor);
     return h;
 }
 
@@ -134,7 +134,7 @@ hashtable_expand(struct hashtable *h)
         }
     }
     h->tablelength = newsize;
-    h->loadlimit   = (unsigned int) ceil(newsize * max_load_factor);
+    h->loadlimit   = ceil(newsize * max_load_factor);
     return -1;
 }
 

--- a/src/igate.c
+++ b/src/igate.c
@@ -400,10 +400,8 @@ int not_a_dupe(int queue_type, int port, char *line, int insert_mode) {
 
             temp->time = (time_t)sec_now();
 
-            xastir_snprintf(temp->data,
-                sizeof(temp->data),
-                "%s",
-                match_line);
+            memcpy(temp->data, match_line, sizeof(temp->data));
+            temp->data[sizeof(temp->data)-1] = '\0';  // Terminate string
 
             temp->next = NULL;  // Will be the end of the linked list
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -6574,11 +6574,11 @@ void output_my_aprs_data(void) {
             // Add '\r' onto end.
             strncat(data_txt_save, "\r", sizeof(data_txt_save)-strlen(data_txt_save)-1);
 
-            xastir_snprintf(data_txt,
-                            sizeof(data_txt),
-                            "%s%s",
-                            output_net,
-                            data_txt_save);
+            strcpy(data_txt, output_net);
+            data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+
+            strcat(data_txt, data_txt_save);
+            data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
 
             break;
 
@@ -6623,11 +6623,11 @@ void output_my_aprs_data(void) {
             // Add '\r' onto end.
             strncat(data_txt_save, "\r", sizeof(data_txt_save)-strlen(data_txt_save)-1);
 
-            xastir_snprintf(data_txt,
-                            sizeof(data_txt),
-                            "%s%s",
-                            output_net,
-                            data_txt_save);
+            strcpy(data_txt, output_net);
+            data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+
+            strcat(data_txt, data_txt_save);
+            data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
 
             break;
 
@@ -6672,11 +6672,11 @@ void output_my_aprs_data(void) {
             // Add '\r' onto end.
             strncat(data_txt_save, "\r", sizeof(data_txt_save)-strlen(data_txt_save)-1);
 
-            xastir_snprintf(data_txt,
-                            sizeof(data_txt),
-                            "%s%s",
-                            output_net,
-                            data_txt_save);
+            strcpy(data_txt, output_net);
+            data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+
+            strcat(data_txt, data_txt_save);
+            data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
 
             break;
 
@@ -6717,11 +6717,11 @@ void output_my_aprs_data(void) {
                 // Add '\r' onto end.
                 strncat(data_txt_save, "\r", sizeof(data_txt_save)-strlen(data_txt_save)-1);
 
-                xastir_snprintf(data_txt,
-                                sizeof(data_txt),
-                                "%s%s",
-                                output_net,
-                                data_txt_save);
+                strcpy(data_txt, output_net);
+                data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+
+                strcat(data_txt, data_txt_save);
+                data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
             }
             else {
                 /* default to APRS FIXED if no wx data. No timestamp */
@@ -6760,11 +6760,11 @@ void output_my_aprs_data(void) {
                 // Add '\r' onto end.
                 strncat(data_txt_save, "\r", sizeof(data_txt_save)-strlen(data_txt_save)-1);
 
-                xastir_snprintf(data_txt,
-                                sizeof(data_txt),
-                                "%s%s",
-                                output_net,
-                                data_txt_save);
+                strcpy(data_txt, output_net);
+                data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+
+                strcat(data_txt, data_txt_save);
+                data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
             }
 
             break;
@@ -6801,11 +6801,11 @@ void output_my_aprs_data(void) {
                 // Add '\r' onto end.
                 strncat(data_txt_save, "\r", sizeof(data_txt_save)-strlen(data_txt_save)-1);
 
-                xastir_snprintf(data_txt,
-                                sizeof(data_txt),
-                                "%s%s",
-                                output_net,
-                                data_txt_save);
+                strcpy(data_txt, output_net);
+                data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+
+                strcat(data_txt, data_txt_save);
+                data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
             }
             else {
                 /* default to APRS FIXED if no wx data */
@@ -6844,11 +6844,11 @@ void output_my_aprs_data(void) {
                 // Add '\r' onto end.
                 strncat(data_txt_save, "\r", sizeof(data_txt_save)-strlen(data_txt_save)-1);
 
-                xastir_snprintf(data_txt,
-                                sizeof(data_txt),
-                                "%s%s",
-                                output_net,
-                                data_txt_save);
+                strcpy(data_txt, output_net);
+                data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+
+                strcat(data_txt, data_txt_save);
+                data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
             }
             break;
 
@@ -6892,11 +6892,11 @@ void output_my_aprs_data(void) {
             // Add '\r' onto end.
             strncat(data_txt_save, "\r", sizeof(data_txt_save)-strlen(data_txt_save)-1);
 
-            xastir_snprintf(data_txt,
-                            sizeof(data_txt),
-                            "%s%s",
-                            output_net,
-                            data_txt_save);
+            strcpy(data_txt, output_net);
+            data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+
+            strcat(data_txt, data_txt_save);
+            data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
 
             break;
         }
@@ -6975,13 +6975,21 @@ void output_my_aprs_data(void) {
                 // For packets that we're igating we end up with a CR or
                 // LF on the end of them.  Remove that so the display
                 // looks nice.
-                xastir_snprintf(temp,
-                                sizeof(temp),
-                                "%s>%s,%s:%s",
-                                my_callsign,
-                                VERSIONFRM,
-                                unproto_path,
-                                data_txt);
+                strcpy(temp, my_callsign);
+                temp[sizeof(temp)-1] = '\0';  // Terminate string
+                strcat(temp, ">");
+                temp[sizeof(temp)-1] = '\0';  // Terminate string
+                strcat(temp, VERSIONFRM);
+                temp[sizeof(temp)-1] = '\0';  // Terminate string
+                strcat(temp, ",");
+                temp[sizeof(temp)-1] = '\0';  // Terminate string
+                strcat(temp, unproto_path);
+                temp[sizeof(temp)-1] = '\0';  // Terminate string
+                strcat(temp, ":");
+                temp[sizeof(temp)-1] = '\0';  // Terminate string
+                strcat(temp, data_txt);
+                temp[sizeof(temp)-1] = '\0';  // Terminate string
+
                 makePrintable(temp);
                 packet_data_add("TX ", temp, port);
             }
@@ -7028,8 +7036,18 @@ void output_my_aprs_data(void) {
     // This will log a posit in the general format for a network interface
     // whether or not any network interfaces are currently up.
     if (log_net_data) {
-        xastir_snprintf(data_txt, sizeof(data_txt), "%s>%s,TCPIP*:%s", my_callsign,
-                        VERSIONFRM, data_txt_save);
+
+        strcpy(data_txt, my_callsign);
+        data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+        strcat(data_txt, ">");
+        data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+        strcat(data_txt, VERSIONFRM);
+        data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+        strcat(data_txt, ",TCPIP*:");
+        data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+        strcat(data_txt, data_txt_save);
+        data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+
         log_data( get_user_base_dir(LOGFILE_NET, logfile_tmp_path, 
                                     sizeof(logfile_tmp_path)), 
                   (char *)data_txt );
@@ -7039,9 +7057,17 @@ void output_my_aprs_data(void) {
     if (enable_server_port && !transmit_disable && !posit_tx_disable) {
         // Send data to the x_spider server
 
-        xastir_snprintf(data_txt, sizeof(data_txt), "%s>%s,TCPIP*:%s", my_callsign,
-                        VERSIONFRM, data_txt_save);
- 
+        strcpy(data_txt, my_callsign);
+        data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+        strcat(data_txt, ">");
+        data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+        strcat(data_txt, VERSIONFRM);
+        data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+        strcat(data_txt, ",TCPIP*:");
+        data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+        strcat(data_txt, data_txt_save);
+        data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+
         if (writen(pipe_xastir_to_tcp_server,
                    data_txt,
                    strlen(data_txt)) != (int)strlen(data_txt)) {
@@ -7065,7 +7091,12 @@ void output_my_aprs_data(void) {
     // have anything output to the log file here.
     if (log_tnc_data) {
         if (header_txt_save[0] != '\0') {
-            xastir_snprintf(data_txt, sizeof(data_txt), "%s%s", header_txt_save, data_txt_save);
+
+            strcpy(data_txt, header_txt_save);
+            data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+            strcat(data_txt, data_txt_save);
+            data_txt[sizeof(data_txt)-1] = '\0';  // Terminate string
+
             log_data( get_user_base_dir(LOGFILE_TNC, logfile_tmp_path, 
                                         sizeof(logfile_tmp_path)), 
                       (char *)data_txt );

--- a/src/interface.c
+++ b/src/interface.c
@@ -6259,10 +6259,8 @@ void output_my_aprs_data(void) {
     // "EMERGENCY" at the beginning of the comment field we'll
     // transmit.
     if (emergency_beacon) {
-        xastir_snprintf(my_comment_tx,
-                        sizeof(my_comment_tx),
-                        "EMERGENCY %s",
-                        my_comment);
+        strncpy(my_comment_tx, "EMERGENCY", sizeof(my_comment_tx));
+        my_comment_tx[sizeof(my_comment_tx)-1] = '\0';  // Terminate string
     }
     else {
         xastir_snprintf(my_comment_tx,

--- a/src/interface.c
+++ b/src/interface.c
@@ -7824,7 +7824,7 @@ void tnc_data_clean(char *buf) {
 // Note that the length of "buf" can be up to MAX_DEVICE_BUFFER,
 // which is currently set to 4096.
 //
-int tnc_get_data_type(char *buf, int port) {
+int tnc_get_data_type(char *buf, int UNUSED(port) ) {
     register int i;
     int type=1;      // Don't know what it is yet.  Assume NMEA for now.
 

--- a/src/interface_gui.c
+++ b/src/interface_gui.c
@@ -96,7 +96,7 @@ int device_data_type;
 
 
 
-void speed_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void speed_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
 
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
@@ -110,7 +110,7 @@ void speed_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer c
 
 
 
-void style_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void style_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
 
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
@@ -125,7 +125,7 @@ void style_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer c
 
 
 
-void data_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void data_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
 
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
@@ -140,7 +140,7 @@ void data_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer ca
 
 
 
-void rain_gauge_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void rain_gauge_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
 
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
@@ -155,7 +155,7 @@ void rain_gauge_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoin
 
 
 
-void igate_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void igate_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
 
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
@@ -265,7 +265,7 @@ Widget TNC_relay_digipeat;
 
 
  
-void Config_TNC_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void Config_TNC_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -606,7 +606,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Config_TNC_change_data" );
 
 
 
-void Config_TNC( /*@unused@*/ Widget w, int device_type, int config_type, int port) {
+void Config_TNC( /*@unused@*/ Widget UNUSED(w), int device_type, int config_type, int port) {
     static Widget  pane, form, form2, button_ok, button_cancel,
                 frame, frame2, frame3, frame4,
                 setup1, setup3, setup4,
@@ -2003,7 +2003,7 @@ Widget GPS_set_time;
 
 
 
-void Config_GPS_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void Config_GPS_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -2100,7 +2100,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Config_GPS_change_data" );
 
 
 
-void Config_GPS( /*@unused@*/ Widget w, int config_type, int port) {
+void Config_GPS( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel,
                 frame, frame2,
                 device, comment, speed_box,
@@ -2588,7 +2588,7 @@ Widget WX_tenths, WX_hundredths, WX_millimeters;
 
 
 
-void Config_WX_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void Config_WX_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -2685,7 +2685,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Config_WX_change_data" );
 
 
 
-void Config_WX( /*@unused@*/ Widget w, int config_type, int port) {
+void Config_WX( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel,
                 frame, frame2, frame3, frame4, WX_none,
                 device, comment, speed_box,
@@ -3286,7 +3286,7 @@ Widget NWX_host_reconnect_data;
 
 
 
-void Config_NWX_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void Config_NWX_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -3392,7 +3392,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Config_NWX_change_data" );
 
 
 
-void Config_NWX( /*@unused@*/ Widget w, int config_type, int port) {
+void Config_NWX( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, frame3, frame4, WX_none,
                 button_ok, button_cancel,
                 hostn, portn, comment,
@@ -3822,7 +3822,7 @@ Widget NGPS_set_time;
 
 
 
-void Config_NGPS_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void Config_NGPS_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -3928,7 +3928,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Config_NGPS_change_data" );
 
 
 
-void Config_NGPS( /*@unused@*/ Widget w, int config_type, int port) {
+void Config_NGPS( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel,
                 hostn, portn, comment,
                 sep;
@@ -4232,7 +4232,7 @@ Widget AX25_relay_digipeat;
 
 
 
-void Config_AX25_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void Config_AX25_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -4400,7 +4400,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Config_AX25_change_data" );
 
 
 
-void Config_AX25( /*@unused@*/ Widget w, int config_type, int port) {
+void Config_AX25( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel, frame,
                 devn, comment,
                 proto, proto1, proto2, proto3,
@@ -4920,7 +4920,7 @@ int    Inet_port;
 
 
 
-void Inet_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void Inet_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -5045,7 +5045,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Inet_change_data" );
 
 
 
-void Config_Inet( /*@unused@*/ Widget w, int config_type, int port) {
+void Config_Inet( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel,
                 ihost, iport, password,
                 filter, comment, sep;
@@ -5426,7 +5426,7 @@ int    Database_port;
 
 
 
-void Database_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void Database_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -5550,7 +5550,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Database_change_data" );
 
 
 
-void Config_Database( /*@unused@*/ Widget w, int config_type, int port) {
+void Config_Database( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel,
                 ihost, iport, password,
                 filter, sep, comment;
@@ -7023,7 +7023,7 @@ int    AGWPE_port;
 
 
 
-void AGWPE_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void AGWPE_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -7212,7 +7212,7 @@ end_critical_section(&devices_lock, "interface_gui.c:AGWPE_change_data" );
 
 
 
-void Config_AGWPE( /*@unused@*/ Widget w, int config_type, int port) {
+void Config_AGWPE( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel,
                 ihost, iport, password, sep,
                 igate_box, igate_o_0, igate_o_1, igate_o_2,
@@ -7909,7 +7909,7 @@ int are_shells_up(void) {
 
 
 
-void Choose_interface_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void Choose_interface_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     if (are_shells_up()==0) {
         XtPopdown(shell);
@@ -8184,7 +8184,7 @@ void update_interface_list(void) {
 
 
 
-void interface_setup(Widget w, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void interface_setup(Widget w, XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     char *what = (char *)clientData;
     int x,i,do_w;
     char *temp;
@@ -8363,7 +8363,7 @@ end_critical_section(&devices_lock, "interface_gui.c:interface_setup" );
 //      1 = Delete
 //      2 = Properties
 //
-void interface_option(Widget w, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void interface_option(Widget w, XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget pane, form, label, button_add, button_cancel;
     char *what = (char *)clientData;
     int i,x,n,do_w;
@@ -8738,7 +8738,7 @@ extern void shutdown_all_active_or_defined_port(int port);
 
 
 
-void start_stop_interface( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void start_stop_interface( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     char *which = (char *)clientData;
     int do_w;
     char temp2[50];
@@ -8808,7 +8808,7 @@ void start_stop_interface( /*@unused@*/ Widget widget, XtPointer clientData,  /*
 
 
 
-void start_stop_all_interfaces( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void start_stop_all_interfaces( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     char *which = (char *)clientData;   // Whether to start or stop the interfaces
     int do_w;
 
@@ -8840,7 +8840,7 @@ void start_stop_all_interfaces( /*@unused@*/ Widget widget, XtPointer clientData
 
 
 
-void Control_interface_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void Control_interface_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -8857,7 +8857,7 @@ end_critical_section(&control_interface_dialog_lock, "interface_gui.c:Control_in
 
 
 
-void control_interface( /*@unused@*/ Widget w,  /*@unused@*/ XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void control_interface( /*@unused@*/ Widget UNUSED(w),  /*@unused@*/ XtPointer UNUSED(clientData),  /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget rowcol, form, button_start, button_stop, button_start_all, button_stop_all, button_cancel;
     static Widget button_add, button_delete, button_properties;
     Atom delw;

--- a/src/io-mmap.c
+++ b/src/io-mmap.c
@@ -19,6 +19,7 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <string.h>
+#include "xastir.h"
 
 // Must be last include file
 #include "leak_detection.h"
@@ -115,7 +116,7 @@ void io_close(struct io_file *f) {
 
 /* Attempts to make the mapping cover [pos,pos+len), or at least [pos].
    Returns nonzero iff failed. */
-static int remap(struct io_file *f,int pos,int len) {
+static int remap(struct io_file *f,int pos,int UNUSED(len) ) {
     if (pos < (int)f->map_offset || pos >= (int)(f->map_offset + f->map_size) ) {
         const int flags = MAP_SHARED;
 

--- a/src/list_gui.c
+++ b/src/list_gui.c
@@ -430,7 +430,7 @@ void Call_Station_data(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/
  */
 void Station_List_fill(int type, int new_offset) {
     int row;
-    char temp[8];
+    char temp[11];
     char *temp_ptr;
     Dimension w,h;            // size of scrollbar in pixel
     Dimension ww,wh;          // size of entire widget in pixel
@@ -875,14 +875,14 @@ begin_critical_section(&station_list_dialog_lock, "list_gui.c:Station_List_fill"
                                     weather->wx_baro);
                             }
                             else {  // Inches Mercury
-                                float temp;
+                                float tempf;
                                 char temp2[15];
 
-                                temp = atof(weather->wx_baro)*0.02953;
+                                tempf = atof(weather->wx_baro)*0.02953;
                                 xastir_snprintf(temp2,
                                     sizeof(temp2),
                                     "%0.2f",
-                                    temp);
+                                    tempf);
                                 XmTextFieldSetString(SL_wx_baro[type][row],
                                     temp2);
                             }

--- a/src/list_gui.c
+++ b/src/list_gui.c
@@ -376,7 +376,7 @@ int stations_types(int type) {
 
 
 
-void station_list_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void station_list_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     int type;
     int i;
 
@@ -405,7 +405,7 @@ void station_list_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientDat
  * Callback for station icon in list.
  * Calls a function to center the map on the selected station from the list.
  */
-void Call_locate_station(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Call_locate_station(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     if (clientData != NULL && strlen(clientData) > 0) { 
        locate_station(w, clientData, 1,1,1); 
     } 
@@ -417,7 +417,7 @@ void Call_locate_station(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@
  * *** This callback is not linked to a control on list yet. ***
  * Invokes the station information dialog for the selected station from the list.
  */
-void Call_Station_data(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Call_Station_data(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     if (clientData != NULL && strlen(clientData) > 0) { 
        Station_data(w, clientData, NULL); 
     } 
@@ -1057,7 +1057,7 @@ void update_station_scroll_list(void) {         // called from UpdateTime() [mai
 
 
 
-void dragCallback(/*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void dragCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     int i;
 
     XmScrollBarCallbackStruct *cbs = (XmScrollBarCallbackStruct *)callData;
@@ -1073,7 +1073,7 @@ void dragCallback(/*@unused@*/ Widget w, XtPointer clientData, XtPointer callDat
 
 
 
-void decrementCallback(/*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void decrementCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     int i;
 
     XmScrollBarCallbackStruct *cbs = (XmScrollBarCallbackStruct *)callData;
@@ -1085,7 +1085,7 @@ void decrementCallback(/*@unused@*/ Widget w, XtPointer clientData, XtPointer ca
 
 
 
-void incrementCallback(/*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void incrementCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     int i;
 
     XmScrollBarCallbackStruct *cbs = (XmScrollBarCallbackStruct *)callData;
@@ -1097,7 +1097,7 @@ void incrementCallback(/*@unused@*/ Widget w, XtPointer clientData, XtPointer ca
 
 
 
-void pageDecrementCallback(/*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void pageDecrementCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     int i;
 
     XmScrollBarCallbackStruct *cbs = (XmScrollBarCallbackStruct *)callData;
@@ -1109,7 +1109,7 @@ void pageDecrementCallback(/*@unused@*/ Widget w, XtPointer clientData, XtPointe
 
 
 
-void pageIncrementCallback(/*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void pageIncrementCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     int i;
 
     XmScrollBarCallbackStruct *cbs = (XmScrollBarCallbackStruct *)callData;
@@ -1121,7 +1121,7 @@ void pageIncrementCallback(/*@unused@*/ Widget w, XtPointer clientData, XtPointe
 
 
 
-void mouseScrollHandler(Widget w, XtPointer clientData, XButtonEvent* event, Boolean* continueToDispatch) {
+void mouseScrollHandler(Widget UNUSED(w), XtPointer clientData, XButtonEvent* event, Boolean * UNUSED(continueToDispatch)) {
     int i = atoi((char*)clientData);
     int lines = 2;
     // no modifier moves 2 lines
@@ -1152,7 +1152,7 @@ void mouseScrollHandler(Widget w, XtPointer clientData, XButtonEvent* event, Boo
 
 
 
-void valueChangedCallback(/*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void valueChangedCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     int i;
 
     XmScrollBarCallbackStruct *cbs = (XmScrollBarCallbackStruct *)callData;
@@ -1167,7 +1167,7 @@ void valueChangedCallback(/*@unused@*/ Widget w, XtPointer clientData, XtPointer
 /*
  *  Setup the various list layouts
  */
-void Station_List(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Station_List(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     int i;
     Widget pane, form, win_list, form2, button_close;
     Widget numl,call,sep,sep2;

--- a/src/locate_gui.c
+++ b/src/locate_gui.c
@@ -102,7 +102,7 @@ void locate_gui_init(void)
 
 /**** LOCATE STATION ******/
 
-void Locate_station_destroy_shell(/*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Locate_station_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -126,7 +126,7 @@ end_critical_section(&locate_station_dialog_lock, "locate_gui.c:Locate_station_d
 // Determine whether it is a U.S. or Canadian callsign then search
 // through the appropriate database and present the results.
 
-void fcc_rac_lookup(Widget w, XtPointer clientData, XtPointer callData) {
+void fcc_rac_lookup(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     char station_call[200];
     char temp[1000];
     char temp2[300];
@@ -260,7 +260,7 @@ void fcc_rac_lookup(Widget w, XtPointer clientData, XtPointer callData) {
 /*
  *  Locate a station by centering the map at its position
  */
-void Locate_station_now(Widget w, XtPointer clientData, XtPointer callData) {
+void Locate_station_now(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     char temp2[200];
     char *temp_ptr;
 
@@ -296,7 +296,7 @@ void Locate_station_now(Widget w, XtPointer clientData, XtPointer callData) {
 // Here we pass in a 1 in callData if it's an emergency locate,
 // for when we've received a Mic-E emergency packet.
 //
-void Locate_station(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, XtPointer callData) {
+void Locate_station(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), XtPointer callData) {
     static Widget pane, form, button_locate, button_cancel, call,
         button_lookup, sep;
     Atom delw;
@@ -509,7 +509,7 @@ end_critical_section(&locate_station_dialog_lock, "locate_gui.c:Locate_station" 
 /*
  *  Locate Place Chooser PopUp window: Cancelled
  */
-void Locate_place_chooser_destroy_shell(Widget widget, XtPointer clientData, XtPointer callData) {
+void Locate_place_chooser_destroy_shell(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
 
 begin_critical_section(&locate_place_chooser_lock, "locate_gui.c:Locate_place_chooser_destroy_shell" );
@@ -529,8 +529,8 @@ end_critical_section(&locate_place_chooser_lock, "locate_gui.c:Locate_place_choo
  *  Locate Place Selection PopUp window: Map selected place
  */
 void Locate_place_chooser_select(Widget widget,
-        XtPointer clientData,
-        XtPointer callData) {
+        XtPointer UNUSED(clientData),
+        XtPointer UNUSED(callData) ) {
 
     int ii, xx;
     char *temp;
@@ -576,9 +576,9 @@ end_critical_section(&locate_place_chooser_lock, "locate_gui.c:Locate_place_choo
 
 
 
-void Locate_place_chooser(/*@unused@*/ Widget widget,
-        XtPointer clientData,
-        /*@unused@*/ XtPointer callData) {
+void Locate_place_chooser(/*@unused@*/ Widget UNUSED(widget),
+        XtPointer UNUSED(clientData),
+        /*@unused@*/ XtPointer UNUSED(callData) ) {
 
     Widget pane, form, button_ok, button_cancel;
     Arg al[50];
@@ -723,7 +723,7 @@ end_critical_section(&locate_place_chooser_lock, "locate_gui.c:Locate_place_choo
 
 /**** LOCATE PLACE ******/
 
-void Locate_place_destroy_shell(/*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Locate_place_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -866,7 +866,7 @@ clear_dangerous();
 
 
 
-void Locate_place(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Locate_place(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget pane, form, button_ok, button_cancel, sep,
         place, state, county, quad, place_type, gnis_file;
     Atom delw;

--- a/src/location_gui.c
+++ b/src/location_gui.c
@@ -131,10 +131,8 @@ void location_view(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@
                 if (!feof(f) && strlen(temp)>8) {
                     temp_ptr=strtok(temp,"|");  /* get the name */
                     if (temp_ptr!=NULL) {
-                        xastir_snprintf(name,
-                            sizeof(name),
-                            "%s",
-                            temp);
+                        memcpy(name, temp, sizeof(name));
+                        name[sizeof(name)-1] = '\0';  // Terminate string
                         temp_ptr=strtok(NULL,"|");  /* get the pos */
                         xastir_snprintf(pos,
                             sizeof(pos),
@@ -185,10 +183,8 @@ void jump_sort(void) {
             if (!feof(f) && strlen(temp)>8) {
                 temp_ptr=strtok(temp,"|");  /* get the name */
                 if (temp_ptr!=NULL) {
-                    xastir_snprintf(name,
-                        sizeof(name),
-                        "%s",
-                        temp);
+                    memcpy(name, temp, sizeof(name));
+                    name[sizeof(name)-1] = '\0';  // Terminate string
                     (void)sort_input_database(location_db_file_path,name,200);
                 }
             }
@@ -249,10 +245,8 @@ void location_delete(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /
                     if (!feof(f) && strlen(temp)>8) {
                         temp_ptr=strtok(temp,"|");  /* get the name */
                         if (temp_ptr!=NULL) {
-                            xastir_snprintf(name,
-                                sizeof(name),
-                                "%s",
-                                temp);
+                            memcpy(name, temp, sizeof(name));
+                            name[sizeof(name)-1] = '\0';  // Terminate string
                             temp_ptr=strtok(NULL,"|");  /* get the pos */
                             xastir_snprintf(pos,
                                 sizeof(pos),

--- a/src/location_gui.c
+++ b/src/location_gui.c
@@ -64,7 +64,7 @@ void location_gui_init(void)
 /************************************************/
 /* button fuction for last location             */
 /************************************************/
-void Last_location(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Last_location(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     map_pos_last_position();
 }
 
@@ -75,7 +75,7 @@ void Last_location(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@
 /************************************************/
 /* manage jump locations                        */
 /************************************************/
-void location_destroy_shell(/*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void location_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -95,7 +95,7 @@ end_critical_section(&location_dialog_lock, "location_gui.c:location_destroy_she
 /************************************************/
 /* jump to chosen location/zoom                 */
 /************************************************/
-void location_view(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void location_view(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     int i,x;
     char *location;
     XmString *list;
@@ -202,7 +202,7 @@ void jump_sort(void) {
 /************************************************/
 /* delete location/zoom                         */
 /************************************************/
-void location_delete(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void location_delete(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     int i,x;
     char *location;
     XmString *list;
@@ -297,7 +297,7 @@ void location_delete(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /
 /************************************************/
 /* add location/zoom                            */
 /************************************************/
-void location_add(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void location_add(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     char name[100];
     char s_long[20];
     char s_lat[20];
@@ -377,7 +377,7 @@ void location_add(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPo
 /************************************************/
 /* manage jump locations                        */
 /************************************************/
-void Jump_location(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Jump_location(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget  pane,form, button_ok, button_add, button_delete, button_cancel, locdata, location_name;
     int n;
     Arg al[50];           /* Arg List */

--- a/src/main.c
+++ b/src/main.c
@@ -14259,7 +14259,7 @@ void Window_Quit( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(c
 
 
 
-void Menu_Quit( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Menu_Quit( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     quit(0);
 }
 
@@ -14267,7 +14267,7 @@ void Menu_Quit( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unu
 
 
 
-void save_state( /*@unused@*/ Widget w, /*@unused@*/ XtPointer client, /*@unused@*/ XtPointer calldata) {
+void save_state( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(client), /*@unused@*/ XtPointer calldata) {
     if (((XtCheckpointToken)calldata)->shutdown) {
     save_data();
 
@@ -14284,7 +14284,7 @@ void save_state( /*@unused@*/ Widget w, /*@unused@*/ XtPointer client, /*@unused
 
 
 // Turn on or off map border, callback from map_border_button.
-void Map_border_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Map_border_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
     
     if(state->set)
@@ -14297,7 +14297,7 @@ void Map_border_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer c
 
 
 
-void Grid_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Grid_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14333,7 +14333,7 @@ void Grid_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callDat
 
 // Callback from menu buttons that allow user to turn on or off the 
 // global display of CAD objects and their metadata on the map.
-void  CAD_draw_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  CAD_draw_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14364,7 +14364,7 @@ void  CAD_draw_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoint
 
 
 
-void  Map_lock_pan_zoom_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Map_lock_pan_zoom_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14392,7 +14392,7 @@ void  Map_lock_pan_zoom_toggle( /*@unused@*/ Widget widget, XtPointer clientData
 
 
 
-void  Map_disable_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Map_disable_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14414,7 +14414,7 @@ void  Map_disable_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPo
 
 
 
-void  Map_auto_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Map_auto_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14450,7 +14450,7 @@ void  Map_auto_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoint
 
 
 
-void  Map_auto_skip_raster_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Map_auto_skip_raster_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14477,7 +14477,7 @@ void  Map_auto_skip_raster_toggle( /*@unused@*/ Widget widget, XtPointer clientD
 
 
 
-void  Map_levels_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Map_levels_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14507,7 +14507,7 @@ void  Map_levels_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoi
 
 
 
-void  Map_labels_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Map_labels_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14532,7 +14532,7 @@ void  Map_labels_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoi
 
 
 
-void  Map_fill_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Map_fill_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14562,7 +14562,7 @@ void  Map_fill_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoint
 
 
 
-void Map_background( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Map_background( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
     int bgcolor;
     int i;
 
@@ -14595,7 +14595,7 @@ void Map_background( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ X
 
 
 #if !defined(NO_GRAPHICS)
-void Raster_intensity(Widget w, XtPointer clientData, XtPointer calldata) {
+void Raster_intensity(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     float my_intensity;
     int i;
 
@@ -14632,7 +14632,7 @@ void Raster_intensity(Widget w, XtPointer clientData, XtPointer calldata) {
 
 
 
-void Map_station_label( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Map_station_label( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
     int style;
 
     style=atoi((char *)clientData);
@@ -14658,7 +14658,7 @@ void Map_station_label( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*
 
 
 
-void Map_icon_outline( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Map_icon_outline( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
     int style;
 
     style=atoi((char *)clientData);
@@ -14697,7 +14697,7 @@ void Map_icon_outline( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/
 
 
 
-void  Map_wx_alerts_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Map_wx_alerts_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14725,7 +14725,7 @@ void  Map_wx_alerts_toggle( /*@unused@*/ Widget widget, XtPointer clientData, Xt
 
 
 
-void  Index_maps_on_startup_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Index_maps_on_startup_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
     if(state->set)
@@ -14738,7 +14738,7 @@ void  Index_maps_on_startup_toggle( /*@unused@*/ Widget widget, XtPointer client
 
 
 
-void TNC_Transmit_now( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void TNC_Transmit_now( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     transmit_now = 1;              /* toggle transmission of station now*/
 }
 
@@ -15184,7 +15184,7 @@ void process_RINO_waypoints(void) {
 
 
  
-void GPS_operations_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void GPS_operations_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -15362,7 +15362,7 @@ void GPS_operations_cancel(Widget widget, XtPointer clientData, XtPointer callDa
 
 
 
-void  GPS_operations_color_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  GPS_operations_color_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16168,7 +16168,7 @@ static void* gps_transfer_thread(void *arg) {
 // transfer operation, to make sure we're not called again until the
 // first operation is over.
 //
-void GPS_operations( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void GPS_operations( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     pthread_t gps_operations_thread;
     int parameter;
 
@@ -16251,7 +16251,7 @@ void Set_Log_Indicator(void) {
 
 
 
-void  TNC_Logging_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  TNC_Logging_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16266,7 +16266,7 @@ void  TNC_Logging_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPo
 
 
 
-void Net_Logging_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Net_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16281,7 +16281,7 @@ void Net_Logging_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer 
 
 
 
-void IGate_Logging_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void IGate_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16296,7 +16296,7 @@ void IGate_Logging_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointe
 
 
 
-void Message_Logging_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Message_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16311,7 +16311,7 @@ void Message_Logging_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoin
 
 
 
-void WX_Logging_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void WX_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16326,7 +16326,7 @@ void WX_Logging_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer c
 
 
 
-void WX_Alert_Logging_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void WX_Alert_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16489,7 +16489,7 @@ void set_sensitive_display(int sensitive)
 
 
 
-void Select_none_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_none_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16520,7 +16520,7 @@ void Select_none_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer 
 
 
 
-void Select_mine_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_mine_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16546,7 +16546,7 @@ void Select_mine_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer 
 
 
 
-void Select_tnc_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_tnc_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16579,7 +16579,7 @@ void Select_tnc_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer c
 
 
 
-void Select_direct_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_direct_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16605,7 +16605,7 @@ void Select_direct_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointe
 
 
 
-void Select_via_digi_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_via_digi_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16631,7 +16631,7 @@ void Select_via_digi_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoin
 
 
 
-void Select_net_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_net_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16656,7 +16656,7 @@ void Select_net_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer c
 
 
 
-void Select_tactical_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_tactical_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16681,7 +16681,7 @@ void Select_tactical_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoin
 
 
 
-void Select_old_data_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_old_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16697,7 +16697,7 @@ void Select_old_data_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoin
 
 
 
-void Select_stations_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16725,7 +16725,7 @@ void Select_stations_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoin
 
 
 
-void Select_fixed_stations_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_fixed_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16741,7 +16741,7 @@ void Select_fixed_stations_toggle( /*@unused@*/ Widget w, XtPointer clientData, 
 
 
 
-void Select_moving_stations_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_moving_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16757,7 +16757,7 @@ void Select_moving_stations_toggle( /*@unused@*/ Widget w, XtPointer clientData,
 
 
 
-void Select_weather_stations_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_weather_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16777,7 +16777,7 @@ void Select_weather_stations_toggle( /*@unused@*/ Widget w, XtPointer clientData
 
 
 
-void Select_CWOP_wx_stations_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_CWOP_wx_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16793,7 +16793,7 @@ void Select_CWOP_wx_stations_toggle( /*@unused@*/ Widget w, XtPointer clientData
 
 
 
-void Select_objects_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16821,7 +16821,7 @@ void Select_objects_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoint
 
 
 
-void Select_weather_objects_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_weather_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16837,7 +16837,7 @@ void Select_weather_objects_toggle( /*@unused@*/ Widget w, XtPointer clientData,
 
 
 
-void Select_gauge_objects_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_gauge_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16850,7 +16850,7 @@ void Select_gauge_objects_toggle( /*@unused@*/ Widget w, XtPointer clientData, X
 }
 
 
-void Select_aircraft_objects_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_aircraft_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16862,7 +16862,7 @@ void Select_aircraft_objects_toggle( /*@unused@*/ Widget w, XtPointer clientData
     redraw_on_new_data = 2;     // Immediate screen update
 }
 
-void Select_vessel_objects_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_vessel_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16874,7 +16874,7 @@ void Select_vessel_objects_toggle( /*@unused@*/ Widget w, XtPointer clientData, 
     redraw_on_new_data = 2;     // Immediate screen update
 }
 
-void Select_other_objects_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Select_other_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16892,7 +16892,7 @@ void Select_other_objects_toggle( /*@unused@*/ Widget w, XtPointer clientData, X
 
 // Display Menu button callbacks
 
-void Display_callsign_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_callsign_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16912,7 +16912,7 @@ void Display_callsign_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoi
 
 
 
-void Display_label_all_trackpoints_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_label_all_trackpoints_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16928,7 +16928,7 @@ void Display_label_all_trackpoints_toggle( /*@unused@*/ Widget w, XtPointer clie
 
 
 
-void Display_symbol_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_symbol_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16948,7 +16948,7 @@ void Display_symbol_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoint
 
 
 
-void Display_symbol_rotate_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_symbol_rotate_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16964,7 +16964,7 @@ void Display_symbol_rotate_toggle( /*@unused@*/ Widget w, XtPointer clientData, 
 
 
 
-void Display_trail_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_trail_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16980,7 +16980,7 @@ void Display_trail_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointe
 
 
 
-void Display_course_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_course_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16996,7 +16996,7 @@ void Display_course_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoint
 
 
 
-void Display_speed_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_speed_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17016,7 +17016,7 @@ void Display_speed_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointe
 
 
 
-void Display_speed_short_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_speed_short_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17032,7 +17032,7 @@ void Display_speed_short_toggle( /*@unused@*/ Widget w, XtPointer clientData, Xt
 
 
 
-void Display_altitude_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_altitude_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17048,7 +17048,7 @@ void Display_altitude_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoi
 
 
 
-void Display_weather_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_weather_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17072,7 +17072,7 @@ void Display_weather_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoin
 
 
 
-void Display_weather_text_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_weather_text_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17092,7 +17092,7 @@ void Display_weather_text_toggle( /*@unused@*/ Widget w, XtPointer clientData, X
 
 
 
-void Display_temperature_only_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_temperature_only_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17108,7 +17108,7 @@ void Display_temperature_only_toggle( /*@unused@*/ Widget w, XtPointer clientDat
 
 
 
-void Display_wind_barb_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_wind_barb_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17124,7 +17124,7 @@ void Display_wind_barb_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPo
 
 
 
-void Display_aloha_circle_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_aloha_circle_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17140,7 +17140,7 @@ void Display_aloha_circle_toggle( /*@unused@*/ Widget w, XtPointer clientData, X
 
 
 
-void Display_ambiguity_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_ambiguity_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17156,7 +17156,7 @@ void Display_ambiguity_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPo
 
 
 
-void Display_phg_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_phg_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17178,7 +17178,7 @@ void Display_phg_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer 
 
 
 
-void Display_default_phg_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_default_phg_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17194,7 +17194,7 @@ void Display_default_phg_toggle( /*@unused@*/ Widget w, XtPointer clientData, Xt
 
 
 
-void Display_phg_of_moving_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_phg_of_moving_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17210,7 +17210,7 @@ void Display_phg_of_moving_toggle( /*@unused@*/ Widget w, XtPointer clientData, 
 
 
 
-void Display_df_data_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_df_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17227,7 +17227,7 @@ void Display_df_data_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoin
     redraw_on_new_data = 2;     // Immediate screen update
 }
 
-void Display_df_beamwidth_data_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_df_beamwidth_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17239,7 +17239,7 @@ void Display_df_beamwidth_data_toggle( /*@unused@*/ Widget w, XtPointer clientDa
     redraw_on_new_data = 2;     // Immediate screen update
 }
 
-void Display_df_bearing_data_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_df_bearing_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17255,7 +17255,7 @@ void Display_df_bearing_data_toggle( /*@unused@*/ Widget w, XtPointer clientData
 
 
 
-void Display_dr_data_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_dr_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17279,7 +17279,7 @@ void Display_dr_data_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoin
 
 
 
-void Display_dr_arc_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_dr_arc_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17295,7 +17295,7 @@ void Display_dr_arc_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPoint
 
 
 
-void Display_dr_course_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_dr_course_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17311,7 +17311,7 @@ void Display_dr_course_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPo
 
 
 
-void Display_dr_symbol_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_dr_symbol_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17327,7 +17327,7 @@ void Display_dr_symbol_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPo
 
 
 
-void Display_dist_bearing_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_dist_bearing_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17343,7 +17343,7 @@ void Display_dist_bearing_toggle( /*@unused@*/ Widget w, XtPointer clientData, X
 
 
 
-void Display_last_heard_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_last_heard_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17362,7 +17362,7 @@ void Display_last_heard_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtP
 /*
  *  Toggle unit system (button callbacks)
  */
-void  Units_choice_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Units_choice_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17383,7 +17383,7 @@ void  Units_choice_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtP
 /*
  *  Toggle dist/bearing status (button callbacks)
  */
-void  Dbstatus_choice_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Dbstatus_choice_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17452,7 +17452,7 @@ void update_units(void) {
 
 
 
-void  Auto_msg_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Auto_msg_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17466,7 +17466,7 @@ void  Auto_msg_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoint
 
 
 
-void  Satellite_msg_ack_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Satellite_msg_ack_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17480,7 +17480,7 @@ void  Satellite_msg_ack_toggle( /*@unused@*/ Widget widget, XtPointer clientData
 
 
 
-void  Transmit_disable_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Transmit_disable_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17502,7 +17502,7 @@ void  Transmit_disable_toggle( /*@unused@*/ Widget widget, XtPointer clientData,
 
 
 
-void  Posit_tx_disable_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Posit_tx_disable_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17516,7 +17516,7 @@ void  Posit_tx_disable_toggle( /*@unused@*/ Widget widget, XtPointer clientData,
 
 
 
-void  Object_tx_disable_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Object_tx_disable_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17530,7 +17530,7 @@ void  Object_tx_disable_toggle( /*@unused@*/ Widget widget, XtPointer clientData
 
 
 
-void  Emergency_beacon_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Emergency_beacon_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17554,7 +17554,7 @@ void  Emergency_beacon_toggle( /*@unused@*/ Widget widget, XtPointer clientData,
 
 
 
-void  Server_port_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Server_port_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17581,7 +17581,7 @@ void  Server_port_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPo
 
 
 
-void Help_About( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Help_About( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget d;
     Widget child;
     XmString xms, xa, xb;
@@ -17709,7 +17709,7 @@ Widget GetTopShell(Widget w) {
 /*********************** Display incoming data*******************************/
 /****************************************************************************/
 
-void Display_data_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Display_data_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -17720,7 +17720,7 @@ void Display_data_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientDat
 
 
 
-void  Display_packet_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Display_packet_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17739,7 +17739,7 @@ void  Display_packet_toggle( /*@unused@*/ Widget widget, XtPointer clientData, X
 // Turn on or off "Station Capabilities", callback for capabilities
 // button.
 //
-void Capabilities_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Capabilities_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
     if(state->set)
@@ -17754,7 +17754,7 @@ void Capabilities_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer
 
 // Turn on or off "Mine Only"
 //
-void Display_packet_mine_only_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Display_packet_mine_only_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
     if(state->set)
@@ -17767,7 +17767,7 @@ void Display_packet_mine_only_toggle( /*@unused@*/ Widget w, XtPointer clientDat
 
 
 
-void Display_data( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Display_data( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget pane, my_form, button_close, option_box, tnc_data,
         net_data, tnc_net_data, capabilities_button,
         mine_only_button;
@@ -18019,7 +18019,7 @@ void Display_data( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@
 /****************************** Help menu ***********************************/
 /****************************************************************************/
 
-void help_view_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void help_view_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -18030,7 +18030,7 @@ void help_view_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, 
 
 
 
-void help_index_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void help_index_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
 
     if (help_view_dialog)
@@ -18047,7 +18047,7 @@ void help_index_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData,
 
 
 
-void help_view( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void help_view( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget pane, my_form, button_close,help_text;
     int i;
     Position x, y;
@@ -18212,7 +18212,7 @@ void help_view( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unu
 
 
 
-void Help_Index( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Help_Index( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel;
     int n;
     char temp[600];
@@ -18360,7 +18360,7 @@ void Help_Index( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@un
 /************************** Clear stations *******************************/
 /*************************************************************************/
 
-void Stations_Clear( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Stations_Clear( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
 
     delete_all_stations();
 
@@ -18383,7 +18383,7 @@ void Stations_Clear( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /
 /*************************************************************************/
 
 // Destroys the Map Properties dialog
-void map_properties_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void map_properties_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -18822,7 +18822,7 @@ if (current->temp_select) {
 // Removes the highlighting for maps in the current view of the map
 // properties list.
 //
-void map_properties_deselect_maps(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_properties_deselect_maps(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x;
     XmString *list;
 
@@ -18846,8 +18846,7 @@ void map_properties_deselect_maps(Widget widget, XtPointer clientData, XtPointer
 
 // Selects all maps in the current view of the map properties list.
 //
-void map_properties_select_all_maps(Widget widget, XtPointer clientData, XtPointer
- callData) {
+void map_properties_select_all_maps(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x;
     XmString *list;
 
@@ -18928,7 +18927,7 @@ void map_index_update_filled_no(char *filename) {
 
 
 
-void map_properties_filled_auto(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_properties_filled_auto(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x;
     XmString *list;
     char *temp;
@@ -18969,7 +18968,7 @@ void map_properties_filled_auto(Widget widget, XtPointer clientData, XtPointer c
 
 
 
-void map_properties_filled_yes(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_properties_filled_yes(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x;
     XmString *list;
     char *temp;
@@ -19010,7 +19009,7 @@ void map_properties_filled_yes(Widget widget, XtPointer clientData, XtPointer ca
 
 
 
-void map_properties_filled_no(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_properties_filled_no(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x;
     XmString *list;
     char *temp;
@@ -19069,7 +19068,7 @@ void map_index_update_usgs_drg(char *filename, int drg_setting) {
 
 // common functionality of all the callbacks.  Probably don't even need 
 // all the X data here, either
-void map_properties_usgs_drg(Widget widget, XtPointer clientData, XtPointer callData, int drg_setting) {
+void map_properties_usgs_drg(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData), int drg_setting) {
     int i, x;
     XmString *list;
     char *temp;
@@ -19157,7 +19156,7 @@ void map_index_update_auto_maps_no(char *filename) {
 
 
 
-void map_properties_auto_maps_yes(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_properties_auto_maps_yes(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x;
     XmString *list;
     char *temp;
@@ -19198,7 +19197,7 @@ void map_properties_auto_maps_yes(Widget widget, XtPointer clientData, XtPointer
 
 
 
-void map_properties_auto_maps_no(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_properties_auto_maps_no(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x;
     XmString *list;
     char *temp;
@@ -19258,7 +19257,7 @@ void map_index_update_layer(char *filename, int map_layer) {
 
 
 
-void map_properties_layer_change(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_properties_layer_change(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x, new_layer;
     XmString *list;
     char *temp;
@@ -19326,7 +19325,7 @@ void map_index_update_max_zoom(char *filename, int max_zoom) {
 
 
 
-void map_properties_max_zoom_change(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_properties_max_zoom_change(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x, new_max_zoom;
     XmString *list;
     char *temp;
@@ -19394,7 +19393,7 @@ void map_index_update_min_zoom(char *filename, int min_zoom) {
 
 
 
-void map_properties_min_zoom_change(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_properties_min_zoom_change(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x, new_min_zoom;
     XmString *list;
     char *temp;
@@ -19466,7 +19465,7 @@ void map_properties_min_zoom_change(Widget widget, XtPointer clientData, XtPoint
 // in-memory list and fetch it from file again.  OK would write the
 // in-memory list to disk.
 //
-void map_properties( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void map_properties( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
 //    int i;
 //    int x;
 //    char *temp;
@@ -19906,7 +19905,7 @@ void map_properties( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused
 /*************************************************************************/
 
 // Destroys the Map Chooser dialog
-void map_chooser_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void map_chooser_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -20117,7 +20116,7 @@ void map_chooser_select_maps(Widget widget, XtPointer clientData, XtPointer call
 
 // Same as map_chooser_select_maps, but doesn't destroy the Map
 // Chooser dialog.
-void map_chooser_apply_maps(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_chooser_apply_maps(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x;
     char *temp;
     XmString *list;
@@ -20256,7 +20255,7 @@ void map_chooser_update_quantity(void) {
 
 
 
-void map_chooser_select_vector_maps(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_chooser_select_vector_maps(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x;
     char *temp;
     char *ext;
@@ -20313,7 +20312,7 @@ void map_chooser_select_vector_maps(Widget widget, XtPointer clientData, XtPoint
 
 
 
-void map_chooser_select_250k_maps(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_chooser_select_250k_maps(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x, length;
     char *temp;
     char *ext;
@@ -20353,7 +20352,7 @@ void map_chooser_select_250k_maps(Widget widget, XtPointer clientData, XtPointer
 
 
 
-void map_chooser_select_100k_maps(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_chooser_select_100k_maps(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x, length;
     char *temp;
     char *ext;
@@ -20393,7 +20392,7 @@ void map_chooser_select_100k_maps(Widget widget, XtPointer clientData, XtPointer
 
 
 
-void map_chooser_select_24k_maps(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_chooser_select_24k_maps(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x, length;
     char *temp;
     char *ext;
@@ -20447,7 +20446,7 @@ void map_chooser_select_24k_maps(Widget widget, XtPointer clientData, XtPointer 
 // currently seen selections, but not the selections in the other
 // mode.
 //
-void map_chooser_deselect_maps(Widget widget, XtPointer clientData, XtPointer callData) {
+void map_chooser_deselect_maps(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i, x;
     XmString *list;
 //    map_index_record *current = map_index_head;
@@ -20654,7 +20653,7 @@ void map_chooser_fill_in (void) {
 
 ///////////////////////////////////////  Configure DRG Dialog //////////////////////////////////////////////
 #if defined(HAVE_LIBGEOTIFF)
-void Configure_DRG_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_DRG_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
 
     if (configure_DRG_dialog) {
@@ -20765,7 +20764,7 @@ void Configure_DRG_change_data(Widget widget, XtPointer clientData, XtPointer ca
 
 
 
-void Configure_DRG_all(Widget widget, XtPointer clientData, XtPointer callData) {
+void Configure_DRG_all(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
 
     if (configure_DRG_dialog) {
         XmToggleButtonSetState(DRG_color0,TRUE,FALSE);
@@ -20788,7 +20787,7 @@ void Configure_DRG_all(Widget widget, XtPointer clientData, XtPointer callData) 
 
 
 
-void Configure_DRG_none(Widget widget, XtPointer clientData, XtPointer callData) {
+void Configure_DRG_none(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
 
     if (configure_DRG_dialog) {
         XmToggleButtonSetState(DRG_color0,FALSE,FALSE);
@@ -20811,7 +20810,7 @@ void Configure_DRG_none(Widget widget, XtPointer clientData, XtPointer callData)
 
 
 
-void Config_DRG( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Config_DRG( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget DRG_pane, DRG_form, button_ok, button_cancel,
         DRG_label1, sep1, sep2, button_all, button_none;
 
@@ -21351,7 +21350,7 @@ void Expand_Dirs_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer 
 
 
 
-void Map_chooser( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Map_chooser( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_clear, button_V,
             button_C, button_F, button_O,
             rowcol, expand_dirs_button, button_properties,
@@ -21662,7 +21661,7 @@ void Map_chooser( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@u
 
 /****** Read in file **********/
 
-void read_file_selection_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void read_file_selection_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtDestroyWidget(shell);
     read_selection_dialog = (Widget)NULL;
@@ -21704,7 +21703,7 @@ void read_file_selection_now(Widget w, XtPointer clientData, XtPointer callData)
 
 
 
-void Read_File_Selection( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Read_File_Selection( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     Arg al[50];                    /* Arg List */
     register unsigned int ac = 0;           /* Arg Count */
     Widget fs;
@@ -21801,7 +21800,7 @@ void Read_File_Selection( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientDa
 
 
 
-void Test(Widget w, XtPointer clientData, XtPointer callData) {
+void Test(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
 //    static char temp[256];
 //    int port = 7;
 
@@ -21876,7 +21875,7 @@ void Test(Widget w, XtPointer clientData, XtPointer callData) {
 
 /****** Save Config data **********/
 
-void Save_Config( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Save_Config( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     save_data();
 }
 
@@ -21887,7 +21886,7 @@ void Save_Config( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@u
 ///////////////////////////////////   Configure Defaults Dialog   //////////////////////////////////
 
 
-void Configure_defaults_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_defaults_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -22036,7 +22035,7 @@ void Configure_defaults_change_data(Widget widget, XtPointer clientData, XtPoint
 
 
 /* Station_transmit type radio buttons */
-void station_type_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void station_type_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -22052,7 +22051,7 @@ void station_type_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPo
 
 
 /* Igate type radio buttons */
-void igate_type_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void igate_type_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -22079,7 +22078,7 @@ void lpomff_menuCallback(Widget widget, XtPointer ptr, XtPointer callData) {
 
 
 
-void Configure_defaults( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_defaults( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel,
                 frame4, frame5,
                 type_box,
@@ -22791,7 +22790,7 @@ void Configure_defaults( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientDat
 ///////////////////////////////////   Configure Timing Dialog   //////////////////////////////////
 
 
-void Configure_timing_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_timing_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -22862,7 +22861,7 @@ void Configure_timing_change_data(Widget widget, XtPointer clientData, XtPointer
 
 
 
-void Configure_timing( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_timing( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel;
     Atom delw;
     XmString x_str;
@@ -23374,7 +23373,7 @@ XtSetSensitive(RINO_download_timeout, FALSE);
 
 ///////////////////////////////////   Configure Coordinates Dialog   //////////////////////////////////
 
-void coordinates_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void coordinates_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -23393,7 +23392,7 @@ void coordinates_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoi
 
 
 
-void Configure_coordinates_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_coordinates_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -23404,7 +23403,7 @@ void Configure_coordinates_destroy_shell( /*@unused@*/ Widget widget, XtPointer 
 
 
 
-void Configure_coordinates( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_coordinates( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel, frame,
                 coord_box, coord_0, coord_1, coord_2,
                 coord_3, coord_4, coord_5;
@@ -23638,7 +23637,7 @@ void Configure_coordinates( /*@unused@*/ Widget w, /*@unused@*/ XtPointer client
 
 /////////////////////////////////   Configure Audio Alarms Dialog   ////////////////////////////////
 
-void Configure_audio_alarm_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_audio_alarm_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -23775,7 +23774,7 @@ void Configure_audio_alarm_change_data(Widget widget, XtPointer clientData, XtPo
 
 
 
-void Configure_audio_alarms( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_audio_alarms( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel,
                 audio_play, file1, file2,
                 min1, max1,
@@ -24410,7 +24409,7 @@ void Configure_audio_alarms( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clien
 /////////////////////////////////////   Configure Speech Dialog   //////////////////////////////////
 
 
-void Configure_speech_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_speech_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -24421,7 +24420,7 @@ void Configure_speech_destroy_shell( /*@unused@*/ Widget widget, XtPointer clien
 
 
 
-void Test_speech(Widget widget, XtPointer clientData, XtPointer callData) {
+void Test_speech(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     SayText(SPEECH_TEST_STRING);
 }
 
@@ -24477,7 +24476,7 @@ void Configure_speech_change_data(Widget widget, XtPointer clientData, XtPointer
 //that basicly pops up a box that says where to get Festival, have
 //it be ungrayed if Festival isn't installed.
 
-void Configure_speech( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_speech( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel, file1,
         sep, button_test;
     Atom delw;
@@ -24795,7 +24794,7 @@ void Configure_speech( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData,
  *  Track_Me
  *
  */
-void Track_Me( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Track_Me( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -24826,7 +24825,7 @@ static Cursor cs_move_measure = (Cursor)NULL;
  *  Move_Object
  *
  */
-void  Move_Object( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Move_Object( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -24860,7 +24859,7 @@ void  Move_Object( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer c
  *  Measure_Distance
  *
  */
-void  Measure_Distance( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Measure_Distance( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -24918,7 +24917,7 @@ void Configure_station_destroy_shell( /*@unused@*/ Widget widget, XtPointer clie
 
 
 
-void  Configure_station_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Configure_station_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -25110,7 +25109,7 @@ void Configure_station_change_data(Widget widget, XtPointer clientData, XtPointe
 /*
  *  Update symbol picture for changed symbol or table
  */
-void updateSymbolPictureCallback( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void updateSymbolPictureCallback( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     char table, overlay;
     char symb, group;
     char *temp_ptr;
@@ -25145,7 +25144,7 @@ void updateSymbolPictureCallback( /*@unused@*/ Widget w, /*@unused@*/ XtPointer 
 
 
 /* Power radio buttons */
-void Power_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Power_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -25169,7 +25168,7 @@ void Power_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer c
 
 
 /* Height radio buttons */
-void Height_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Height_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -25189,7 +25188,7 @@ void Height_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer 
 
 
 /* Gain radio buttons */
-void Gain_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Gain_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -25209,7 +25208,7 @@ void Gain_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer ca
 
 
 /* Directivity radio buttons */
-void Directivity_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Directivity_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -25227,7 +25226,7 @@ void Directivity_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoi
 
 
 
-void Posit_compressed_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Posit_compressed_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -25276,7 +25275,7 @@ void Configure_change_symbol(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer 
 /*
  *  Setup Configure Station dialog
  */
-void Configure_station( /*@unused@*/ Widget ww, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_station( /*@unused@*/ Widget UNUSED(ww), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget  pane, cs_form, cs_form1, button_ok, button_cancel, call, frame, frame2,
                 framephg, formphg,
                 power_box,poption0,poption1,poption2,poption3,poption4,poption5,poption6,poption7,poption8,poption9,poption10,

--- a/src/main.c
+++ b/src/main.c
@@ -1873,11 +1873,12 @@ void Flush_Entire_Map_Queue(Widget w, XtPointer clientData, XtPointer callData) 
     while ((dl = readdir(dm))) {
 
         //Construct the entire path/filename
-        xastir_snprintf(fullpath,
-            sizeof(fullpath),
-            "%s/%s",
-            dir,
-            dl->d_name);
+        strcpy(fullpath, dir);
+        fullpath[sizeof(fullpath)-1] = '\0';  // Terminate string
+        strcat(fullpath, "/");
+        fullpath[sizeof(fullpath)-1] = '\0';  // Terminate string
+        strcat(fullpath, dl->d_name);
+        fullpath[sizeof(fullpath)-1] = '\0';  // Terminate string
 
         if (stat(fullpath, &nfile) == 0) {
             if ((nfile.st_mode & S_IFMT) == S_IFREG) {
@@ -3748,8 +3749,10 @@ static void TrackMouse( /*@unused@*/ Widget w, XtPointer clientData, XEvent *eve
                     value*1.852);
             }
         }
-        xastir_snprintf(temp_my_course, sizeof(temp_my_course), "%s\xB0",temp1_my_course);
-
+        strcpy(temp_my_course, temp1_my_course);
+        temp_my_course[sizeof(temp_my_course)-1] = '\0';  // Terminate string
+        strcat(temp_my_course, "\xB0");
+        temp_my_course[sizeof(temp_my_course)-1] = '\0';  // Terminate string
 
         strncat(my_text,
             " ",
@@ -4449,10 +4452,13 @@ void Load_station_font(void) {
             rotated_label_fontname[FONT_STATION]);
         fprintf(stderr,"Loading default station font instead.\n");
 
-        xastir_snprintf(tempy,
-            sizeof(tempy),
-            "Couldn't get font %s.  Loading default font instead.",
-            rotated_label_fontname[FONT_STATION]);
+        strcpy(tempy, "Couldn't get font ");
+        tempy[sizeof(tempy)-1] = '\0';  // Terminate string
+        strcat(tempy, rotated_label_fontname[FONT_STATION]);
+        tempy[sizeof(tempy)-1] = '\0';  // Terminate string
+        strcat(tempy, ".  Loading default font instead.");
+        tempy[sizeof(tempy)-1] = '\0';  // Terminate string
+
         popup_message_always(langcode("POPEM00035"), tempy);
 
         station_font = (XFontStruct *)XLoadQueryFont(XtDisplay(da), "fixed");
@@ -5387,10 +5393,13 @@ void create_appshell( /*@unused@*/ Display *display, char *app_name, /*@unused@*
             // as we have a font to work with!
             char tempy[100];
 
-            xastir_snprintf(tempy,
-                sizeof(tempy),
-                "Couldn't get font %s.  Loading default font instead.",
-                rotated_label_fontname[FONT_SYSTEM]);
+            strcpy(tempy, "Couldn't get font ");
+            tempy[sizeof(tempy)-1] = '\0';  // Terminate string
+            strcat(tempy, rotated_label_fontname[FONT_SYSTEM]);
+            tempy[sizeof(tempy)-1] = '\0';  // Terminate string
+            strcat(tempy, ".  Loading default font instead.");
+            tempy[sizeof(tempy)-1] = '\0';  // Terminate string
+
             popup_message_always(langcode("POPEM00035"), tempy);
         }
     }
@@ -14997,10 +15006,10 @@ void process_RINO_waypoints(void) {
                 // Strip off the "APRS" at the beginning of the
                 // name.  Add spaces to flush out the length of an
                 // APRS object name.
-                xastir_snprintf(temp2,
-                    sizeof(temp2),
-                    "%s         ",
-                    &name[4]);
+                strcpy(temp2, &name[4]);
+                temp2[sizeof(temp2)-1] = '\0';  // Terminate string
+                strcat(temp2, "         ");
+                temp2[sizeof(temp2)-1] = '\0';  // Terminate string
 
                 // Copy it back to the "name" variable.
                 xastir_snprintf(name,
@@ -15268,41 +15277,56 @@ void GPS_operations_change_data(Widget widget, XtPointer clientData, XtPointer c
 
     // If doing waypoints, don't add the color onto the end
     if (strcmp("Waypoints",gps_map_type) == 0) {
-        xastir_snprintf(gps_map_filename,
-            sizeof(gps_map_filename),
-            "%s_%s.shp",
-            short_filename,
-            gps_map_type);
+        strcpy(gps_map_filename, short_filename);
+        gps_map_filename[sizeof(gps_map_filename)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename, "_");
+        gps_map_filename[sizeof(gps_map_filename)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename, gps_map_type);
+        gps_map_filename[sizeof(gps_map_filename)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename, ".shp");
+        gps_map_filename[sizeof(gps_map_filename)-1] = '\0';  // Terminate string
 
         // Same without ".shp"
-        xastir_snprintf(gps_map_filename_base,
-            sizeof(gps_map_filename_base),
-            "%s_%s",
-            short_filename,
-            gps_map_type);
+        strcpy(gps_map_filename_base, short_filename);
+        gps_map_filename_base[sizeof(gps_map_filename_base)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename_base, "_");
+        gps_map_filename_base[sizeof(gps_map_filename_base)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename_base, gps_map_type);
+        gps_map_filename_base[sizeof(gps_map_filename_base)-1] = '\0';  // Terminate string
     }
     else {  // Doing Tracks/Routes
-        xastir_snprintf(gps_map_filename,
-            sizeof(gps_map_filename),
-            "%s_%s_%s.shp",
-            short_filename,
-            gps_map_type,
-            color_text);
+        strcpy(gps_map_filename, short_filename);
+        gps_map_filename[sizeof(gps_map_filename)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename, "_");
+        gps_map_filename[sizeof(gps_map_filename)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename, gps_map_type);
+        gps_map_filename[sizeof(gps_map_filename)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename, "_");
+        gps_map_filename[sizeof(gps_map_filename)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename, color_text);
+        gps_map_filename[sizeof(gps_map_filename)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename, ".shp");
+        gps_map_filename[sizeof(gps_map_filename)-1] = '\0';  // Terminate string
 
         // Same without ".shp"
-        xastir_snprintf(gps_map_filename_base,
-            sizeof(gps_map_filename_base),
-            "%s_%s_%s",
-            short_filename,
-            gps_map_type,
-            color_text);
+        strcpy(gps_map_filename_base, short_filename);
+        gps_map_filename_base[sizeof(gps_map_filename_base)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename_base, "_");
+        gps_map_filename_base[sizeof(gps_map_filename_base)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename_base, gps_map_type);
+        gps_map_filename_base[sizeof(gps_map_filename_base)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename_base, "_");
+        gps_map_filename_base[sizeof(gps_map_filename_base)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename_base, color_text);
+        gps_map_filename_base[sizeof(gps_map_filename_base)-1] = '\0';  // Terminate string
 
         // Same without ".shp" *or* color
-        xastir_snprintf(gps_map_filename_base2,
-            sizeof(gps_map_filename_base2),
-            "%s_%s",
-            short_filename,
-            gps_map_type);
+        strcpy(gps_map_filename_base2, short_filename);
+        gps_map_filename_base2[sizeof(gps_map_filename_base2)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename_base2, "_");
+        gps_map_filename_base2[sizeof(gps_map_filename_base2)-1] = '\0';  // Terminate string
+        strcat(gps_map_filename_base2, gps_map_type);
+        gps_map_filename_base2[sizeof(gps_map_filename_base2)-1] = '\0';  // Terminate string
     }
 
 //fprintf(stderr,"%s\t%s\n",gps_map_filename,gps_map_filename_base);
@@ -15706,14 +15730,24 @@ void check_for_new_gps_map(int curr_sec) {
             // do this three times, once for each piece of the Shapefile
             // map.
 #if defined(HAVE_MV)
-            xastir_snprintf(temp,
-                sizeof(temp),
-                "%s %s/%s %s/%s",
-                MV_PATH,
-                gps_base_dir,
-                gps_temp_map_filename,
-                gps_base_dir,
-                gps_map_filename);
+            strcpy(temp, MV_PATH);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, " ");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_base_dir);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, "/");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_temp_map_filename);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, " ");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_base_dir);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, "/");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_map_filename);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
 
             if ( system(temp) ) {
                 fprintf(stderr,"Couldn't rename the downloaded GPS map file\n");
@@ -15724,14 +15758,27 @@ void check_for_new_gps_map(int curr_sec) {
             }
             // Done for the ".shp" file.  Now repeat for the ".shx" and
             // ".dbf" files.
-            xastir_snprintf(temp,
-                sizeof(temp),
-                "%s %s/%s.shx %s/%s.shx",
-                MV_PATH,
-                gps_base_dir,
-                gps_temp_map_filename_base,
-                gps_base_dir,
-                gps_map_filename_base);
+
+            strcpy(temp, MV_PATH);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, " ");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_base_dir);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, "/");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_temp_map_filename_base);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, ".shx ");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_base_dir);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, "/");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_map_filename_base);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, ".shx");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
 
             if ( system(temp) ) {
                 fprintf(stderr,"Couldn't rename the downloaded GPS map file\n");
@@ -15740,14 +15787,27 @@ void check_for_new_gps_map(int curr_sec) {
                 gps_details_selected = 0;
                 return;
             }
-            xastir_snprintf(temp,
-                sizeof(temp),
-                "%s %s/%s.dbf %s/%s.dbf",
-                MV_PATH,
-                gps_base_dir,
-                gps_temp_map_filename_base,
-                gps_base_dir,
-                gps_map_filename_base);
+
+            strcpy(temp, MV_PATH);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, " ");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_base_dir);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, "/");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_temp_map_filename_base);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, ".dbf ");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_base_dir);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, "/");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_map_filename_base);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, ".dbf");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
 
             if ( system(temp) ) {
                 fprintf(stderr,"Couldn't rename the downloaded GPS map file\n");
@@ -15863,9 +15923,12 @@ static void* gps_transfer_thread(void *arg) {
 
     // Set up the postfix string.  The files will be created in the
     // "~/.xastir/gps/" directory.
-    xastir_snprintf(postfix, sizeof(postfix),
-        "Shapefile dim=2 %s/",
-        gps_base_dir);
+    strcpy(postfix, "Shapefile dim=2 ");
+    postfix[sizeof(postfix)-1] = '\0';  // Terminate string
+    strcat(postfix, gps_base_dir);
+    postfix[sizeof(postfix)-1] = '\0';  // Terminate string
+    strcat(postfix, "/");
+    postfix[sizeof(postfix)-1] = '\0';  // Terminate string
 
     input_param = atoi((char *)arg);
 
@@ -15892,14 +15955,16 @@ static void* gps_transfer_thread(void *arg) {
             xastir_snprintf(gps_map_type,
                 sizeof(gps_map_type),
                 "Track");
- 
-            xastir_snprintf(temp,
-                sizeof(temp),
-                "%s getwrite TR %s%s",
-                prefix,
-                postfix,
-                gps_temp_map_filename);
 
+            strcpy(temp, prefix);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, " getwrite TR ");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, postfix);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_temp_map_filename);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+ 
             if ( system(temp) ) {
                 fprintf(stderr,"Couldn't download the gps track\n");
                 gps_operation_pending = 0;  // We're done
@@ -15924,14 +15989,16 @@ static void* gps_transfer_thread(void *arg) {
             xastir_snprintf(gps_map_type,
                 sizeof(gps_map_type),
                 "Routes");
- 
-            xastir_snprintf(temp,
-                sizeof(temp),
-                "%s getwrite RT %s%s",
-                prefix,
-                postfix,
-                gps_temp_map_filename);
 
+            strcpy(temp, prefix);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, " getwrite RT ");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, postfix);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_temp_map_filename);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+ 
             if ( system(temp) ) {
                 fprintf(stderr,"Couldn't download the gps routes\n");
                 gps_operation_pending = 0;  // We're done
@@ -15956,13 +16023,15 @@ static void* gps_transfer_thread(void *arg) {
             xastir_snprintf(gps_map_type,
                 sizeof(gps_map_type),
                 "Waypoints");
- 
-            xastir_snprintf(temp,
-                sizeof(temp),
-                "%s getwrite WP %s%s",
-                prefix,
-                postfix,
-                gps_temp_map_filename);
+
+            strcpy(temp, prefix);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, " getwrite WP ");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, postfix);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_temp_map_filename); 
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
 
             if ( system(temp) ) {
                 fprintf(stderr,"Couldn't download the gps waypoints\n");
@@ -16019,13 +16088,21 @@ static void* gps_transfer_thread(void *arg) {
             xastir_snprintf(gps_map_type,
                 sizeof(gps_map_type),
                 "RINO");
- 
-            xastir_snprintf(temp,
-                sizeof(temp),
-                "(%s getwrite WP GPStrans %s/%s 2>&1) >/dev/null",
-                prefix,
-                gps_base_dir,
-                gps_temp_map_filename);
+
+            strcpy(temp, "(");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, prefix);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, " getwrite WP GPStrans ");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_base_dir);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, "/");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, gps_temp_map_filename);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, " 2>&1) >/dev/null");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
 
             // Execute the command
             if (system(temp) != 0) {
@@ -17514,6 +17591,7 @@ void Help_About( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@un
     char string1[200];
     char string2[200];
     extern char gitstring[];
+    char version_str[50];
    
     xastir_snprintf(string2, sizeof(string2),"\nXastir V%s %s\n",xastir_version,gitstring);
     xms = XmStringCreateLocalized(string2);
@@ -17573,7 +17651,18 @@ void Help_About( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@un
     //xa is still defined
 
     version = XRotVersion( string1, 99 );
-    xastir_snprintf(string2, sizeof(string2), "\n%s, Version %0.2f", string1, version);
+
+    xastir_snprintf(version_str, sizeof(version_str), "%0.2f", version);
+    strcpy(string2, "\n");
+    string2[sizeof(string2)-1] = '\0';  // Terminate string
+    strcat(string2, string1);
+    string2[sizeof(string2)-1] = '\0';  // Terminate string
+    strcat(string2, ", Version ");
+    string2[sizeof(string2)-1] = '\0';  // Terminate string
+    strcat(string2, version_str);
+    string2[sizeof(string2)-1] = '\0';  // Terminate string
+ 
+
     xb = XmStringCreateLocalized( string2);    // Add Xvertext version string
     xms = XmStringConcat(xa, xb);
     XmStringFree(xa);
@@ -18064,7 +18153,11 @@ void help_view( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unu
                             data_on=0;
                     } else {
                         if (data_on) {
-                            xastir_snprintf(temp3, sizeof(temp3), "%s\n", temp2);
+                            strcpy(temp3, temp2);
+                            temp3[sizeof(temp3)-1] = '\0';  // Terminate string
+                            strcat(temp3, "\n");
+                            temp3[sizeof(temp3)-1] = '\0';  // Terminate string
+
                             XmTextInsert(help_text,pos,temp3);
                             pos += strlen(temp3);
                             XmTextShowPosition(help_text,0);

--- a/src/main.c
+++ b/src/main.c
@@ -1210,7 +1210,7 @@ int moving_object = 0;
 
 
 
-void Smart_Beacon_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Smart_Beacon_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -1321,7 +1321,7 @@ void Smart_Beacon_change_data(Widget widget, XtPointer clientData, XtPointer cal
 
 
 
-void Smart_Beacon(Widget w, XtPointer clientData, XtPointer callData) {
+void Smart_Beacon(Widget w, XtPointer UNUSED(clientData), XtPointer callData) {
     static Widget  pane, form, label1, label2, label3,
         label4, label5, label6,
         button_ok, button_cancel;
@@ -1825,7 +1825,7 @@ void Smart_Beacon(Widget w, XtPointer clientData, XtPointer callData) {
 // method of getting rid of corrupted maps without having to wipe
 // out the entire cache.
 //
-void Re_Download_Maps_Now(Widget w, XtPointer clientData, XtPointer callData) {
+void Re_Download_Maps_Now(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
 
 #ifdef USE_MAP_CACHE
     // Disable reads from the map cache
@@ -1851,7 +1851,7 @@ void Re_Download_Maps_Now(Widget w, XtPointer clientData, XtPointer callData) {
 // Removes all files in the ~/.xastir/map_cache directory.  Does not
 // recurse down into subdirectories, but it shouldn't have to.
 //
-void Flush_Entire_Map_Queue(Widget w, XtPointer clientData, XtPointer callData) {
+void Flush_Entire_Map_Queue(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     struct dirent *dl = NULL;
     DIR *dm;
     char fullpath[MAX_FILENAME];
@@ -1907,7 +1907,7 @@ void Flush_Entire_Map_Queue(Widget w, XtPointer clientData, XtPointer callData) 
 // If passed a "1" in the callback, we do a full reindexing:  Delete
 // the in-memory index and start indexing from scratch.
 // 
-void Index_Maps_Now(Widget w, XtPointer clientData, XtPointer callData) {
+void Index_Maps_Now(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callData) ) {
     int parameter = 0;  // Default:  Smart timestamp-checking indexing
 
 
@@ -1968,7 +1968,7 @@ void check_nws_weather_symbol(void) {
 
 
 
-void Coordinate_calc_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Coordinate_calc_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -1980,7 +1980,7 @@ void Coordinate_calc_destroy_shell( /*@unused@*/ Widget widget, XtPointer client
 
 
 // Clears out the dialog's input textFields
-void Coordinate_calc_clear_data(Widget widget, XtPointer clientData, XtPointer callData) {
+void Coordinate_calc_clear_data(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     XmTextSetString(coordinate_calc_zone, "");
     XmTextSetString(coordinate_calc_latitude_easting, "");
     XmTextSetString(coordinate_calc_longitude_northing, "");
@@ -2172,7 +2172,7 @@ void Coordinate_calc_output(char *full_zone, long northing,
 // inputs are good it calls Coordinate_calc_output() to format and
 // save/output the results.
 //
-void Coordinate_calc_compute(Widget widget, XtPointer clientData, XtPointer callData) {
+void Coordinate_calc_compute(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     char *str_ptr;
     char zone_letter;
     int zone_number = 0;
@@ -3631,7 +3631,7 @@ void redraw_symbols(Widget w) {
 
 
 
-static void TrackMouse( /*@unused@*/ Widget w, XtPointer clientData, XEvent *event, /*@unused@*/ Boolean *flag) {
+static void TrackMouse( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XEvent *event, /*@unused@*/ Boolean * UNUSED(flag) ) {
     char my_text[70];
     char str_lat[20];
     char str_long[20];
@@ -3779,7 +3779,7 @@ static void TrackMouse( /*@unused@*/ Widget w, XtPointer clientData, XEvent *eve
 
 
 
-static void ClearTrackMouse( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XEvent *event, /*@unused@*/ Boolean *flag) {
+static void ClearTrackMouse( /*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(clientData), /*@unused@*/ XEvent * UNUSED(event), /*@unused@*/ Boolean * UNUSED(flag) ) {
 // N7TAP: In my opinion, it is handy to have the cursor position still displayed
 //        in the xastir window when I switch to another (like to write it down...)
 //    Widget textarea = (Widget) clientData;
@@ -3794,7 +3794,7 @@ static void ClearTrackMouse( /*@unused@*/ Widget w, XtPointer clientData, /*@unu
 /*
  *  Delete tracks of all stations
  */
-void Tracks_All_Clear( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Tracks_All_Clear( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     DataRow *p_station;
 
     p_station = n_first;
@@ -3836,7 +3836,7 @@ void clear_all_tactical(void) {
  *  Clear all tactical callsigns from the station records.  Comment
  *  out the active records in the log file.
  */
-void Tactical_Callsign_Clear( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Tactical_Callsign_Clear( /*@unused@*/ Widget UNUSED(w) , /*@unused@*/ XtPointer UNUSED(clientData) , /*@unused@*/ XtPointer UNUSED(callData) ) {
     char file[200];
     char file_temp[200];
     FILE *f;
@@ -3903,7 +3903,7 @@ void Tactical_Callsign_Clear( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clie
 /*
  *  Clear out tactical callsign log file
  */
-void Tactical_Callsign_History_Clear( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Tactical_Callsign_History_Clear( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     char file[MAX_VALUE];
     FILE *f;
 
@@ -3938,7 +3938,7 @@ void Tactical_Callsign_History_Clear( /*@unused@*/ Widget w, /*@unused@*/ XtPoin
 /*
  *  Display text in the status line, text is removed after timeout
  */
-void statusline(char *status_text,int update) {
+void statusline(char *status_text,int UNUSED(update) ) {
 
     XmTextFieldSetString (text, status_text);
     last_statusline = sec_now();    // Used for auto-ID timeout
@@ -4073,7 +4073,7 @@ void display_zoom_status(void) {
 
 
 
-void Change_debug_level_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Change_debug_level_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -4084,7 +4084,7 @@ void Change_debug_level_destroy_shell( /*@unused@*/ Widget widget, XtPointer cli
 
 
 
-void Change_debug_level_reset(Widget widget, XtPointer clientData, XtPointer callData) {
+void Change_debug_level_reset(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     debug_level = 0;
     XmTextSetString(debug_level_text, "0");
 //    Change_debug_level_destroy_shell(widget,clientData,callData);
@@ -4094,7 +4094,7 @@ void Change_debug_level_reset(Widget widget, XtPointer clientData, XtPointer cal
 
 
 
-void Change_debug_level_change_data(Widget widget, XtPointer clientData, XtPointer callData) {
+void Change_debug_level_change_data(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     char *temp;
     char temp_string[10];
 
@@ -4117,7 +4117,7 @@ void Change_debug_level_change_data(Widget widget, XtPointer clientData, XtPoint
 
 
 
-void Change_Debug_Level(Widget w, XtPointer clientData, XtPointer callData) {
+void Change_Debug_Level(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_close,
         button_reset;
     Atom delw;
@@ -4268,7 +4268,7 @@ void Change_Debug_Level(Widget w, XtPointer clientData, XtPointer callData) {
 
 
 #if !defined(NO_GRAPHICS) && defined(HAVE_MAGICK)
-void Gamma_adjust_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Gamma_adjust_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -4279,7 +4279,7 @@ void Gamma_adjust_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientDat
 
 
 
-void Gamma_adjust_change_data(Widget widget, XtPointer clientData, XtPointer callData) {
+void Gamma_adjust_change_data(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     char *temp;
     char temp_string[10];
 
@@ -4313,7 +4313,7 @@ void Gamma_adjust_change_data(Widget widget, XtPointer clientData, XtPointer cal
 
 
 
-void Gamma_adjust(Widget w, XtPointer clientData, XtPointer callData) {
+void Gamma_adjust(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_close;
     Atom delw;
     char temp_string[10];
@@ -4481,7 +4481,7 @@ void Load_station_font(void) {
 
 
 // chose map label font
-void Map_font_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Map_font_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
 
     xfontsel_query = 0;
@@ -4561,7 +4561,7 @@ void Query_xfontsel_pipe (void) {
 
 
  
-void Map_font_xfontsel(Widget widget, XtPointer clientData, XtPointer callData) {
+void Map_font_xfontsel(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
 
 #if defined(HAVE_XFONTSEL)
  
@@ -4590,7 +4590,7 @@ void Map_font_xfontsel(Widget widget, XtPointer clientData, XtPointer callData) 
 
 
 
-void Map_font_change_data(Widget widget, XtPointer clientData, XtPointer callData) {
+void Map_font_change_data(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     char *temp;
     Widget shell = (Widget) clientData;
     int i;
@@ -4630,7 +4630,7 @@ void Map_font_change_data(Widget widget, XtPointer clientData, XtPointer callDat
 
 
 
-void Map_font(Widget w, XtPointer clientData, XtPointer callData) {
+void Map_font(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, fontname[FONT_MAX], button_ok,
                 button_cancel,button_xfontsel[FONT_MAX];
     Atom delw;
@@ -4933,7 +4933,7 @@ char *report_gps_status(void) {
 
 
 
-void view_gps_status(Widget w, XtPointer clientData, XtPointer callData) {
+void view_gps_status(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
 
     // GPS status data too old?
     if ((gps_status_save_time + 30) >= sec_now()) {
@@ -4953,7 +4953,7 @@ void view_gps_status(Widget w, XtPointer clientData, XtPointer callData) {
 
 
 
-void Compute_Uptime(Widget w, XtPointer clientData, XtPointer callData) {
+void Compute_Uptime(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     char temp[200];
     unsigned long runtime;
     int days, hours, minutes, seconds;
@@ -5012,7 +5012,7 @@ void Compute_Uptime(Widget w, XtPointer clientData, XtPointer callData) {
 
 
 
-void Mouse_button_handler (Widget w, Widget popup, XButtonEvent *event, Boolean *dispatch) {
+void Mouse_button_handler (Widget UNUSED(w), Widget UNUSED(popup), XButtonEvent *event, Boolean * UNUSED(dispatch) ) {
 
     // Snag the current pointer position
     input_x = event->x;
@@ -5068,7 +5068,7 @@ void Mouse_button_handler (Widget w, Widget popup, XButtonEvent *event, Boolean 
 
 
 
-void menu_link_for_mouse_menu(Widget w, XtPointer clientData, XtPointer callData) {
+void menu_link_for_mouse_menu(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     if (right_menu_popup!=NULL) {
         //XmMenuPosition(right_menu_popup,(XButtonPressedEvent *)event);
         XtManageChild(right_menu_popup);
@@ -5079,7 +5079,7 @@ void menu_link_for_mouse_menu(Widget w, XtPointer clientData, XtPointer callData
 
 
 
-void store_all_kml_callback(/*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void store_all_kml_callback(/*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     export_trail_as_kml(NULL);
     last_kmlsnapshot = sec_now();
 }
@@ -5087,7 +5087,7 @@ void store_all_kml_callback(/*@unused@*/ Widget w, XtPointer clientData, XtPoint
 
 
 
-void KML_Snapshots_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void KML_Snapshots_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -5106,7 +5106,7 @@ void KML_Snapshots_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointe
 
 
 
-void Snapshots_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Snapshots_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -5153,7 +5153,7 @@ Widget pan_up_menu, pan_down_menu,
 
 
  
-void create_appshell( /*@unused@*/ Display *display, char *app_name, /*@unused@*/ int app_argc, char ** app_argv) {
+void create_appshell( /*@unused@*/ Display *display, char * UNUSED(app_name), /*@unused@*/ int UNUSED(app_argc), char ** UNUSED(app_argv) ) {
     Pixmap icon_pixmap;
     Atom WM_DELETE_WINDOW;
     Widget children[9];         /* Children to manage */
@@ -10061,7 +10061,7 @@ void create_gc(Widget w) {
 // return to X.  If it did any map drawing, we'd make it
 // interruptable.
 //
-void da_expose(Widget w, /*@unused@*/ XtPointer client_data, XtPointer call_data) {
+void da_expose(Widget w, /*@unused@*/ XtPointer UNUSED(client_data), XtPointer call_data) {
     Dimension width, height, margin_width, margin_height;
     XmDrawingAreaCallbackStruct *db = (XmDrawingAreaCallbackStruct *)call_data;
     XExposeEvent *event = (XExposeEvent *) db->event;
@@ -10191,7 +10191,7 @@ void da_resize_execute(Widget w) {
 // the interrupt_drawing_now flag periodically while doing the
 // resize drawing.
 //
-void da_resize(Widget w, /*@unused@*/ XtPointer client_data, /*@unused@*/ XtPointer call_data) {
+void da_resize(Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(client_data), /*@unused@*/ XtPointer UNUSED(call_data) ) {
 
     // Set the interrupt_drawing_now flag
     interrupt_drawing_now++;
@@ -11283,7 +11283,7 @@ static int last_alert_on_screen = -1;
 
 // This is the periodic process that updates the maps/symbols/tracks.
 // At the end of the function it schedules itself to be run again.
-void UpdateTime( XtPointer clientData, /*@unused@*/ XtIntervalId id ) {
+void UpdateTime( XtPointer clientData, /*@unused@*/ XtIntervalId UNUSED(id) ) {
     Widget w = (Widget) clientData;
     time_t nexttime;
 //  int do_time;
@@ -12686,7 +12686,7 @@ void shut_down_server(void) {
 // to call signal() from outside any signal handlers to tell it to
 // ignore further SIGHUP's.
 //
-static void restart(int sig) {
+static void restart(int UNUSED(sig) ) {
 
     char temp_file_name[MAX_VALUE];
 
@@ -12853,7 +12853,7 @@ static int pid_file_check(int hold){
 
 
 /* handle segfault signal */
-void segfault(/*@unused@*/ int sig) {
+void segfault(/*@unused@*/ int UNUSED(sig) ) {
     fprintf(stderr, "Caught Segfault! Xastir will terminate\n");
     fprintf(stderr, "Previous incoming line was: %s\n", incoming_data_copy_previous);
     fprintf(stderr, "    Last incoming line was: %s\n", incoming_data_copy);
@@ -13259,7 +13259,7 @@ void display_zoom_image(int recenter) {
 
 
 
-void Zoom_in( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Zoom_in( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13277,7 +13277,7 @@ void Zoom_in( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unuse
 
 
 
-void Zoom_in_no_pan( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Zoom_in_no_pan( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up && !map_lock_pan_zoom) {
@@ -13295,7 +13295,7 @@ void Zoom_in_no_pan( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /
 
 
 
-void Zoom_out(  /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Zoom_out(  /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13314,7 +13314,7 @@ void Zoom_out(  /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unu
 
 
 
-void Zoom_out_no_pan( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Zoom_out_no_pan( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up && !map_lock_pan_zoom) {
@@ -13333,7 +13333,7 @@ void Zoom_out_no_pan( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, 
 
 
 
-void Custom_Zoom_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Custom_Zoom_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -13350,7 +13350,7 @@ static Widget custom_zoom_zoom_level;
 
 
 
-void Custom_Zoom_do_it( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Custom_Zoom_do_it( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     char *temp_ptr;
 
     temp_ptr = XmTextFieldGetString(custom_zoom_zoom_level);
@@ -13368,7 +13368,7 @@ void Custom_Zoom_do_it( /*@unused@*/ Widget widget, XtPointer clientData, /*@unu
 // Function to bring up a dialog.  User can then select zoom for the
 // display directly.
 //
-void Custom_Zoom( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Custom_Zoom( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     static Widget  pane,form, button_ok, button_cancel, zoom_label;
 //    Arg al[50];           /* Arg List */
 //    unsigned int ac = 0;           /* Arg Count */
@@ -13615,7 +13615,7 @@ void Zoom_level( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPoi
 
 
 
-void Pan_ctr( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Pan_ctr( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13631,7 +13631,7 @@ void Pan_ctr( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unuse
 
 
 
-void Pan_up( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Pan_up( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13647,7 +13647,7 @@ void Pan_up( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused
 
 
 
-void Pan_up_less( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Pan_up_less( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up && !map_lock_pan_zoom) {
@@ -13663,7 +13663,7 @@ void Pan_up_less( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@u
 
 
 
-void Pan_down( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Pan_down( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13679,7 +13679,7 @@ void Pan_down( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unus
 
 
 
-void Pan_down_less( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Pan_down_less( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up && !map_lock_pan_zoom) {
@@ -13695,7 +13695,7 @@ void Pan_down_less( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*
 
 
 
-void Pan_left( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Pan_left( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13711,7 +13711,7 @@ void Pan_left( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unus
 
 
 
-void Pan_left_less( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Pan_left_less( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up && !map_lock_pan_zoom) {
@@ -13727,7 +13727,7 @@ void Pan_left_less( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*
 
 
 
-void Pan_right( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Pan_right( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13743,7 +13743,7 @@ void Pan_right( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unu
 
 
 
-void Pan_right_less( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Pan_right_less( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up && !map_lock_pan_zoom) {
@@ -13759,7 +13759,7 @@ void Pan_right_less( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /
 
 
 
-void Center_Zoom_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Center_Zoom_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData)) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -13778,7 +13778,7 @@ static Widget center_zoom_latitude,
 
 
 
-void Center_Zoom_do_it( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Center_Zoom_do_it( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     unsigned long x, y;
     char *temp_ptr;
 
@@ -13811,7 +13811,7 @@ void Center_Zoom_do_it( /*@unused@*/ Widget widget, XtPointer clientData, /*@unu
 
 
 
-void Go_Home( Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Go_Home( Widget w, /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     DataRow *p_station;
 
     if (!map_lock_pan_zoom) {
@@ -13832,7 +13832,7 @@ void Go_Home( Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointe
 // could input lat/long in any of the supported formats.  Right now
 // it is DD.DDDD format only.
 //
-void Center_Zoom( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Center_Zoom( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer calldata) {
     static Widget  pane,form, button_ok, button_cancel,
             lat_label, lon_label, zoom_label;
 //    Arg al[50];           /* Arg List */
@@ -14213,7 +14213,7 @@ void Center_Zoom( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@u
 
 
 
-void SetMyPosition( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void SetMyPosition( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     
     Dimension width, height;
     long my_new_latl, my_new_lonl;
@@ -14251,7 +14251,7 @@ void SetMyPosition( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*
 
 
 
-void Window_Quit( /*@unused@*/ Widget w, /*@unused@*/ XtPointer client, /*@unused@*/ XtPointer calldata) {
+void Window_Quit( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(client), /*@unused@*/ XtPointer UNUSED(calldata) ) {
     quit(0);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -2101,20 +2101,16 @@ void Coordinate_calc_output(char *full_zone, long northing,
             sizeof(temp_string),
             "  %s",
             full_zone);
-        xastir_snprintf(full_zone,
-            4,
-            "%s",
-            temp_string);
+        memcpy(full_zone, temp_string, sizeof(&full_zone));
+        full_zone[sizeof(full_zone)-1] = '\0';  // Terminate string
     }
     else if (strlen(full_zone) == 2) {
         xastir_snprintf(temp_string,
             sizeof(temp_string),
             " %s",
             full_zone);
-        xastir_snprintf(full_zone,
-            4,
-            "%s",
-            temp_string);
+        memcpy(full_zone, temp_string, sizeof(&full_zone));
+        full_zone[sizeof(full_zone)-1] = '\0';  // Terminate string
     }
         
 

--- a/src/main.c
+++ b/src/main.c
@@ -4047,7 +4047,7 @@ void display_zoom_status(void) {
     char siz_str[6];
 
     if (scale_y < 9000) {
-        xastir_snprintf(siz_str, sizeof(siz_str), "%ld", scale_y);
+        xastir_snprintf(siz_str, sizeof(siz_str), "%5.0f", (float)scale_y);
     }
     else {
         char temp_scale[20];

--- a/src/main.c
+++ b/src/main.c
@@ -2142,14 +2142,18 @@ void Coordinate_calc_output(char *full_zone, long northing,
 
     // Fill in the global dd mm.mmm values in case we wish to write
     // the result back to the calling dialog.
+
+    // Changing to double to make "%02.0f" formatting work / get rid of compiler warning
     xastir_snprintf(coordinate_calc_lat_deg, sizeof(coordinate_calc_lat_deg),
-        "%02d", lat_deg_int);
+        "%02.0f", (double)lat_deg_int);
     xastir_snprintf(coordinate_calc_lat_min, sizeof(coordinate_calc_lat_min),
         "%06.3f", lat_min);
     xastir_snprintf(coordinate_calc_lat_dir, sizeof(coordinate_calc_lat_dir),
         "%c", (south) ? 'S':'N');
+
+    // Changing to double to make "%03.0f" formatting work / get rid of compiler warning
     xastir_snprintf(coordinate_calc_lon_deg, sizeof(coordinate_calc_lon_deg),
-        "%03d", lon_deg_int);
+        "%03.0f", (double)lon_deg_int);
     xastir_snprintf(coordinate_calc_lon_min, sizeof(coordinate_calc_lon_min),
         "%06.3f", lon_min);
     xastir_snprintf(coordinate_calc_lon_dir, sizeof(coordinate_calc_lon_dir),
@@ -4046,15 +4050,22 @@ void display_zoom_status(void) {
     char zoom[30];
     char siz_str[6];
 
-    if (scale_y < 9000)
+    if (scale_y < 9000) {
         xastir_snprintf(siz_str, sizeof(siz_str), "%ld", scale_y);
-    else
-        xastir_snprintf(siz_str, sizeof(siz_str), "%ldk", scale_y/1024);
+    }
+    else {
+        char temp_scale[20];
+        xastir_snprintf(temp_scale, sizeof(temp_scale), "%ldk", scale_y/1024);
+        memcpy(siz_str, temp_scale, sizeof(siz_str));
+        siz_str[sizeof(siz_str)-1] = '\0';  // Terminate string
+    }
 
-    if (track_station_on == 1)
+    if (track_station_on == 1) {
         xastir_snprintf(zoom, sizeof(zoom), langcode("BBARZM0002"), siz_str);
-    else
-        xastir_snprintf(zoom, sizeof(zoom), langcode("BBARZM0001"), siz_str);
+    }
+    else {
+        xastir_snprintf(zoom, sizeof(zoom), langcode("BBARZM0001"), siz_str);\
+    }
 
     XmTextFieldSetString(text4,zoom);
 }
@@ -18466,7 +18477,7 @@ if (current->temp_select) {
 
             // Make sure it's a file and not a directory
             if (current->filename[strlen(current->filename)-1] != '/') {
-                char temp[MAX_FILENAME];
+                char temp[MAX_FILENAME+100];
                 char temp_layer[10];
                 char temp_max_zoom[10];
                 char temp_min_zoom[10];

--- a/src/main.c
+++ b/src/main.c
@@ -2640,9 +2640,9 @@ void Coordinate_calc_compute(Widget UNUSED(widget), XtPointer UNUSED(clientData)
             fprintf(stderr,"Zone: %s, Easting: %f, Northing: %f\n", full_zone, double_easting, double_northing);
         // Round the UTM values as we convert them to longs
         xastir_snprintf(temp_string,sizeof(temp_string),"%7.0f",double_northing);
-        northing = (long)(atof(temp_string));
+        northing = atof(temp_string);
         xastir_snprintf(temp_string,sizeof(temp_string),"%7.0f",double_easting);
-        easting  = (long)(atof(temp_string));
+        easting  = atof(temp_string);
         Coordinate_calc_output(full_zone,
             (long)northing,
             (long)easting,
@@ -10673,8 +10673,8 @@ void da_input(Widget w, XtPointer client_data, XtPointer call_data) {
 
                         // Compute the new scale, or as close to it as we can get
                         //new_scale_y = scale_y / 2;    // Zoom in by a factor of 2
-                        new_scale_y = (long)( (((float)abs(menu_y - input_y) / (float)height ) * (float)scale_y ) + 0.5);
-                        new_scale_x = (long)( (((float)abs(menu_x - input_x) / (float)width  ) * (float)scale_x ) + 0.5);
+                        new_scale_y = (long)( (((1.0 * abs(menu_y - input_y)) / (float)height ) * (float)scale_y ) + 0.5);
+                        new_scale_x = (long)( (((1.0 * abs(menu_x - input_x)) / (float)width  ) * (float)scale_x ) + 0.5);
 
                         if (new_scale_y < 1)
                             new_scale_y = 1;            // Don't go further in than zoom 1
@@ -10692,7 +10692,7 @@ void da_input(Widget w, XtPointer client_data, XtPointer call_data) {
                         // this, computed from the new midpoint.
                         //
                         //fprintf(stderr,"scale_x:%ld\tscale_y:%ld\n", get_x_scale(new_mid_x, new_mid_y, scale_y), scale_y );
-                        ratio = ((float)get_x_scale(new_mid_x,new_mid_y,scale_y) / (float)scale_y);
+                        ratio = ( (1.0 * get_x_scale(new_mid_x,new_mid_y,scale_y)) / (float)scale_y);
 
                         //fprintf(stderr,"Ratio: %f\n", ratio);
                         //fprintf(stderr,"x:%ld\ty:%ld\n", new_scale_x, new_scale_y);

--- a/src/main.c
+++ b/src/main.c
@@ -5012,7 +5012,7 @@ void Compute_Uptime(Widget w, XtPointer clientData, XtPointer callData) {
 
 
 
-void Mouse_button_handler (Widget w, Widget popup, XButtonEvent *event) {
+void Mouse_button_handler (Widget w, Widget popup, XButtonEvent *event, Boolean *dispatch) {
 
     // Snag the current pointer position
     input_x = event->x;
@@ -12624,7 +12624,7 @@ if (!skip_decode) {
 
     (void)XtAppAddTimeOut(XtWidgetToApplicationContext(w),
         nexttime,
-        (XtTimerCallbackProc)UpdateTime,
+        (XtPointer)UpdateTime,
         (XtPointer)w);
 }
 

--- a/src/map_OSM.c
+++ b/src/map_OSM.c
@@ -1526,7 +1526,8 @@ void draw_OSM_map (Widget w,
     xastir_snprintf(tmpstr, sizeof(tmpstr), "z=%d", osm_zl);
     strncat (OSMtmp, tmpstr, sizeof(OSMtmp) - 1 - strlen(OSMtmp));
 
-    xastir_snprintf(fileimg, sizeof(fileimg), "%s", OSMtmp);
+    memcpy(fileimg, OSMtmp, sizeof(fileimg));
+    fileimg[sizeof(fileimg)-1] = '\0';  // Terminate string
 
     if (debug_level & 512) {
           fprintf(stderr,"left side is %f\n", left);

--- a/src/map_OSM.c
+++ b/src/map_OSM.c
@@ -1364,7 +1364,7 @@ void draw_OSM_map (Widget w,
         int destination_pixmap,
         char *url,
         char *style,
-        int nocache) {  // For future implementation of a "refresh cached map" option
+        int UNUSED(nocache) ) {     // For future implementation of a "refresh cached map" option
     char file[MAX_FILENAME];        // Complete path/name of image file
     char short_filenm[MAX_FILENAME];
     FILE *f;                        // Filehandle of image file

--- a/src/map_WMS.c
+++ b/src/map_WMS.c
@@ -378,8 +378,9 @@ void draw_WMS_map (Widget w,
 //    strncat(WMStmp, "&BGCOLOR=0xffffff", sizeof(WMStmp) - 1 - strlen(WMStmp));
 //    strncat(WMStmp, "&BGCOLOR=0x000000", sizeof(WMStmp) - 1 - strlen(WMStmp));
 //    strncat(WMStmp, "&CRS=CRS:84", sizeof(WMStmp) - 1 - strlen(WMStmp));
-
-    xastir_snprintf(fileimg, sizeof(fileimg), "%s", WMStmp);
+  
+    memcpy(fileimg, WMStmp, sizeof(fileimg));
+    fileimg[sizeof(fileimg)-1] = '\0';  // Terminate string
 
     if (debug_level & 512) {
           fprintf(stderr,"left side is %f\n", left);

--- a/src/map_dos.c
+++ b/src/map_dos.c
@@ -517,7 +517,7 @@ void draw_dos_map(Widget w,
 
                     case 2:
 //fprintf(stderr,"points_per_degree: %s\n", Buffer);
-                        points_per_degree = (int) atof (Buffer);
+                        points_per_degree = atoi (Buffer);
                         break;
 
                     case 3:

--- a/src/map_dos.c
+++ b/src/map_dos.c
@@ -1001,7 +1001,8 @@ process:        if (strncasecmp ("Line", map_version, 4) == 0) {
                     if (trailer) {
                         if (*trailer == ',' || *trailer == ' ') {
                             if (LongHld == 0) {
-                                xastir_snprintf(map_version,sizeof(map_version),"ASCII");
+                                memcpy(map_version, "ASCII", sizeof(map_version));
+                                map_version[sizeof(map_version)-1] = '\0';  // Terminate string
                             }
     
                             map_version[4] = '\0';

--- a/src/map_dos.c
+++ b/src/map_dos.c
@@ -337,7 +337,7 @@ void map_plot (Widget w, long max_x, long max_y, long x_long_cord,
 void draw_dos_map(Widget w,
                   char *dir,
                   char *filenm,
-                  alert_entry *alert,
+                  alert_entry * UNUSED(alert),
                   u_char alert_color,
                   int destination_pixmap,
                   map_draw_flags *mdf) {  

--- a/src/map_dos.c
+++ b/src/map_dos.c
@@ -539,7 +539,8 @@ void draw_dos_map(Widget w,
 
                     case 7:
 //fprintf(stderr,"Map Version: %s\n", Buffer);
-                        xastir_snprintf(map_version,sizeof(map_version),"%s",Buffer);
+                        memcpy(map_version, Buffer, sizeof(map_version));
+                        map_version[sizeof(map_version)-1] = '\0';  // Terminate string
 //fprintf(stderr,"MAP VERSION: %s\n", map_version);
                         break;
                 } // end of switch
@@ -1187,7 +1188,8 @@ process:        if (strncasecmp ("Line", map_version, 4) == 0) {
                     if (trailer && strncmp (Buffer, "0", 1) != 0) {
                         *trailer = '\0';
                         trailer++;
-                        xastir_snprintf(label_text,sizeof(label_text),"%s",Buffer);
+                        memcpy(label_text, Buffer, sizeof(label_text));
+                        label_text[sizeof(label_text)-1] = '\0';  // Terminate string
                 
                         // Check for '#' or '$' as the first character of the label.
                         // If found, we have an embedded symbol and colored text to display.

--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -312,7 +312,7 @@ int check_trans (XColor c, transparent_color_record *c_trans_color_head) {
 // decides whether we're fetching 50k or 250k maps.
 //
 void draw_toporama_map (Widget w, 
-                        char *dir,
+                        char * UNUSED(dir),
                         char *filenm, 
                         alert_entry *alert,
                         u_char alert_color,

--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -745,7 +745,8 @@ void draw_geo_image_map (Widget w,
                     char temp[MAX_FILENAME];
 
                     // grab .geo file name
-                    xastir_snprintf(temp,sizeof(temp),"%s",file);
+                    strcpy(temp, file);
+                    temp[sizeof(temp)-1] = '\0';  // Terminate line
 
                     (void)get_map_dir(temp);           // leaves just the path and trailing /
                     if (strlen(temp) < (MAX_FILENAME - 1 - strlen(fileimg)))

--- a/src/map_gnis.c
+++ b/src/map_gnis.c
@@ -101,10 +101,10 @@
 void draw_gnis_map (Widget w,
             char *dir,
             char *filenm,
-            alert_entry *alert,
-            u_char alert_color,
+            alert_entry * UNUSED(alert),
+            u_char UNUSED(alert_color),
             int destination_pixmap,
-            map_draw_flags *mdf)
+            map_draw_flags * UNUSED(mdf) )
 {
     char file[MAX_FILENAME];        // Complete path/name of GNIS file
     char short_filenm[MAX_FILENAME];
@@ -978,7 +978,7 @@ FINISH:
 // Might also need to place a label at that position on the map in
 // case that GNIS file isn't currently selected.
 //
-int gnis_locate_place( Widget w,
+int gnis_locate_place( Widget UNUSED(w),
         char *name_in,
         char *state_in,
         char *county_in,

--- a/src/map_pop.c
+++ b/src/map_pop.c
@@ -104,10 +104,10 @@
 void draw_pop_map (Widget w,
             char *dir,
             char *filenm,
-            alert_entry *alert,
-            u_char alert_color,
+            alert_entry * UNUSED(alert),
+            u_char UNUSED(alert_color),
             int destination_pixmap,
-            map_draw_flags *mdf)
+            map_draw_flags * UNUSED(mdf) )
 {
     char file[MAX_FILENAME];        // Complete path/name of pop file
     char short_filenm[MAX_FILENAME];
@@ -978,7 +978,7 @@ FINISH:
 // Might also need to place a label at that position on the map in
 // case that pop file isn't currently selected.
 //
-int pop_locate_place( Widget w,
+int pop_locate_place( Widget UNUSED(w),
         char *name_in,
         char *state_in,
         char *county_in,

--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -3044,7 +3044,8 @@ void draw_shapefile_map (Widget w,
                                 ptr2 = (label_string *)malloc(sizeof(label_string));
                                 CHECKMALLOC(ptr2);
 
-                                xastir_snprintf(ptr2->label,sizeof(ptr2->label),"%s",temp);
+                                memcpy(ptr2->label, temp, sizeof(ptr2->label));
+                                ptr2->label[sizeof(ptr2->label)-1] = '\0';  // Terminate string
                                 ptr2->found = 1;
 
                                 // We use first character of string

--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -244,10 +244,11 @@ void create_shapefile_map(char *dir, char *shapefile_name, int type,
     }
 
     // Write out a WKT in a .prj file to go with this shapefile.
-    xastir_snprintf(temp_prj_name,
-                    sizeof(temp_prj_name),
-                    "%s.prj",
-                    temp_shapefile_name);
+    strcpy(temp_prj_name, temp_shapefile_name);
+    temp_prj_name[sizeof(temp_prj_name)-1] = '\0';  // Terminate string
+    strcat(temp_prj_name, ".prj");
+    temp_prj_name[sizeof(temp_prj_name)-1] = '\0';  // Terminate string
+
     xastirWriteWKT(temp_prj_name);
 
     // Create the different fields we'll use to store the
@@ -1704,7 +1705,14 @@ void draw_shapefile_map (Widget w,
         to_lower(xbm_filename);
 
         // Construct the complete path/filename
-        xastir_snprintf(xbm_path, sizeof(xbm_path), "%s/%s.xbm", SYMBOLS_DIR, xbm_filename);
+        strcpy(xbm_path, SYMBOLS_DIR);
+        xbm_path[sizeof(xbm_path)-1] = '\0';  // Terminate string
+        strcat(xbm_path, "/");
+        xbm_path[sizeof(xbm_path)-1] = '\0';  // Terminate string
+        strcat(xbm_path, xbm_filename);
+        xbm_path[sizeof(xbm_path)-1] = '\0';  // Terminate string
+        strcat(xbm_path, ".xbm");
+        xbm_path[sizeof(xbm_path)-1] = '\0';  // Terminate string
 
         // Try opening the file
         alert_fp = fopen(xbm_path, "rb");

--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -121,7 +121,7 @@ int RTree_hitarray_index=0;
 
 //This trivial routine is used by the RTreeSearch as a callback when it finds
 // a match.
-int RTreeSearchCallback(int id, void* arg) 
+int RTreeSearchCallback(int id, void* UNUSED(arg) ) 
 {
     if (!RTree_hitarray) {
         RTree_hitarray = (int *)malloc(1000*sizeof(int));

--- a/src/map_tif.c
+++ b/src/map_tif.c
@@ -365,8 +365,8 @@ int read_fgd_file ( char* tif_filename,
 void draw_geotiff_image_map (Widget w, 
                  char *dir, 
                  char *filenm,
-                 alert_entry *alert,
-                 u_char alert_color,
+                 alert_entry * UNUSED(alert),
+                 u_char UNUSED(alert_color),
                  int destination_pixmap,
                  map_draw_flags *mdf) {
     char file[MAX_FILENAME];    /* Complete path/name of image file */

--- a/src/maps.c
+++ b/src/maps.c
@@ -445,7 +445,7 @@ void maps_init(void)
  *  Calculate NS distance scale at a given location
  *  in meters per Xastir unit
  */
-double calc_dscale_y(long x, long y) {
+double calc_dscale_y(long UNUSED(x), long UNUSED(y) ) {
 
     // approximation by looking at +/- 0.5 minutes offset
     //    (void)(calc_distance(y-3000, x, y+3000, x)/6000.0);
@@ -3630,7 +3630,7 @@ current_rotated_label_fontname[FONT_MAX][sizeof(rotated_label_fontname)] = {"","
  **********************************************************/
 /* common code used by the two entries --- a result of retrofitting a new
    feature (centered) */
-static void draw_rotated_label_text_common (Widget w, float my_rotation, int x, int y, int label_length, int color, char *label_text, int align, int fontsize, Pixmap target_pixmap, int draw_outline, int outline_bg_color) {
+static void draw_rotated_label_text_common (Widget w, float my_rotation, int x, int y, int UNUSED(label_length), int color, char *label_text, int align, int fontsize, Pixmap target_pixmap, int draw_outline, int outline_bg_color) {
 //    XPoint *corner;
 //    int i;
     int x_outline;
@@ -3886,7 +3886,7 @@ void draw_centered_label_text (Widget w, int rotation, int x, int y, int label_l
 
 
 
-static void Print_postscript_destroy_shell(/*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+static void Print_postscript_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     char *temp_ptr;
 
@@ -3959,7 +3959,7 @@ end_critical_section(&print_postscript_dialog_lock, "maps.c:Print_postscript_des
 
 
 
-static void Print_properties_destroy_shell(/*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+static void Print_properties_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
 
     if (!shell)
@@ -3983,7 +3983,7 @@ end_critical_section(&print_properties_dialog_lock, "maps.c:Print_properties_des
 // Print_window:  Prints the drawing area to a Postscript file and
 // then sends it to the printer program (usually "lpr).
 //
-static void Print_window( Widget widget, XtPointer clientData, XtPointer callData ) {
+static void Print_window( Widget widget, XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
 
 #ifdef NO_XPM
 //    fprintf(stderr,"XPM or ImageMagick support not compiled into Xastir!\n");
@@ -4147,7 +4147,7 @@ static void Print_window( Widget widget, XtPointer clientData, XtPointer callDat
 // previewer_program has "gv" in it, then use the various options
 // selected by the user.  If not, skip those options.
 //
-static void Print_preview( Widget widget, XtPointer clientData, XtPointer callData ) {
+static void Print_preview( Widget widget, XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
 
 #ifdef NO_XPM
 //    fprintf(stderr,"XPM or ImageMagick support not compiled into Xastir!\n");
@@ -4425,7 +4425,7 @@ static void Print_preview( Widget widget, XtPointer clientData, XtPointer callDa
  *  Auto_rotate
  *
  */
-static void  Auto_rotate( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+static void  Auto_rotate( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -4447,7 +4447,7 @@ static void  Auto_rotate( /*@unused@*/ Widget widget, XtPointer clientData, XtPo
  *  Rotate_90
  *
  */
-static void  Rotate_90( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+static void  Rotate_90( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -4469,7 +4469,7 @@ static void  Rotate_90( /*@unused@*/ Widget widget, XtPointer clientData, XtPoin
  *  Auto_scale
  *
  */
-static void  Auto_scale( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+static void  Auto_scale( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -4489,7 +4489,7 @@ static void  Auto_scale( /*@unused@*/ Widget widget, XtPointer clientData, XtPoi
  *  Monochrome
  *
  */
-void  Monochrome( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Monochrome( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -4509,7 +4509,7 @@ void  Monochrome( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer ca
  *  Invert
  *
  */
-static void  Invert( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+static void  Invert( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -4533,7 +4533,7 @@ static void  Invert( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer
 // 1) Select an area on the screen to print
 // 2) -label
 //
-void Print_properties( Widget w, XtPointer clientData, XtPointer callData ) {
+void Print_properties( Widget w, XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget pane, form, button_ok, button_cancel,
             sep, auto_scale,
 //            paper_size, paper_size_data, scale, scale_data, blank_background,
@@ -4984,7 +4984,7 @@ end_critical_section(&print_properties_dialog_lock, "maps.c:Print_properties" );
 // options.  From here we should be able to set the print device
 // and the print preview program & path.
 //
-void Print_Postscript( Widget w, XtPointer clientData, XtPointer callData ) {
+void Print_Postscript( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget pane, form, button_print, button_cancel,
             sep, button_preview;
     Atom delw;
@@ -5174,7 +5174,7 @@ end_critical_section(&print_postscript_dialog_lock, "maps.c:Print_Postscript" );
 // created.  We now create a .geo file to go with the .png file.
 //
 #ifndef NO_XPM
-static void* snapshot_thread(void *arg) {
+static void* snapshot_thread(void * UNUSED(arg) ) {
     char xpm_filename[MAX_FILENAME];
     char png_filename[MAX_FILENAME];
     char geo_filename[MAX_FILENAME];
@@ -5548,7 +5548,7 @@ enum map_onscreen_enum map_onscreen(long left,
                                     long right, 
                                     long top, 
                                     long bottom,
-                                    int check_percentage) {
+                                    int UNUSED(check_percentage) ) {
 
     enum map_onscreen_enum in_window = MAP_NOT_VIS;
 
@@ -8684,7 +8684,7 @@ static void insert_map_sorted(char *filename){
  * OLD: Recurses through the map directories looking for
  * maps to load.
  **********************************************************/
-void load_auto_maps (Widget w, char *dir) {
+void load_auto_maps (Widget w, char * UNUSED(dir) ) {
     map_index_record *current = map_index_head;
     map_draw_flags mdf;
 

--- a/src/maps.c
+++ b/src/maps.c
@@ -1360,7 +1360,7 @@ void draw_complete_lat_lon_grid(Widget w) {
     // scale_x * (screen_width/10) = one tenth of the screen width in xastir coordinates
     // scale_x number of xastir coordinates per pixel
     screen_width_degrees = (float)(screen_width_xastir / (float)360000);
-    log_screen_width_degrees = (int)log10(screen_width_degrees);
+    log_screen_width_degrees = log10(screen_width_degrees);
  
 
     if (draw_labeled_grid_border==TRUE) { 
@@ -1419,7 +1419,7 @@ void draw_complete_lat_lon_grid(Widget w) {
             // For decimal minutes or minutes and seconds.
             // Find screen width and log screen width in minutes.
             screen_width_degrees = screen_width_degrees * 60.0;
-            log_screen_width_degrees = (int)log10(screen_width_degrees);
+            log_screen_width_degrees = log10(screen_width_degrees);
             // round to minutes or tenths of minutes.
             stepsx = ((float)(int)
                       ((float)(screen_width_degrees) / pow(10,log_screen_width_degrees) * 10.0)

--- a/src/maps.c
+++ b/src/maps.c
@@ -6167,10 +6167,11 @@ static void map_search (Widget w, char *dir, alert_entry * alert, int *alert_cou
                                                 || dl->d_name[strlen(dl->d_name)-1] == 'P') ) {
                                             // We have an exact match.
                                             // Save the filename in the alert
-                                            xastir_snprintf(alert->filename,
-                                                sizeof(alert->filename),
-                                                "%s",
-                                                dl->d_name);
+                                            memcpy(alert->filename,
+                                                dl->d_name,
+                                                sizeof(alert->filename));
+                                            // Terminate string
+                                            alert->filename[sizeof(alert->filename)-1] = '\0';
                                             done++;
                                             //fprintf(stderr,"%s\n",dl->d_name);
                                         }

--- a/src/maps.c
+++ b/src/maps.c
@@ -1897,10 +1897,17 @@ void draw_major_utm_mgrs_grid(Widget w) {
                 mgrs_zone,mgrs_ul_digraph,(float)int_utmEasting,(float)int_utmNorthing);
         } 
         else {
-            xastir_snprintf(grid_label,
-                sizeof(grid_label),
-                "%s %07.0f %07.0f",
-                zone_str,easting,northing);
+            char easting_str[10];
+            char northing_str[10];
+
+            xastir_snprintf(easting_str, sizeof(easting_str), " %07.0f", easting);
+            xastir_snprintf(northing_str, sizeof(northing_str), " %07.0f", northing);
+            strcpy(grid_label, zone_str);
+            grid_label[sizeof(grid_label)-1] = '\0';  // Terminate string
+            strcat(grid_label, easting_str);
+            grid_label[sizeof(grid_label)-1] = '\0';  // Terminate string
+            strcat(grid_label, northing_str); 
+            grid_label[sizeof(grid_label)-1] = '\0';  // Terminate string
         }
         // find location of lower right corner of map, convert to UTM
         xx2 = NW_corner_longitude  + ((screen_width - border_width) * scale_x);
@@ -1928,10 +1935,17 @@ void draw_major_utm_mgrs_grid(Widget w) {
            }
         } 
         else {
-            xastir_snprintf(grid_label1,
-                sizeof(grid_label1),
-                "%s %07.0f %07.0f",
-                zone_str,easting,northing);
+            char easting_str[10];
+            char northing_str[10];
+
+            xastir_snprintf(easting_str, sizeof(easting_str), " %07.0f", easting);
+            xastir_snprintf(northing_str, sizeof(northing_str), " %07.0f", northing);
+            strcpy(grid_label1, zone_str);
+            grid_label1[sizeof(grid_label1)-1] = '\0';  // Terminate string
+            strcat(grid_label1, easting_str);
+            grid_label1[sizeof(grid_label1)-1] = '\0';  // Terminate string
+            strcat(grid_label1, northing_str); 
+            grid_label1[sizeof(grid_label1)-1] = '\0';  // Terminate string
         }
         // Write metadata on upper border of map.
         //"XASTIR Map of %s (upper left) to %s (lower right).  UTM zones, %s datum. ",
@@ -2311,10 +2325,17 @@ void actually_draw_utm_minor_grid(Widget w) {
                         mgrs_zone,mgrs_ul_digraph,(float)int_utmEasting,(float)int_utmNorthing);
                 } 
                 else {
-                    xastir_snprintf(grid_label,
-                        sizeof(grid_label),
-                        "%s %07.0f %07.0f",
-                        zone_str,easting,northing);
+                    char easting_str[10];
+                    char northing_str[10];
+
+                    xastir_snprintf(easting_str, sizeof(easting_str), " %07.0f", easting);
+                    xastir_snprintf(northing_str, sizeof(northing_str), " %07.0f", northing);
+                    strcpy(grid_label, zone_str);
+                    grid_label[sizeof(grid_label)-1] = '\0';  // Terminate string
+                    strcat(grid_label, easting_str);
+                    grid_label[sizeof(grid_label)-1] = '\0';  // Terminate string
+                    strcat(grid_label, northing_str); 
+                    grid_label[sizeof(grid_label)-1] = '\0';  // Terminate string
                 }
                 // find location of lower right corner of map, convert to UTM
                 xx2 = NW_corner_longitude  + ((screen_width - border_width) * scale_x);
@@ -2342,10 +2363,17 @@ void actually_draw_utm_minor_grid(Widget w) {
                    }
                 } 
                 else {
-                    xastir_snprintf(grid_label1,
-                        sizeof(grid_label1),
-                        "%s %07.0f %07.0f",
-                        zone_str,easting,northing);
+                    char easting_str[10];
+                    char northing_str[10];
+
+                    xastir_snprintf(easting_str, sizeof(easting_str), " %07.0f", easting);
+                    xastir_snprintf(northing_str, sizeof(northing_str), " %07.0f", northing);
+                    strcpy(grid_label1, zone_str);
+                    grid_label1[sizeof(grid_label1)-1] = '\0';  // Terminate string
+                    strcat(grid_label1, easting_str);
+                    grid_label1[sizeof(grid_label1)-1] = '\0';  // Terminate string
+                    strcat(grid_label1, northing_str);
+                    grid_label1[sizeof(grid_label1)-1] = '\0';  // Terminate string
                 }
                 //"XASTIR Map of %s (upper left) to %s (lower right).  UTM %d m grid, %s datum. ",
                 xastir_snprintf(top_label,

--- a/src/maps.c
+++ b/src/maps.c
@@ -1370,10 +1370,14 @@ void draw_complete_lat_lon_grid(Widget w) {
         // find location of upper left corner of map, convert to Lat/Long
         convert_lon_l2s(xx, grid_label1, sizeof(grid_label1), coordinate_format);
         convert_lat_l2s(yy, grid_label2, sizeof(grid_label2), coordinate_format);
-        xastir_snprintf(grid_label,
-            sizeof(grid_label),
-            "%s %s",
-            grid_label1,grid_label2);
+
+        strcpy(grid_label, grid_label1);
+        grid_label[sizeof(grid_label)-1] = '\0';  // Terminate string
+        strcat(grid_label, " ");
+        grid_label[sizeof(grid_label)-1] = '\0';  // Terminate string
+        strcat(grid_label, grid_label2);
+        grid_label[sizeof(grid_label)-1] = '\0';  // Terminate string
+
         // find location of lower right corner of map, convert to Lat/Long
         convert_lon_l2s(xx2, grid_label1, sizeof(grid_label1), coordinate_format);
         convert_lat_l2s(yy2, grid_label2, sizeof(grid_label2), coordinate_format);
@@ -4027,12 +4031,16 @@ static void Print_window( Widget widget, XtPointer clientData, XtPointer callDat
 
 
 #ifdef HAVE_CONVERT
-        xastir_snprintf(command,
-            sizeof(command),
-            "%s -filter Point %s %s",
-            CONVERT_PATH,
-            xpm_filename,
-            ps_filename );
+        strcpy(command, CONVERT_PATH);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, " -filter Point ");
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, xpm_filename);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, " ");
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, ps_filename);
+        command[sizeof(command)-1] = '\0';  // Terminate string
 
         if ( debug_level & 512 )
             fprintf(stderr,"%s\n", command );
@@ -4061,11 +4069,12 @@ static void Print_window( Widget widget, XtPointer clientData, XtPointer callDat
 // Since we could be running SUID root, we don't want to be
 // calling "system" anyway.  Several problems with it.
 
-        xastir_snprintf(command,
-            sizeof(command),
-            "%s %s",
-            printer_program,
-            ps_filename );
+        strcpy(command, printer_program);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, " ");
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, ps_filename);
+        command[sizeof(command)-1] = '\0';  // Terminate string
 
         if ( debug_level & 512 )
             fprintf(stderr,"%s\n", command);
@@ -4285,17 +4294,29 @@ static void Print_preview( Widget widget, XtPointer clientData, XtPointer callDa
         }
 
 #ifdef HAVE_CONVERT
-        xastir_snprintf(command,
-            sizeof(command),
-            "%s -filter Point %s%s%s%s%s %s %s",
-            CONVERT_PATH,
-            mono,
-            invert,
-            rotate,
-            scale,
-            density,
-            xpm_filename,
-            ps_filename );
+        strcpy(command, CONVERT_PATH);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, " -filter Point ");
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, mono);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, invert);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, rotate);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, scale);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, density);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, " ");
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, xpm_filename);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, " ");
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, ps_filename);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+
         if ( debug_level & 512 )
             fprintf(stderr,"%s\n", command );
 
@@ -4320,12 +4341,18 @@ static void Print_preview( Widget widget, XtPointer clientData, XtPointer callDa
 // calling "system" anyway.  Several problems with it.
 
         // Bring up the postscript viewer
-        xastir_snprintf(command,
-            sizeof(command),
-            "%s %s %s &",
-            previewer_program,
-            format,
-            ps_filename );
+        strcpy(command, previewer_program);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, " ");
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, format);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, " ");
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, ps_filename);
+        command[sizeof(command)-1] = '\0';  // Terminate string
+        strcat(command, " &");
+        command[sizeof(command)-1] = '\0';  // Terminate string
 
         if ( debug_level & 512 )
             fprintf(stderr,"%s\n", command);
@@ -5292,12 +5319,16 @@ static void* snapshot_thread(void *arg) {
 #ifdef HAVE_CONVERT
     // Convert it to a png file.  This depends upon having the
     // ImageMagick command "convert" installed.
-    xastir_snprintf(command,
-        sizeof(command),
-        "%s -quality 100 -colors 256 %s %s",
-        CONVERT_PATH,
-        xpm_filename,
-        png_filename );
+    strcpy(command, CONVERT_PATH);
+    command[sizeof(command)-1] = '\0';  // Terminate string
+    strcat(command, " -quality 100 -colors 256 ");
+    command[sizeof(command)-1] = '\0';  // Terminate string
+    strcat(command, xpm_filename);
+    command[sizeof(command)-1] = '\0';  // Terminate string
+    strcat(command, " ");
+    command[sizeof(command)-1] = '\0';  // Terminate string
+    strcat(command, png_filename);
+    command[sizeof(command)-1] = '\0';  // Terminate string
 
     if ( system( command ) != 0 ) {
         // We _may_ have had an error.  Check errno to make

--- a/src/messages.c
+++ b/src/messages.c
@@ -741,10 +741,9 @@ void output_message(char *from, char *to, char *message, char *path) {
                     sizeof(message_pool[i].from_call_sign),
                     "%s",
                     from);
-                xastir_snprintf(message_pool[i].message_line,
-                    sizeof(message_pool[i].message_line),
-                    "%s",
-                    message_out);
+                memcpy(message_pool[i].message_line, message_out, sizeof(message_pool[i].message_line));
+                // Terminate line
+                message_pool[i].message_line[sizeof(message_pool[i].message_line)-1] = '\0';
 
                 if (path != NULL)
                     xastir_snprintf(message_pool[i].path,
@@ -1105,10 +1104,8 @@ void check_delayed_transmit_queue(int curr_sec) {
 //    "Changing queued ack's to new path: %s\n",
 //    new_path);
 
-                xastir_snprintf(ptr->path,
-                    sizeof(ptr->path),
-                    "%s",
-                    new_path);
+                memcpy(ptr->path, new_path, sizeof(ptr->path));
+                ptr->path[sizeof(ptr->path)-1] = '\0';  // Terminate string
             }
 
 

--- a/src/messages_gui.c
+++ b/src/messages_gui.c
@@ -2520,10 +2520,8 @@ void Auto_msg_set_now(Widget w, XtPointer clientData, XtPointer callData) {
     XtFree(temp_ptr);
 
     (void)remove_trailing_spaces(temp);
-    xastir_snprintf(auto_reply_message,
-        sizeof(auto_reply_message),
-        "%s",
-        temp);
+    memcpy(auto_reply_message, temp, sizeof(auto_reply_message));
+    auto_reply_message[sizeof(auto_reply_message)-1] = '\0';  // Terminate string
     Auto_msg_destroy_shell(w, clientData, callData);
 }
 

--- a/src/messages_gui.c
+++ b/src/messages_gui.c
@@ -292,7 +292,7 @@ static Widget current_path = NULL;
 
 
 
-void Send_message_change_path_destroy_shell(Widget widget, XtPointer clientData, XtPointer callData) {
+void Send_message_change_path_destroy_shell(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
 
     if (change_path_dialog) {
         XtPopdown(change_path_dialog);
@@ -310,7 +310,7 @@ void Send_message_change_path_destroy_shell(Widget widget, XtPointer clientData,
 // Fetch the text from the "current_path" widget and place it into
 // the mw[ii].send_message_path widget.
 //
-void Send_message_change_path_apply(Widget widget, XtPointer clientData, XtPointer callData) {
+void Send_message_change_path_apply(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     char path[MAX_PATH+1];
     char *temp_ptr;
 
@@ -348,7 +348,7 @@ void Send_message_change_path_apply(Widget widget, XtPointer clientData, XtPoint
 // way to the transmit routines, then change it to an empty path
 // when the transmit actually goes out.
 //
-void Send_message_change_path_direct(Widget widget, XtPointer clientData, XtPointer callData) {
+void Send_message_change_path_direct(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
 
     if (current_path == NULL || clientData == NULL) {
         Send_message_change_path_destroy_shell(NULL, NULL, NULL);
@@ -370,7 +370,7 @@ void Send_message_change_path_direct(Widget widget, XtPointer clientData, XtPoin
 // "DEFAULT PATH" all the way to the transmit routines, then change
 // it there to be a blank.
 //
-void Send_message_change_path_default(Widget widget, XtPointer clientData, XtPointer callData) {
+void Send_message_change_path_default(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
 
     if (current_path == NULL || clientData == NULL) {
         Send_message_change_path_destroy_shell(NULL, NULL, NULL);
@@ -411,7 +411,7 @@ void Send_message_change_path_default(Widget widget, XtPointer clientData, XtPoi
 // three bugs on the active bug-list:  #1499820, #1326975, and
 // #1326973.
 //
-void Send_message_change_path( Widget widget, XtPointer clientData, XtPointer callData) {
+void Send_message_change_path( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     int ii;
     //Atom delw;
     Widget pane, form, current_path_label, reverse_path_label,
@@ -839,7 +839,7 @@ void get_send_message_path(char *callsign, char *path, int path_size) {
 
 
 
-void Send_message_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Send_message_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData)) {
     int ii;
 //    char *temp_ptr;
 //    char temp1[MAX_LINE_SIZE+1];
@@ -904,7 +904,7 @@ end_critical_section(&send_message_dialog_lock, "messages_gui.c:Send_message_des
 
 
 
-void Check_new_call_messages( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Check_new_call_messages( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     int pos;
     intptr_t i;
 
@@ -943,7 +943,7 @@ end_critical_section(&send_message_dialog_lock, "messages_gui.c:Check_new_call_m
 
 
 
-void Clear_messages( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Clear_messages( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     clear_outgoing_messages();
 }
 
@@ -951,7 +951,7 @@ void Clear_messages( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /
 
 
 
-void Send_message_now( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Send_message_now( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     char temp1[MAX_CALLSIGN+1];
     char temp2[121];
     char temp_line1[68] = "";
@@ -1182,7 +1182,7 @@ end_critical_section(&send_message_dialog_lock, "messages_gui.c:Send_message_now
 
 
 
-void Clear_message_from( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Clear_message_from( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     char temp1[MAX_CALLSIGN+1];
     int i;
     char *temp_ptr;
@@ -1219,7 +1219,7 @@ end_critical_section(&send_message_dialog_lock, "messages_gui.c:Clear_message_fr
 
 
 
-void Clear_message_to( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Clear_message_to( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     char temp1[MAX_CALLSIGN+1];
     int i;
     char *temp_ptr;
@@ -1295,7 +1295,7 @@ end_critical_section(&send_message_dialog_lock, "messages_gui.c:Clear_message_to
 
 
 
-void Kick_timer( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Kick_timer( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     char *temp_ptr;
     char temp1[MAX_CALLSIGN+1];
 
@@ -1318,7 +1318,7 @@ void Kick_timer( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPoi
 
 
 
-void Clear_messages_to( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Clear_messages_to( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     char *temp_ptr;
     char temp1[MAX_CALLSIGN+1];
 
@@ -1342,7 +1342,7 @@ void Clear_messages_to( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*
 
 
 
-void Send_message_call( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Send_message_call( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     char call[20];
 
     if(clientData != NULL) {
@@ -1743,7 +1743,7 @@ void rebuild_send_message_input_boxes(int ii, int hamhud, int d700, int d7) {
 
 
 
-void HamHUD_Msg( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void HamHUD_Msg( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     intptr_t ii =(intptr_t)clientData;
     int hamhud;
 
@@ -1760,7 +1760,7 @@ void HamHUD_Msg( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer cal
 
 
 
-void D700_Msg( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void D700_Msg( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     intptr_t ii = (intptr_t)clientData;
     int d700;
 
@@ -1777,7 +1777,7 @@ void D700_Msg( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callD
 
 
 
-void D7_Msg( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void D7_Msg( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     intptr_t ii = (intptr_t)clientData;
     int d7;
 
@@ -1945,7 +1945,7 @@ void select_station_type(int ii) {
 //   on first read capability."
 //
 //
-void Send_message( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Send_message( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Arg args[50];
     char temp[60];
     unsigned int n;
@@ -2454,7 +2454,7 @@ end_critical_section(&send_message_dialog_lock, "messages_gui.c:Send_message" );
 // Bring up a Send Message dialog for each QSO that has pending
 // outbound messages.
 //
-void Show_pending_messages( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Show_pending_messages( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     intptr_t ii;
     int msgs_found = 0;
 
@@ -2488,7 +2488,7 @@ void Show_pending_messages( /*@unused@*/ Widget w, /*@unused@*/ XtPointer client
 
 /************************* Auto msg **************************************/
 /*************************************************************************/
-void Auto_msg_option( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Auto_msg_option( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
     int item_no = XTPOINTER_TO_INT(clientData);
 
     if (item_no)
@@ -2501,7 +2501,7 @@ void Auto_msg_option( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, 
 
 
 
-void Auto_msg_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) { 
+void Auto_msg_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) { 
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -2537,7 +2537,7 @@ void Auto_msg_set_now(Widget w, XtPointer clientData, XtPointer callData) {
 
 
 
-void Auto_msg_set( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Auto_msg_set( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel, reply;
     Atom delw;
 

--- a/src/messages_gui.c
+++ b/src/messages_gui.c
@@ -953,7 +953,7 @@ void Clear_messages( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /
 
 void Send_message_now( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
     char temp1[MAX_CALLSIGN+1];
-    char temp2[68];
+    char temp2[121];
     char temp_line1[68] = "";
 
 #ifndef NO_DYNAMIC_WIDGETS
@@ -1134,13 +1134,21 @@ begin_critical_section(&send_message_dialog_lock, "messages_gui.c:Send_message_n
             if (log_message_data) {
                 char temp_msg[MAX_MESSAGE_LENGTH+1];
 
-                xastir_snprintf(temp_msg,
-                    sizeof(temp_msg),
-                    "%s>%s,%s:%s",
-                    mw[ii].to_call_sign,    // To
-                    temp1,                  // From
-                    path,                   // Path
-                    temp2);                 // Message
+                strcpy(temp_msg, mw[ii].to_call_sign);// To
+                temp_msg[sizeof(temp_msg)-1] = '\0';  // Terminate string
+                strcat(temp_msg, ">");
+                temp_msg[sizeof(temp_msg)-1] = '\0';  // Terminate string
+                strcat(temp_msg, temp1);              // From
+                temp_msg[sizeof(temp_msg)-1] = '\0';  // Terminate string
+                strcat(temp_msg, ",");
+                temp_msg[sizeof(temp_msg)-1] = '\0';  // Terminate string
+                strcat(temp_msg, path);               // Path
+                temp_msg[sizeof(temp_msg)-1] = '\0';  // Terminate string
+                strcat(temp_msg, ":");
+                temp_msg[sizeof(temp_msg)-1] = '\0';  // Terminate string
+                strcat(temp_msg, temp2);              // Message
+                temp_msg[sizeof(temp_msg)-1] = '\0';  // Terminate string
+
                 log_data( get_user_base_dir(LOGFILE_MESSAGE, temp_file_path, 
                                             sizeof(temp_file_path)), 
                           temp_msg );

--- a/src/objects.c
+++ b/src/objects.c
@@ -4407,8 +4407,8 @@ int Setup_object_data(char *line, int line_length, DataRow *p_station) {
        if (Area_bright) {  // Bright color
             xastir_snprintf(complete_area_color, sizeof(complete_area_color), "%2s", Area_color);
         } else {              // Dim color
-            xastir_snprintf(complete_area_color, sizeof(complete_area_color), "%02d",
-                    atoi(&Area_color[1]) + 8);
+            xastir_snprintf(complete_area_color, sizeof(complete_area_color), "%02.0f",
+                    (float)(atoi(&Area_color[1]) + 8) );
 
             if ( (Area_color[1] == '0') || (Area_color[1] == '1') ) {
                 complete_area_color[0] = '/';
@@ -5202,8 +5202,8 @@ int Setup_item_data(char *line, int line_length, DataRow *p_station) {
             xastir_snprintf(complete_area_color, sizeof(complete_area_color), "%2s",
                     Area_color);
         } else {              // Dim color
-            xastir_snprintf(complete_area_color, sizeof(complete_area_color), "%02d",
-                    atoi(&Area_color[1]) + 8);
+            xastir_snprintf(complete_area_color, sizeof(complete_area_color), "%02.0f",
+                    (float)(atoi(&Area_color[1]) + 8) );
             if ((Area_color[1] == '0') || (Area_color[1] == '1')) {
                 complete_area_color[0] = '/';
             }

--- a/src/objects.c
+++ b/src/objects.c
@@ -4444,7 +4444,7 @@ int Setup_object_data(char *line, int line_length, DataRow *p_station) {
         xastir_snprintf(line, line_length, "%s", temp_ptr);
         XtFree(temp_ptr);
 
-        lat_offset = (int)sqrt(atof(line));
+        lat_offset = sqrt(atof(line));
         if (lat_offset > 99)
             lat_offset = 99;
         //fprintf(stderr,"Line: %s\tlat_offset: %d\n", line, lat_offset);
@@ -4453,7 +4453,7 @@ int Setup_object_data(char *line, int line_length, DataRow *p_station) {
         xastir_snprintf(line, line_length, "%s", temp_ptr);
         XtFree(temp_ptr);
 
-        lon_offset = (int)sqrt(atof(line));
+        lon_offset = sqrt(atof(line));
         if (lon_offset > 99)
             lon_offset = 99;
         //fprintf(stderr,"Line: %s\tlon_offset: %d\n", line, lon_offset);
@@ -5238,7 +5238,7 @@ int Setup_item_data(char *line, int line_length, DataRow *p_station) {
         xastir_snprintf(line, line_length, "%s", temp_ptr);
         XtFree(temp_ptr);
 
-        lat_offset = (int)sqrt(atof(line));
+        lat_offset = sqrt(atof(line));
         if (lat_offset > 99)
             lat_offset = 99;
         //fprintf(stderr,"Line: %s\tlat_offset: %d\n", line, lat_offset);
@@ -5246,7 +5246,7 @@ int Setup_item_data(char *line, int line_length, DataRow *p_station) {
         xastir_snprintf(line, line_length, "%s", temp_ptr);
         XtFree(temp_ptr);
 
-        lon_offset = (int)sqrt(atof(line));
+        lon_offset = sqrt(atof(line));
         if (lon_offset > 99)
             lon_offset = 99;
         //fprintf(stderr,"Line: %s\tlon_offset: %d\n", line, lon_offset);

--- a/src/objects.c
+++ b/src/objects.c
@@ -313,10 +313,16 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
             p_station->call_sign);
 
         if (strlen(tempstr) == 1) { // Add two spaces (to make 3 minimum chars)
-            xastir_snprintf(p_station->call_sign, sizeof(p_station->call_sign), "%s  ",tempstr);
+            strcpy(p_station->call_sign, tempstr);
+            p_station->call_sign[sizeof(p_station->call_sign)-1] = '\0';  // Terminate string
+            strcat(p_station->call_sign, "  ");
+            p_station->call_sign[sizeof(p_station->call_sign)-1] = '\0';  // Terminate string
         }
         else if (strlen(tempstr) == 2) { // Add one space (to make 3 minimum chars)
-            xastir_snprintf(p_station->call_sign, sizeof(p_station->call_sign), "%s ",tempstr);
+            strcpy(p_station->call_sign, tempstr);
+            p_station->call_sign[sizeof(p_station->call_sign)-1] = '\0';  // Terminate string
+            strcat(p_station->call_sign, " ");
+            p_station->call_sign[sizeof(p_station->call_sign)-1] = '\0';  // Terminate string
         }
 
         if (!valid_item(p_station->call_sign)) {
@@ -372,35 +378,50 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
 
         if (p_station->probability_max[0] == '\0') {
             // Only have probability_min
-            xastir_snprintf(comment2,
-                sizeof(comment2),"Pmin%s,%s",
-                p_station->probability_min,
-                comment);
+            strcpy(comment2, "Pmin");
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
+            strcat(comment2, p_station->probability_min);
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
+            strcat(comment2, ",");
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
+            strcat(comment2, comment);
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
         }
         else if (p_station->probability_min[0] == '\0') {
             // Only have probability_max
-            xastir_snprintf(comment2,
-                sizeof(comment2),"Pmax%s,%s",
-                p_station->probability_max,
-                comment);
+            strcpy(comment2, "Pmax");
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
+            strcat(comment2, p_station->probability_max);
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
+            strcat(comment2, ",");
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
+            strcat(comment2, comment);
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
         }
         else {  // Have both
-            xastir_snprintf(comment2,
-                sizeof(comment2),"Pmin%s,Pmax%s,%s",
-                p_station->probability_min,
-                p_station->probability_max,
-                comment);
+            strcpy(comment2, "Pmin");
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
+            strcat(comment2, p_station->probability_min);
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
+            strcat(comment2, ",Pmax");
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
+            strcat(comment2, p_station->probability_max);
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
+            strcat(comment2, ",");
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
+            strcat(comment2, comment);
+            comment2[sizeof(comment2)-1] = '\0';  // Terminate string
         }
         xastir_snprintf(comment,sizeof(comment), "%s", comment2);
     }
 
 
     // Put RNG or PHG at the beginning of the comment
-    xastir_snprintf(comment2,
-        sizeof(comment2),
-        "%s%s",
-        p_station->power_gain,
-        comment);
+    strcpy(comment2, p_station->power_gain);
+    comment2[sizeof(comment2)-1] = '\0';  // Terminate string
+    strcat(comment2, comment);
+    comment2[sizeof(comment2)-1] = '\0';  // Terminate string
+
     xastir_snprintf(comment,
         sizeof(comment),
         "%s",
@@ -6756,7 +6777,7 @@ void Populate_predefined_objects(predefinedObject *predefinedObjects) {
     char *variable;
     FILE *fp_file;
     int j = 0;
-    char error_correct_location[256];
+    char error_correct_location[300];
     char predef_obj_path[MAX_VALUE];
 #ifdef OBJECT_DEF_FILE_USER_BASE
     char temp_file_path[MAX_VALUE];
@@ -6783,7 +6804,7 @@ void Populate_predefined_objects(predefinedObject *predefinedObjects) {
         if (filethere(get_data_base_dir(predefined_object_definition_file))) {
             fp_file = fopen(get_data_base_dir(predefined_object_definition_file),"r");
 #endif  // OBJECT_DEF_FILE_USER_BASE
-    
+
             xastir_snprintf(error_correct_location,
                 sizeof(error_correct_location),
                 "Loading from %s/%s \n",
@@ -7119,6 +7140,7 @@ void Create_SAR_Object(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData,
     // a unique name or a killed object name we can use.
     //
     while (!done && iterations_left) {
+        char num_string[10];
  
         // Create object as owned by own station, or take control of
         // object if it has another owner.  Taking control of a
@@ -7226,11 +7248,11 @@ fprintf(stderr, "Object with same name exists, owned by %s\n", p_station->origin
         //
         // Note: Converting to float only to use width specifiers
         // properly and quiet a compiler warning.
-        xastir_snprintf(call,
-            sizeof(call),
-            "%s%2.0f",
-            orig_call,
-            (float)extra_num);
+        xastir_snprintf(num_string, sizeof(num_string), "%2.0f", (float)extra_num);
+        strcpy(call, orig_call);
+        call[sizeof(call)-1] = '\0';  // Terminate string
+        strcat(call, num_string);
+        call[sizeof(call)-1] = '\0';  // Terminate string
 // ****** Bug ********
 // need to check length of call - if it has gone over 9 characters only 
 // the first 9 will be treated as unique, thus FirstAid11 will become FirstAid1 
@@ -10961,7 +10983,7 @@ void reload_object_item(void) {
     char file[MAX_VALUE];
     FILE *f;
     char line[300+1];
-    char line2[300+1];
+    char line2[350];
     int save_state;
 
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -219,7 +219,7 @@ int valid_item(char *name) {
 /*
  *  Clear out object/item history log file
  */
-void Object_History_Clear( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Object_History_Clear( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     char *file;
     FILE *f;
     char temp_file_path[MAX_VALUE];
@@ -245,7 +245,7 @@ void Object_History_Clear( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientD
 /*
  *  Re-read object/item history log file
  */
-void Object_History_Refresh( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Object_History_Refresh( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
 
     // Reload saved objects and items from previous runs.
     reload_object_item();
@@ -2839,8 +2839,8 @@ void free_cs_CAD(void)
 
 // This is the callback for the Draw togglebutton
 //
-void Draw_CAD_Objects_mode( /*@unused@*/ Widget widget,
-        XtPointer clientData,
+void Draw_CAD_Objects_mode( /*@unused@*/ Widget UNUSED(widget),
+        XtPointer UNUSED(clientData),
         XtPointer callData) {
 
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
@@ -3110,9 +3110,9 @@ void Restore_CAD_Objects_from_file(void) {
 
 // popdown and destroy the cad_erase_dialog.
 //
-void Draw_CAD_Objects_erase_dialog_close ( /*@unused@*/ Widget w,
-        /*@unused@*/ XtPointer clientData,
-        /*@unused@*/ XtPointer callData) {
+void Draw_CAD_Objects_erase_dialog_close ( /*@unused@*/ Widget UNUSED(w),
+        /*@unused@*/ XtPointer UNUSED(clientData),
+        /*@unused@*/ XtPointer UNUSED(callData) ) {
 
     if (cad_erase_dialog!=NULL) {
         // close cad_erase_dialog
@@ -3217,9 +3217,9 @@ void Draw_CAD_Objects_erase_selected ( /*@unused@*/ Widget w,
 // users to delete all CAD objects or select individual CAD objects
 // to delete.
 //
-void Draw_CAD_Objects_erase_dialog( /*@unused@*/ Widget w,
-        /*@unused@*/ XtPointer clientData,
-        /*@unused@*/ XtPointer callData) {
+void Draw_CAD_Objects_erase_dialog( /*@unused@*/ Widget UNUSED(w),
+        /*@unused@*/ XtPointer UNUSED(clientData),
+        /*@unused@*/ XtPointer UNUSED(callData) ) {
 
     Widget cad_erase_pane, cad_erase_form, cad_erase_label,
            button_delete_all, button_delete_selected, button_cancel;
@@ -3394,9 +3394,9 @@ void Draw_CAD_Objects_erase_dialog( /*@unused@*/ Widget w,
 
 // popdown and destroy the cad_list_dialog
 //
-void Draw_CAD_Objects_list_dialog_close ( /*@unused@*/ Widget w,
-        /*@unused@*/ XtPointer clientData,
-        /*@unused@*/ XtPointer callData) {
+void Draw_CAD_Objects_list_dialog_close ( /*@unused@*/ Widget UNUSED(w),
+        /*@unused@*/ XtPointer UNUSED(clientData),
+        /*@unused@*/ XtPointer UNUSED(callData) ) {
 
     if (cad_list_dialog!=NULL) {
         // close cad_list_dialog
@@ -3414,9 +3414,9 @@ void Draw_CAD_Objects_list_dialog_close ( /*@unused@*/ Widget w,
 // Show details for selected CAD object.  Callback for the show/edit
 // details button on the Draw_CAD_Objects_list dialog.
 //
-void Show_selected_CAD_object_details ( /*@unused@*/ Widget w,
-        /*@unused@*/ XtPointer clientData,
-        /*@unused@*/ XtPointer callData) {
+void Show_selected_CAD_object_details ( /*@unused@*/ Widget UNUSED(w),
+        /*@unused@*/ XtPointer UNUSED(clientData),
+        /*@unused@*/ XtPointer UNUSED(callData) ) {
 
     static int sizeof_area_description = 200;
     int itemCount;       // number of items in list of CAD objects.
@@ -3488,9 +3488,9 @@ void Show_selected_CAD_object_details ( /*@unused@*/ Widget w,
 // Callback for edit CAD objects menu option.  Dialog to allow users
 // to select individual CAD objects in order to edit their metadata.
 //
-void Draw_CAD_Objects_list_dialog( /*@unused@*/ Widget w,
-        /*@unused@*/ XtPointer clientData,
-        /*@unused@*/ XtPointer callData) {
+void Draw_CAD_Objects_list_dialog( /*@unused@*/ Widget UNUSED(w),
+        /*@unused@*/ XtPointer UNUSED(clientData),
+        /*@unused@*/ XtPointer UNUSED(callData) ) {
 
     Widget cad_list_pane, cad_list_form, cad_list_label,
            button_list_selected, button_close;
@@ -3760,9 +3760,9 @@ void Format_area_for_output(double *area_km2, char *area_description, int sizeof
 // the computed_area field in the Object, and to a dialog that pops
 // up on the screen.
 //
-void Draw_CAD_Objects_close_polygon( /*@unused@*/ Widget widget,
-        XtPointer clientData,
-        /*@unused@*/ XtPointer callData) {
+void Draw_CAD_Objects_close_polygon( /*@unused@*/ Widget UNUSED(widget),
+        XtPointer UNUSED(clientData),
+        /*@unused@*/ XtPointer UNUSED(callData) ) {
     static int sizeof_area_description = 200;
     VerticeRow *tmp;
     double area;
@@ -5679,7 +5679,7 @@ int Setup_item_data(char *line, int line_length, DataRow *p_station) {
 /*
  *  Set an Object
  */
-void Object_change_data_set(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Object_change_data_set(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     char line[43+1+40];                 // ???
     DataRow *p_station = global_parameter1;
 
@@ -5737,7 +5737,7 @@ void Object_change_data_set(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer c
 /*
  *  Set an Item
  */
-void Item_change_data_set(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Item_change_data_set(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     char line[43+1+40];                 // ???
     DataRow *p_station = global_parameter1;
 
@@ -5875,7 +5875,7 @@ void Item_confirm_data_set(Widget widget, XtPointer clientData, XtPointer callDa
 /*
  *  Delete an Object
  */
-void Object_change_data_del(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Object_change_data_del(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     char line[43+1+40];                 // ???
     DataRow *p_station = global_parameter1;
 
@@ -5912,7 +5912,7 @@ void Object_change_data_del(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer c
 /*
  *  Delete an Item
  */
-void Item_change_data_del(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Item_change_data_del(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     char line[43+1+40];                 // ???
     int i, done;
     DataRow *p_station = global_parameter1;
@@ -5971,7 +5971,7 @@ void Ob_change_symbol(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientD
 /*
  *  Update symbol picture for changed symbol or table
  */
-void updateObjectPictureCallback(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void updateObjectPictureCallback(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     char table, overlay;
     char symb, group;
     char *temp_ptr;
@@ -6018,7 +6018,7 @@ void updateObjectPictureCallback(/*@unused@*/ Widget w, /*@unused@*/ XtPointer c
 
 
 // Handler for "Signpost" toggle button
-void Signpost_object_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Signpost_object_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
     char temp_data[40];
     char comment[43+1];     // max 43 characters of comment
@@ -6111,7 +6111,7 @@ void Signpost_object_toggle( /*@unused@*/ Widget widget, XtPointer clientData, X
 
 
 // Handler for "Probability Circles" toggle button
-void Probability_circle_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Probability_circle_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
     char temp_data[40];
     char comment[43+1];     // max 43 characters of comment
@@ -6204,7 +6204,7 @@ void Probability_circle_toggle( /*@unused@*/ Widget widget, XtPointer clientData
 
 
 // Handler for "Enable Area Type" toggle button
-void  Area_object_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Area_object_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
     char temp_data[40];
     char comment[43+1];     // max 43 characters of comment
@@ -6308,7 +6308,7 @@ void  Area_object_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPo
 
 
 // Handler for "DF Bearing Object" toggle button
-void  DF_bearing_object_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  DF_bearing_object_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
     char temp_data[40];
     char comment[43+1];     // max 43 characters of comment
@@ -6410,7 +6410,7 @@ void  DF_bearing_object_toggle( /*@unused@*/ Widget widget, XtPointer clientData
 
 
 // Handler for "Map View Object" toggle button
-void  Map_View_object_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Map_View_object_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
     char temp_data[40];
     char comment[43+1];     // max 43 characters of comment
@@ -6516,7 +6516,7 @@ void  Map_View_object_toggle( /*@unused@*/ Widget widget, XtPointer clientData, 
 
 
 /* Area object type radio buttons */
-void Area_type_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Area_type_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6549,7 +6549,7 @@ void Area_type_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoint
 
 
 /* Area object color radio buttons */
-void Area_color_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Area_color_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6571,7 +6571,7 @@ void Area_color_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoin
 
 
 /* Area bright color enable button */
-void Area_bright_dim_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Area_bright_dim_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6590,7 +6590,7 @@ void Area_bright_dim_toggle( /*@unused@*/ Widget widget, XtPointer clientData, X
 
 
 /* Area filled enable button */
-void Area_open_filled_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Area_open_filled_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6609,7 +6609,7 @@ void Area_open_filled_toggle( /*@unused@*/ Widget widget, XtPointer clientData, 
 
 
 // Handler for "Omni Antenna" toggle button
-void  Omni_antenna_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Omni_antenna_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
  
     if(state->set) {
@@ -6632,7 +6632,7 @@ void  Omni_antenna_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtP
 
 
 // Handler for "Beam Antenna" toggle button
-void  Beam_antenna_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Beam_antenna_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
  
     if(state->set) {
@@ -6655,7 +6655,7 @@ void  Beam_antenna_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtP
 
 
 /* Object signal radio buttons */
-void Ob_signal_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Ob_signal_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6675,7 +6675,7 @@ void Ob_signal_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoint
 
 
 /* Object height radio buttons */
-void Ob_height_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Ob_height_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6695,7 +6695,7 @@ void Ob_height_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPoint
 
 
 /* Object gain radio buttons */
-void Ob_gain_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Ob_gain_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6715,7 +6715,7 @@ void Ob_gain_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer
 
 
 /* Object directivity radio buttons */
-void Ob_directivity_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Ob_directivity_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6735,7 +6735,7 @@ void Ob_directivity_toggle( /*@unused@*/ Widget widget, XtPointer clientData, Xt
 
 
 /* Object beamwidth radio buttons */
-void Ob_width_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void Ob_width_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -7059,7 +7059,7 @@ void Populate_predefined_objects(predefinedObject *predefinedObjects) {
    clientData is pointer to an integer representing the index of a 
    predefined object in the predefinedObjects array
    */
-void Create_SAR_Object(/*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, XtPointer calldata) {
+void Create_SAR_Object(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer clientData, XtPointer UNUSED(calldata) ) {
     Dimension width, height;
     char call[MAX_CALLSIGN+1];
     long x_lat,x_lon;

--- a/src/objects.c
+++ b/src/objects.c
@@ -503,7 +503,10 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
             // Must convert from meters to feet before transmitting
             temp2 = (int)( (atof(p_station->altitude) / 0.3048) + 0.5);
             if ( (temp2 >= 0) && (temp2 <= 99999l) ) {
-                xastir_snprintf(altitude, sizeof(altitude), "/A=%06ld",temp2);
+                char temp_alt[20];
+                xastir_snprintf(temp_alt, sizeof(temp_alt), "/A=%06ld",temp2);
+                memcpy(altitude, temp_alt, sizeof(altitude) - 1);
+                altitude[sizeof(altitude)-1] = '\0';  // Terminate string
             }
         }
     }
@@ -530,8 +533,11 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
         complete_corridor[0] = '\0';
         if ( (complete_area_type == 1) || (complete_area_type == 6)) {
             if (p_station->aprs_symbol.area_object.corridor_width > 0) {
-                xastir_snprintf(complete_corridor, sizeof(complete_corridor), "{%d}",
+                char temp_corridor[10];
+                xastir_snprintf(temp_corridor, sizeof(temp_corridor), "{%d}",
                         p_station->aprs_symbol.area_object.corridor_width);
+                memcpy(complete_corridor, temp_corridor, sizeof(complete_corridor) - 1);
+                complete_corridor[sizeof(complete_corridor)-1] = '\0';  // Terminate string
             }
         }
 
@@ -669,7 +675,10 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
     else if ( (p_station->aprs_symbol.aprs_type == '\\') // We have a signpost object
             && (p_station->aprs_symbol.aprs_symbol == 'm' ) ) {
         if (strlen(p_station->signpost) > 0) {
-            xastir_snprintf(signpost, sizeof(signpost), "{%s}", p_station->signpost);
+            char temp_sign[10];
+            xastir_snprintf(temp_sign, sizeof(temp_sign), "{%s}", p_station->signpost);
+            memcpy(signpost, temp_sign, sizeof(signpost));
+            signpost[sizeof(signpost)-1] = '\0';  // Terminate string
         }
         else {  // No signpost data entered, blank it out
             signpost[0] = '\0';
@@ -4377,7 +4386,10 @@ int Setup_object_data(char *line, int line_length, DataRow *p_station) {
         if (isdigit((int)line[0])) {
             temp2 = atoi(line);
             if ( (temp2 >= 0) && (temp2 <= 999999) ) {
-                xastir_snprintf(altitude, sizeof(altitude), "/A=%06ld", temp2);
+                char temp_alt[20];
+                xastir_snprintf(temp_alt, sizeof(temp_alt), "/A=%06ld", temp2);
+                memcpy(altitude, temp_alt, sizeof(altitude));
+                altitude[sizeof(altitude)-1] = '\0';  // Terminate string
                 //fprintf(stderr,"Altitude string: %s\n",altitude);
             }
         }
@@ -5171,7 +5183,10 @@ int Setup_item_data(char *line, int line_length, DataRow *p_station) {
         if (isdigit((int)line[0])) {
             temp2 = atoi(line);
             if ((temp2 >= 0) && (temp2 <= 999999)) {
-                xastir_snprintf(altitude, sizeof(altitude), "/A=%06ld",temp2);
+                char temp_alt[20];
+                xastir_snprintf(temp_alt, sizeof(temp_alt), "/A=%06ld",temp2);
+                memcpy(altitude, temp_alt, sizeof(altitude));
+                altitude[sizeof(altitude)-1] = '\0';  // Terminate string
             }
         }
     }
@@ -7206,11 +7221,13 @@ fprintf(stderr, "Object with same name exists, owned by %s\n", p_station->origin
         // Append extra_num to the object name (starts at "2"), try
         // again to see if it is unique.
         //
+        // Note: Converting to float only to use width specifiers
+        // properly and quiet a compiler warning.
         xastir_snprintf(call,
             sizeof(call),
-            "%s%d",
+            "%s%2.0f",
             orig_call,
-            extra_num);
+            (float)extra_num);
 // ****** Bug ********
 // need to check length of call - if it has gone over 9 characters only 
 // the first 9 will be treated as unique, thus FirstAid11 will become FirstAid1 

--- a/src/objects.c
+++ b/src/objects.c
@@ -311,10 +311,13 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
             sizeof(tempstr),
             "%s",
             p_station->call_sign);
-        if (strlen(tempstr) == 1)  // Add two spaces (to make 3 minimum chars)
+
+        if (strlen(tempstr) == 1) { // Add two spaces (to make 3 minimum chars)
             xastir_snprintf(p_station->call_sign, sizeof(p_station->call_sign), "%s  ",tempstr);
-        else if (strlen(tempstr) == 2) // Add one space (to make 3 minimum chars)
+        }
+        else if (strlen(tempstr) == 2) { // Add one space (to make 3 minimum chars)
             xastir_snprintf(p_station->call_sign, sizeof(p_station->call_sign), "%s ",tempstr);
+        }
 
         if (!valid_item(p_station->call_sign)) {
             line[0] = '\0';

--- a/src/popup_gui.c
+++ b/src/popup_gui.c
@@ -214,7 +214,7 @@ XmNminHeight, 80,
                                       XmNfontList, fontlist1,
                                       NULL);
 
-            xastir_snprintf(pw[i].name,10,"%d",i);
+            xastir_snprintf(pw[i].name,10,"%9d",i%1000);
 
             msg_str=XmStringCreateLtoR(message,XmFONTLIST_DEFAULT_TAG);
             XtVaSetValues(pw[i].popup_message_data,XmNlabelString,msg_str,NULL);

--- a/src/popup_gui.c
+++ b/src/popup_gui.c
@@ -85,9 +85,9 @@ end_critical_section(&popup_message_dialog_lock, "popup_gui.c:clear_popup_messag
 
 
 
-static void popup_message_destroy_shell(/*@unused@*/ Widget w,
+static void popup_message_destroy_shell(/*@unused@*/ Widget UNUSED(w),
                                 XtPointer clientData,
-                                /*@unused@*/ XtPointer callData) {
+                                /*@unused@*/ XtPointer UNUSED(callData) ) {
     int i;
 
     i=atoi((char *)clientData);
@@ -296,7 +296,7 @@ static XFontStruct *id_font=NULL;
 // Routine which pops up a large message for a few seconds in the
 // middle of the screen, then removes it.
 //
-void popup_ID_message(char *banner, char *message) {
+void popup_ID_message(char * UNUSED(banner), char *message) {
     float my_rotation = 0.0;
     int x = (int)(screen_width/10);
     int y = (int)(screen_height/2);

--- a/src/rac_data.c
+++ b/src/rac_data.c
@@ -233,9 +233,11 @@ int search_rac_data(char *callsign, rac_record *data) {
                 amacall_path );
             return (0);
         }
-        xastir_snprintf(char_offset, sizeof(char_offset), "%s", &index[6]);
+        memcpy(char_offset, &index[6], sizeof(char_offset));
+        char_offset[sizeof(char_offset)-1] = '\0';  // Terminate string
         while (!feof(fndx) && strncmp(callsign, index, 6) > 0) {
-            xastir_snprintf(char_offset, sizeof(char_offset), "%s", &index[6]);
+            memcpy(char_offset, &index[6], sizeof(char_offset));
+            char_offset[sizeof(char_offset)-1] = '\0';  // Terminate string
             if (fgets(index, (int)sizeof(index), fndx) == NULL) {
                 // Error occurred
                 fprintf(stderr,

--- a/src/rotated.c
+++ b/src/rotated.c
@@ -46,6 +46,8 @@
 #include "rotated.h"
 #include "snprintf.h"
 
+#include "xastir.h"
+
 // Must be last include file
 #include "leak_detection.h"
 
@@ -1482,7 +1484,7 @@ static XImage *XRotMagnifyImage( Display *dpy, XImage *ximage) {
 // This function allocates some memory, frees all but xp_out which
 // is returned.
 //
-XPoint *XRotTextExtents( Display *dpy, XFontStruct *font, float angle, int x, int y, char *text, int align) {
+XPoint *XRotTextExtents( Display * UNUSED(dpy), XFontStruct *font, float angle, int x, int y, char *text, int align) {
     int i;
     char *str1, *str2, *str3;
     char *str2_a="\0", *str2_b="\n\0";

--- a/src/track_gui.c
+++ b/src/track_gui.c
@@ -109,7 +109,7 @@ void track_gui_init(void)
 /**** Track STATION ******/
 
 
-void track_station_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void track_station_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -197,7 +197,7 @@ void Track_station_now(Widget w, XtPointer clientData, XtPointer callData) {
 
 
 
-void Track_station( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Track_station( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget pane, my_form, button_ok, button_close, button_clear, call, sep;
     Atom delw;
 
@@ -626,7 +626,7 @@ static void* findu_transfer_thread(void *arg) {
 
 
 
-void Download_trail_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Download_trail_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -765,7 +765,7 @@ void Download_trail_now(Widget w, XtPointer clientData, XtPointer callData) {
 
 
 
-void Reset_posit_length_max(Widget w, XtPointer clientData, XtPointer callData) {
+void Reset_posit_length_max(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
 
     XmScaleGetValue(posit_length_value, &posit_length);
     XmScaleGetValue(posit_start_value, &posit_start);
@@ -795,7 +795,7 @@ void Reset_posit_length_max(Widget w, XtPointer clientData, XtPointer callData) 
 
 
 
-void Download_findu_trail( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Download_findu_trail( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget pane, my_form, button_ok, button_cancel, call, sep;
     Atom delw;
     XmString x_str;

--- a/src/track_gui.c
+++ b/src/track_gui.c
@@ -679,11 +679,11 @@ void Download_trail_now(Widget w, XtPointer clientData, XtPointer callData) {
  
 //    busy_cursor(appshell);
 
-    xastir_snprintf(log_filename,
-        sizeof(log_filename),
-        "%s/map.log",
-        tmp_base_dir);
-
+    strcpy(log_filename, tmp_base_dir);
+    log_filename[sizeof(log_filename)-1] = '\0';  // Terminate string
+    strcat(log_filename, "/map.log");
+    log_filename[sizeof(log_filename)-1] = '\0';  // Terminate string
+ 
     // Erase any previously existing local file by the same name.
     // This avoids the problem of having an old tracklog here and
     // the code trying to display it when the download fails.

--- a/src/util.c
+++ b/src/util.c
@@ -1097,7 +1097,7 @@ void phg_decode(const char *langstr, const char *phg, char *phg_decoded, int phg
 /*********************************************************************/
 void shg_decode(const char *langstr, const char *shg, char *shg_decoded, int shg_decoded_length) {
     double power, height, gain, range;
-    char directivity[6], temp[80], signal[64];
+    char directivity[6], temp[100], signal[64];
     int  gain_db;
     char s;
 
@@ -1271,7 +1271,7 @@ void shg_decode(const char *langstr, const char *shg, char *shg_decoded, int shg
             directivity[0] = '\0';  break;
     }
 
-    if (english_units)
+    if (english_units) {
         xastir_snprintf(temp,
             sizeof(temp),
             "%.0fft %s, %ddB%s, %s: %.1fmi, %s",
@@ -1282,7 +1282,8 @@ void shg_decode(const char *langstr, const char *shg, char *shg_decoded, int shg
             langcode("WPUPSTI075"), // "DF Range"
             range,
             signal);
-    else
+    }
+    else {
         xastir_snprintf(temp,
             sizeof(temp),
             "%.1fm %s, %ddB%s, %s: %.1fkm, %s",
@@ -1293,6 +1294,7 @@ void shg_decode(const char *langstr, const char *shg, char *shg_decoded, int shg
             langcode("WPUPSTI075"), // "DF Range"
             range*1.609344,
             signal);
+    }
 
     xastir_snprintf(shg_decoded,
         shg_decoded_length,

--- a/src/util.c
+++ b/src/util.c
@@ -1347,7 +1347,7 @@ void bearing_decode(const char *langstr, const char *bearing_str,
 
 //fprintf(stderr,"N != 0\n");
 
-        range = (int)( pow(2.0,R - '0') );
+        range = pow(2.0,R - '0');
 
         switch (Q) {
             case('1'):

--- a/src/util.c
+++ b/src/util.c
@@ -4666,7 +4666,8 @@ char *sec_to_loc(long longitude, long latitude)
  *  Substring function WITH a terminating NULL char, needs a string of at least size+1
  */
 void substr(char *dest, char *src, int size) {
-    xastir_snprintf(dest, size+1, "%s", src);
+    memcpy(dest, src, size+1);
+    dest[size] = '\0';  // Terminate string
 }
 
 

--- a/src/util.c
+++ b/src/util.c
@@ -1930,7 +1930,7 @@ char *compress_posit(const char *input_lat, const char group, const char *input_
  * 0N/0E is excluded from trails, could be excluded from map (#define ACCEPT_0N_0E)
  */
 
-int position_defined(long lat, long lon, int strict) {
+int position_defined(long lat, long lon, int UNUSED(strict)) {
 
     if (lat == 0l && lon == 0l)
         return(0);              // undefined location
@@ -2038,12 +2038,12 @@ void convert_xastir_to_UTM_str(char *str, int str_len, long x, long y) {
                     allign more cleanly with UTM strings.
    space_string_len length of the space_string char[]
 */
-void convert_xastir_to_MGRS_str_components(char *utmZone, int utmZone_len, 
+void convert_xastir_to_MGRS_str_components(char *utmZone, int UNUSED(utmZone_len), 
        char *EastingL, int EastingL_len, 
        char *NorthingL, int NorthingL_len, 
        unsigned int *int_utmEasting, unsigned int *int_utmNorthing, 
        long x,  long y, 
-       int nice_format, char *space_string, int space_string_len) {
+       int nice_format, char *space_string, int UNUSED(space_string_len) ) {
 
     double utmNorthing;
     double utmEasting;

--- a/src/view_message_gui.c
+++ b/src/view_message_gui.c
@@ -101,7 +101,7 @@ void view_message_print_record(Message *m_fill) {
 
 
     // Make sure it's within our distance range we have set
-    distance = (int)distance_from_my_station(m_fill->from_call_sign,temp_my_course);
+    distance = distance_from_my_station(m_fill->from_call_sign,temp_my_course);
 
     if (Read_messages_mine_only
             || (!Read_messages_mine_only
@@ -216,7 +216,7 @@ void all_messages(char from, char *call_sign, char *from_call, char *message) {
     if (Read_messages_mine_only
             || (!Read_messages_mine_only
                 && ((vm_range == 0)
-                    || ((int)distance_from_my_station(call_sign,temp_my_course) <= vm_range)) ) ) {
+                    || (distance_from_my_station(call_sign,temp_my_course) <= vm_range)) ) ) {
 
         // Check that it's coming from the correct type of interface
         // Compare Read_messages_packet_data_type against the port

--- a/src/view_message_gui.c
+++ b/src/view_message_gui.c
@@ -141,10 +141,8 @@ void view_message_print_record(Message *m_fill) {
             char short_call[MAX_CALLSIGN];
             char *p;
 
-            xastir_snprintf(short_call,
-                sizeof(short_call),
-                "%s",
-                my_callsign);
+            memcpy(short_call, my_callsign, sizeof(short_call));
+            short_call[sizeof(short_call)-1] = '\0';  // Terminate string
             if ( (p = index(short_call,'-')) ) {
                 *p = '\0';  // Terminate it
             }
@@ -254,10 +252,8 @@ void all_messages(char from, char *call_sign, char *from_call, char *message) {
             char short_call[MAX_CALLSIGN];
             char *p;
 
-            xastir_snprintf(short_call,
-                sizeof(short_call),
-                "%s",
-                my_callsign);
+            memcpy(short_call, my_callsign, sizeof(short_call));
+            short_call[sizeof(short_call)-1] = '\0';  // Terminate string
             if ( (p = index(short_call,'-')) ) {
                 *p = '\0';  // Terminate it
             }

--- a/src/view_message_gui.c
+++ b/src/view_message_gui.c
@@ -361,7 +361,7 @@ end_critical_section(&All_messages_dialog_lock, "view_message_gui.c:all_messages
 
 
 
-void All_messages_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void All_messages_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     char *temp_ptr;
 
@@ -404,7 +404,7 @@ void All_messages_change_range( /*@unused@*/ Widget widget, XtPointer clientData
 
 
 
-void  Read_messages_packet_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Read_messages_packet_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -424,7 +424,7 @@ Widget button_range;
 
 
 
-void  Read_messages_mine_only_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Read_messages_mine_only_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -442,7 +442,7 @@ void  Read_messages_mine_only_toggle( /*@unused@*/ Widget widget, XtPointer clie
 
 
 
-void view_all_messages( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void view_all_messages( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     Widget pane, my_form, button_close, dist, dist_units;
     Widget option_box, tnc_data, net_data, tnc_net_data,
         read_mine_only_button;

--- a/src/view_message_gui.c
+++ b/src/view_message_gui.c
@@ -307,15 +307,30 @@ void all_messages(char from, char *call_sign, char *from_call, char *message) {
                 call_sign,
                 data1,
                 data2);
-        } else
-            xastir_snprintf(temp,
-                my_size,
-                "%s to %s via:%c\t%s%s\n",
-                from_call,
-                call_sign,
-                from,
-                data1,
-                data2);
+        } else {
+            char from_str[10];
+
+            xastir_snprintf(from_str, sizeof(from_str), "%c", from);
+
+            strcpy(temp, from_call);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, " to ");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, call_sign);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, " via:");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, from_str);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, "\t");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, data1);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, data2);
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+            strcat(temp, "\n");
+            temp[sizeof(temp)-1] = '\0';  // Terminate string
+        }
 
         if ((All_messages_dialog != NULL)) {
 

--- a/src/wx.c
+++ b/src/wx.c
@@ -1018,8 +1018,8 @@ void decode_Peet_Bros(int from, unsigned char *data, WeatherRow *weather, int ty
 
         xastir_snprintf(weather->wx_temp,
             sizeof(weather->wx_temp),
-            "%03d",
-            temp4-56);
+            "%03.0f",
+            (float)(temp4-56) );
     } else {
         if (!from)
             weather->wx_temp[0] = 0;
@@ -1348,8 +1348,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
 
                 xastir_snprintf(weather->wx_temp,
                     sizeof(weather->wx_temp),
-                    "%03d",
-                    temp4-56);
+                    "%03.0f",
+                    (float)(temp4-56) );
             } else {
                 if (!from)  // From local station
                     weather->wx_temp[0]=0;

--- a/src/wx.c
+++ b/src/wx.c
@@ -2572,9 +2572,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
 
                         xastir_snprintf(weather->wx_course,
                             sizeof(weather->wx_course),
-                            "%02d%01d",
-                            rswnc(data[3]),
-                            (data[2]&0xf0)>>4);
+                            "%03d",
+                            ( ((rswnc(data[3])*10) + ((data[2]&0xf0)>>4)) %1000 ) );
 
                         // Check for course = 0.  Change to 360.
                         if (strncmp(weather->wx_course,"000",3) == 0) {

--- a/src/wx.c
+++ b/src/wx.c
@@ -562,8 +562,8 @@ void decode_U2000_L(int from, unsigned char *data, WeatherRow *weather) {
         substr(temp_data1,(char *)data,4);
         xastir_snprintf(weather->wx_speed,
             sizeof(weather->wx_speed),
-            "%03d",
-            (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+            "%03.0f",
+            0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
         if (from) {
             weather->wx_speed_sec_time = sec_now();
         } else {
@@ -594,8 +594,8 @@ void decode_U2000_L(int from, unsigned char *data, WeatherRow *weather) {
         temp_data1[1] = '0';
         xastir_snprintf(weather->wx_course,
             sizeof(weather->wx_course),
-            "%03d",
-            (int)(((float)strtol(temp_data1,&temp_conv,16)/256.0)*360.0));
+            "%03.0f",
+            ((strtol(temp_data1,&temp_conv,16)/256.0)*360.0));
     } else {
         xastir_snprintf(weather->wx_course,
             sizeof(weather->wx_course),
@@ -632,7 +632,7 @@ void decode_U2000_L(int from, unsigned char *data, WeatherRow *weather) {
         xastir_snprintf(weather->wx_rain_total,
             sizeof(weather->wx_rain_total),
             "%0.2f",
-            (float)strtol(temp_data1,&temp_conv,16)/100.0);
+            strtol(temp_data1,&temp_conv,16)/100.0);
         if (!from) {
             /* local station */
             compute_rain((float)atof(weather->wx_rain_total));
@@ -663,7 +663,7 @@ void decode_U2000_L(int from, unsigned char *data, WeatherRow *weather) {
         xastir_snprintf(weather->wx_baro,
             sizeof(weather->wx_baro),
             "%0.1f",
-            (float)strtol(temp_data1,&temp_conv,16)/10.0);
+            strtol(temp_data1,&temp_conv,16)/10.0);
     } else {
         if (!from)
             weather->wx_baro[0]=0;
@@ -675,8 +675,8 @@ void decode_U2000_L(int from, unsigned char *data, WeatherRow *weather) {
         substr(temp_data1,(char *)(data+24),4);
         xastir_snprintf(weather->wx_hum,
             sizeof(weather->wx_hum),
-            "%03d",
-            (int)((float)strtol(temp_data1,&temp_conv,16)/10.0));
+            "%03.0f",
+            (strtol(temp_data1,&temp_conv,16)/10.0));
     } else {
         if (!from)
             weather->wx_hum[0]=0;
@@ -689,7 +689,7 @@ void decode_U2000_L(int from, unsigned char *data, WeatherRow *weather) {
             xastir_snprintf(weather->wx_prec_00,
                 sizeof(weather->wx_prec_00),
                 "%0.2f",
-                (float)strtol(temp_data1,&temp_conv,16)/100.0);
+                strtol(temp_data1,&temp_conv,16)/100.0);
         }
     } else {
         if (!from)
@@ -749,20 +749,20 @@ void decode_U2000_P(int from, unsigned char *data, WeatherRow *weather) {
         if (from) {
             xastir_snprintf(weather->wx_gust,
                 sizeof(weather->wx_gust),
-                "%03d",
-                (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                "%03.0f",
+                0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
             /* this may be the only wind data */
             xastir_snprintf(weather->wx_speed,
                 sizeof(weather->wx_speed),
-                "%03d",
-                (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                "%03.0f",
+                0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
         } else {
             /* local station and may be the only wind data */
             if (len < 51) {
                 xastir_snprintf(weather->wx_speed,
                     sizeof(weather->wx_speed),
-                    "%03d",
-                    (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                    "%03.0f",
+                    0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
                 computed_gust = compute_gust((float)atof(weather->wx_speed),
                                         last_speed,
                                         &last_speed_time);
@@ -790,8 +790,8 @@ void decode_U2000_P(int from, unsigned char *data, WeatherRow *weather) {
         temp_data1[1] = '0';
         xastir_snprintf(weather->wx_course,
             sizeof(weather->wx_course),
-            "%03d",
-            (int)(((float)strtol(temp_data1,&temp_conv,16)/256.0)*360.0));
+            "%03.0f",
+            (strtol(temp_data1,&temp_conv,16)/256.0)*360.0);
     } else {
         xastir_snprintf(weather->wx_course,
             sizeof(weather->wx_course),
@@ -827,7 +827,7 @@ void decode_U2000_P(int from, unsigned char *data, WeatherRow *weather) {
             xastir_snprintf(weather->wx_prec_00,
                 sizeof(weather->wx_prec_00),
                 "%0.2f",
-                (float)strtol(temp_data1,&temp_conv,16)/100.0);
+                strtol(temp_data1,&temp_conv,16)/100.0);
         }
     } else {
         if (!from)
@@ -840,7 +840,7 @@ void decode_U2000_P(int from, unsigned char *data, WeatherRow *weather) {
         xastir_snprintf(weather->wx_rain_total,
             sizeof(weather->wx_rain_total),
             "%0.2f",
-            (float)strtol(temp_data1,&temp_conv,16)/100.0);
+            strtol(temp_data1,&temp_conv,16)/100.0);
         if (!from) {
             /* local station */
             compute_rain((float)atof(weather->wx_rain_total));
@@ -871,7 +871,7 @@ void decode_U2000_P(int from, unsigned char *data, WeatherRow *weather) {
         xastir_snprintf(weather->wx_baro,
             sizeof(weather->wx_baro),
             "%0.1f",
-            (float)strtol(temp_data1,&temp_conv,16)/10.0);
+            strtol(temp_data1,&temp_conv,16)/10.0);
     } else {
         if (!from)
             weather->wx_baro[0] = 0;
@@ -882,8 +882,8 @@ void decode_U2000_P(int from, unsigned char *data, WeatherRow *weather) {
         substr(temp_data1,(char *)(data+32),4);
         xastir_snprintf(weather->wx_hum,
             sizeof(weather->wx_hum),
-            "%03d",
-            (int)((float)strtol(temp_data1,&temp_conv,16)/10.0));
+            "%03.0f",
+            strtol(temp_data1,&temp_conv,16)/10.0);
     } else {
         if (!from)
             weather->wx_hum[0] = 0;
@@ -894,8 +894,8 @@ void decode_U2000_P(int from, unsigned char *data, WeatherRow *weather) {
         substr(temp_data1,(char *)(data+48),4);
         xastir_snprintf(weather->wx_speed,
             sizeof(weather->wx_speed),
-            "%03d",
-            (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+            "%03.0f",
+            0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
         if (from) {
             weather->wx_speed_sec_time = sec_now();
         } else {
@@ -967,8 +967,8 @@ void decode_Peet_Bros(int from, unsigned char *data, WeatherRow *weather, int ty
     substr(temp_data1,(char *)data,1);
     xastir_snprintf(weather->wx_course,
         sizeof(weather->wx_course),
-        "%03d",
-        (int)(((float)strtol(temp_data1,&temp_conv,16)/16.0)*360.0));
+        "%03.0f",
+        (strtol(temp_data1,&temp_conv,16)/16.0)*360.0);
 
     /* get last gust speed */
     if (strlen(weather->wx_gust) > 0 && !from) {
@@ -987,8 +987,8 @@ void decode_Peet_Bros(int from, unsigned char *data, WeatherRow *weather, int ty
     } else { // type == APRS_WX6,  '*'  speed in mph
         xastir_snprintf(weather->wx_speed,
             sizeof(weather->wx_speed),
-            "%03d",
-            (int)(0.5 + (float)strtol(temp_data1,&temp_conv,16)));
+            "%03.0f",
+            0.5 + (1.0 * strtol(temp_data1,&temp_conv,16)) );
     }
 
     if (from) {
@@ -1031,7 +1031,7 @@ void decode_Peet_Bros(int from, unsigned char *data, WeatherRow *weather, int ty
         xastir_snprintf(weather->wx_rain_total,
             sizeof(weather->wx_rain_total),
             "%0.2f",
-            (float)strtol(temp_data1,&temp_conv,16)/100.0);
+            strtol(temp_data1,&temp_conv,16)/100.0);
         if (!from) {
             /* local station */
             compute_rain((float)atof(weather->wx_rain_total));
@@ -1290,8 +1290,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
             substr(temp_data1,(char *)(data+1),1);
             xastir_snprintf(weather->wx_course,
                 sizeof(weather->wx_course),
-                "%03d",
-                (int)(((float)strtol(temp_data1,&temp_conv,16)/16.0)*360.0));
+                "%03.0f",
+                (strtol(temp_data1,&temp_conv,16)/16.0)*360.0);
 
             // Check for course == 0.  Change to 360.
             if (strncmp(weather->wx_course,"000",3) == 0) {
@@ -1317,8 +1317,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
             } else { // APRS_WX6 or '*', Data is in MPH
                 xastir_snprintf(weather->wx_speed,
                     sizeof(weather->wx_speed),
-                    "%03d",
-                    (int)(0.5 + (float)strtol(temp_data1,&temp_conv,16)));
+                    "%03.0f",
+                    0.5 + (strtol(temp_data1,&temp_conv,16)*1.0) );
             }
 
             if (from) { // From remote station
@@ -1366,13 +1366,13 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                             xastir_snprintf(weather->wx_rain_total,
                                 sizeof(weather->wx_rain_total),
                                 "%0.2f",
-                                (float)strtol(temp_data1,&temp_conv,16)*10);
+                                strtol(temp_data1,&temp_conv,16)*10.0);
                             break;
                         case 3: // 0.1mm rain gauge
                             xastir_snprintf(weather->wx_rain_total,
                                 sizeof(weather->wx_rain_total),
                                 "%0.2f",
-                                (float)strtol(temp_data1,&temp_conv,16)/2.54);
+                                strtol(temp_data1,&temp_conv,16)/2.54);
                             break;
                         case 2: // 0.01" rain gauge
                         case 0: // No conversion
@@ -1380,7 +1380,7 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                             xastir_snprintf(weather->wx_rain_total,
                                 sizeof(weather->wx_rain_total),
                                 "%0.2f",
-                                (float)strtol(temp_data1,&temp_conv,16));
+                                strtol(temp_data1,&temp_conv,16)*1.0);
                             break;
                     }
                     /* local station */
@@ -1434,8 +1434,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                 substr(temp_data1,(char *)(data+2),4);
                 xastir_snprintf(weather->wx_speed,
                     sizeof(weather->wx_speed),
-                    "%03d",
-                    (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                    "%03.0f",
+                    0.5 + ((strtol(temp_data1,&temp_conv,16) /10.0)*0.62137));
                 if (from) { // From remote station
                     weather->wx_speed_sec_time = sec_now();
                 } else {
@@ -1467,8 +1467,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                 temp_data1[1] = '0';
                 xastir_snprintf(weather->wx_course,
                     sizeof(weather->wx_course),
-                    "%03d",
-                    (int)(((float)strtol(temp_data1,&temp_conv,16)/256.0)*360.0));
+                    "%03.0f",
+                    (strtol(temp_data1,&temp_conv,16)/256.0)*360.0);
 
                 // Check for course = 0.  Change to 360.
                 if (strncmp(weather->wx_course,"000",3) == 0) {
@@ -1514,13 +1514,13 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                             xastir_snprintf(weather->wx_rain_total,
                                 sizeof(weather->wx_rain_total),
                                 "%0.2f",
-                                (float)strtol(temp_data1,&temp_conv,16)*10);
+                                strtol(temp_data1,&temp_conv,16)*10.0);
                             break;
                         case 3: // 0.1mm rain gauge
                             xastir_snprintf(weather->wx_rain_total,
                                 sizeof(weather->wx_rain_total),
                                 "%0.2f",
-                                (float)strtol(temp_data1,&temp_conv,16)/2.54);
+                                strtol(temp_data1,&temp_conv,16)/2.54);
                             break;
                         case 2: // 0.01" rain gauge
                         case 0: // No conversion
@@ -1528,7 +1528,7 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                             xastir_snprintf(weather->wx_rain_total,
                                 sizeof(weather->wx_rain_total),
                                 "%0.2f",
-                                (float)strtol(temp_data1,&temp_conv,16));
+                                strtol(temp_data1,&temp_conv,16)*1.0);
                             break;
                     }
                     /* local station */
@@ -1561,7 +1561,7 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                 xastir_snprintf(weather->wx_baro,
                     sizeof(weather->wx_baro),
                     "%0.1f",
-                    (float)strtol(temp_data1,&temp_conv,16)/10.0);
+                    strtol(temp_data1,&temp_conv,16)/10.0);
             }
 
             /* outdoor humidity */
@@ -1569,8 +1569,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                 substr(temp_data1,(char *)(data+26),4);
                 xastir_snprintf(weather->wx_hum,
                     sizeof(weather->wx_hum),
-                    "%03d",
-                    (int)((float)strtol(temp_data1,&temp_conv,16)/10.0));
+                    "%03.0f",
+                    strtol(temp_data1,&temp_conv,16)/10.0);
             } else {
                 if (!from)  // From local station
                     weather->wx_hum[0]=0;
@@ -1587,7 +1587,7 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                         xastir_snprintf(weather->wx_prec_00,
                             sizeof(weather->wx_prec_00),
                             "%0.2f",
-                            (float)strtol(temp_data1,&temp_conv,16)/100.0);
+                            strtol(temp_data1,&temp_conv,16)/100.0);
                     }
                 } else {
                     if (!from)  // From local station
@@ -1623,20 +1623,20 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                 if (from) { // From remote station
                     xastir_snprintf(weather->wx_gust,
                         sizeof(weather->wx_gust),
-                        "%03d",
-                        (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                        "%03.0f",
+                        0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
                     /* this may be the only wind data */
                     xastir_snprintf(weather->wx_speed,
                         sizeof(weather->wx_speed),
-                        "%03d",
-                        (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                        "%03.0f",
+                        0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
                 } else {
                     /* local station and may be the only wind data */
                     if (len<56) {
                         xastir_snprintf(weather->wx_speed,
                             sizeof(weather->wx_speed),
-                            "%03d",
-                            (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                            "%03.0f",
+                            0.5 + ( strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
                         computed_gust = compute_gust((float)atof(weather->wx_speed),
                                             last_speed,
                                             &last_speed_time);
@@ -1664,8 +1664,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                 temp_data1[1] = '0';
                 xastir_snprintf(weather->wx_course,
                     sizeof(weather->wx_course),
-                    "%03d",
-                    (int)(((float)strtol(temp_data1,&temp_conv,16)/256.0)*360.0));
+                    "%03.0f",
+                    (strtol(temp_data1,&temp_conv,16)/256.0)*360.0);
 
                 // Check for course = 0.  Change to 360.
                 if (strncmp(weather->wx_course,"000",3) == 0) {
@@ -1708,7 +1708,7 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                     xastir_snprintf(weather->wx_prec_00,
                         sizeof(weather->wx_prec_00),
                         "%0.2f",
-                        (float)strtol(temp_data1,&temp_conv,16)/100.0);
+                        strtol(temp_data1,&temp_conv,16)/100.0);
                 }
             } else {
                 if (!from)  // From local station
@@ -1724,13 +1724,13 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                             xastir_snprintf(weather->wx_rain_total,
                                 sizeof(weather->wx_rain_total),
                                 "%0.2f",
-                                (float)strtol(temp_data1,&temp_conv,16)*10);
+                                strtol(temp_data1,&temp_conv,16)*10.0);
                             break;
                         case 3: // 0.1mm rain gauge
                             xastir_snprintf(weather->wx_rain_total,
                                 sizeof(weather->wx_rain_total),
                                 "%0.2f",
-                                (float)strtol(temp_data1,&temp_conv,16)/2.54);
+                                strtol(temp_data1,&temp_conv,16)/2.54);
                             break;
                         case 2: // 0.01" rain gauge
                         case 0: // No conversion
@@ -1738,7 +1738,7 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                             xastir_snprintf(weather->wx_rain_total,
                                 sizeof(weather->wx_rain_total),
                                 "%0.2f",
-                                (float)strtol(temp_data1,&temp_conv,16));
+                                strtol(temp_data1,&temp_conv,16)*1.0);
                             break;
                     }
                     /* local station */
@@ -1771,7 +1771,7 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                 xastir_snprintf(weather->wx_baro,
                     sizeof(weather->wx_baro),
                     "%0.1f",
-                    (float)strtol(temp_data1, &temp_conv, 16)/10.0);
+                    strtol(temp_data1, &temp_conv, 16)/10.0);
             } else {
                 if (!from)  // From local station
                     weather->wx_baro[0]=0;
@@ -1782,8 +1782,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                 substr(temp_data1,(char *)(data+37),4);
                 xastir_snprintf(weather->wx_hum,
                     sizeof(weather->wx_hum),
-                    "%03d",
-                    (int)((float)strtol(temp_data1,&temp_conv,16)/10.0));
+                    "%03.0f",
+                    strtol(temp_data1,&temp_conv,16)/10.0);
             } else {
                 if (!from)  // From local station
                     weather->wx_hum[0]=0;
@@ -1794,8 +1794,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                 substr(temp_data1,(char *)(data+53),4);
                 xastir_snprintf(weather->wx_speed,
                     sizeof(weather->wx_speed),
-                    "%03d",
-                    (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                    "%03.0f",
+                    0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
                 if (from) { // From remote station
                     weather->wx_speed_sec_time = sec_now();
                 } else {
@@ -1847,8 +1847,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                     substr(temp_data1,(char *)(data+12),4);
                     xastir_snprintf(weather->wx_gust,
                         sizeof(weather->wx_gust),
-                        "%03d",
-                        (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                        "%03.0f",
+                        0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
                 }
                 else
                     weather->wx_gust[0]=0;
@@ -1862,9 +1862,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                     substr(temp_data1,(char *)(data+452),4);
                     xastir_snprintf(weather->wx_speed,
                         sizeof(weather->wx_speed),
-                        "%03d",
-                        (int)(0.5
-                            + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                        "%03.0f",
+                        0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
                     done_with_wx_speed++;
                 }
 
@@ -1881,21 +1880,21 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                 /* Wind Speed fields 1, 34, and 71.  Wind direction fields 2, 35, 72. */
                 if (data[4] !='-') { // '-' signifies invalid data
                     substr(temp_data1, (char *)data+4, 4);
-                    temp1 = (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
+                    temp1 = 0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137;
                 }
                 else {
                     temp1=0;
                 }
                 if (data[136] !='-') { // '-' signifies invalid data
                     substr(temp_data1, (char *)data+136, 4);
-                    temp2 = (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
+                    temp2 = 0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137;
                 }
                 else {
                     temp2=0;
                 }
                 if (data[284] !='-') { // '-' signifies invalid data
                     substr(temp_data1, (char *)data+284, 4);
-                    temp3 = (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
+                    temp3 = 0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137;
                 }
                 else {
                     temp3=0;
@@ -1915,8 +1914,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                         substr(temp_data1,(char *)(data+4),4);
                         xastir_snprintf(weather->wx_speed,
                             sizeof(weather->wx_speed),
-                            "%03d",
-                            (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                            "%03.0f",
+                            0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
                     }
 
                     /* wind direction */
@@ -1931,8 +1930,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                         temp_data1[1] = '0';
                         xastir_snprintf(weather->wx_course,
                             sizeof(weather->wx_course),
-                            "%03d",
-                            (int)(((float)strtol(temp_data1,&temp_conv,16)/256.0)*360.0));
+                            "%03.0f",
+                            (strtol(temp_data1,&temp_conv,16)/256.0)*360.0);
 
                         // Check for course = 0.  Change to 360.
                         if (strncmp(weather->wx_course,"000",3) == 0) {
@@ -1956,8 +1955,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                         substr(temp_data1,(char *)(data+136),4);
                         xastir_snprintf(weather->wx_speed,
                             sizeof(weather->wx_speed),
-                            "%03d",
-                            (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                            "%03.0f",
+                            0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
                     }
 
                     /* wind direction */
@@ -1972,8 +1971,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                         temp_data1[1] = '0';
                         xastir_snprintf(weather->wx_course,
                             sizeof(weather->wx_course),
-                            "%03d",
-                            (int)(((float)strtol(temp_data1,&temp_conv,16)/256.0)*360.0));
+                            "%03.0f",
+                            (strtol(temp_data1,&temp_conv,16)/256.0)*360.0);
 
                         // Check for course = 0.  Change to 360.
                         if (strncmp(weather->wx_course,"000",3) == 0) {
@@ -1997,8 +1996,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                         substr(temp_data1,(char *)(data+284),4);
                         xastir_snprintf(weather->wx_speed,
                             sizeof(weather->wx_speed),
-                            "%03d",
-                            (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                            "%03.0f",
+                            0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
                     }
 
                     /* wind direction */
@@ -2013,8 +2012,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                         temp_data1[1] = '0';
                         xastir_snprintf(weather->wx_course,
                             sizeof(weather->wx_course),
-                            "%03d",
-                            (int)(((float)strtol(temp_data1,&temp_conv,16)/256.0)*360.0));
+                            "%03.0f",
+                            (strtol(temp_data1,&temp_conv,16)/256.0)*360.0);
 
                         // Check for course = 0.  Change to 360.
                         if (strncmp(weather->wx_course,"000",3) == 0) {
@@ -2038,8 +2037,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                         substr(temp_data1,(char *)(data+4),4);
                         xastir_snprintf(weather->wx_speed,
                             sizeof(weather->wx_speed),
-                            "%03d",
-                            (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                            "%03.0f",
+                            0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
                     }
 
                     /* wind direction */
@@ -2054,8 +2053,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                         temp_data1[1] = '0';
                         xastir_snprintf(weather->wx_course,
                             sizeof(weather->wx_course),
-                            "%03d",
-                            (int)(((float)strtol(temp_data1,&temp_conv,16)/256.0)*360.0));
+                            "%03.0f",
+                            (strtol(temp_data1,&temp_conv,16)/256.0)*360.0);
 
                         // Check for course = 0.  Change to 360.
                         if (strncmp(weather->wx_course,"000",3) == 0) {
@@ -2135,13 +2134,13 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                             xastir_snprintf(weather->wx_rain_total,
                                 sizeof(weather->wx_rain_total),
                                 "%0.2f",
-                                (float)strtol(temp_data1,&temp_conv,16)*10);
+                                strtol(temp_data1,&temp_conv,16)*10.0);
                             break;
                         case 3: // 0.1mm rain gauge
                             xastir_snprintf(weather->wx_rain_total,
                                 sizeof(weather->wx_rain_total),
                                 "%0.2f",
-                                (float)strtol(temp_data1,&temp_conv,16)/2.54);
+                                strtol(temp_data1,&temp_conv,16)/2.54);
                             break;
                         case 2: // 0.01" rain gauge
                         case 0: // No conversion
@@ -2149,7 +2148,7 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                             xastir_snprintf(weather->wx_rain_total,
                                 sizeof(weather->wx_rain_total),
                                 "%0.2f",
-                                (float)strtol(temp_data1,&temp_conv,16));
+                                strtol(temp_data1,&temp_conv,16)*1.0);
                             break;
                     }
                     /* Since local station only */
@@ -2182,7 +2181,7 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                     xastir_snprintf(weather->wx_baro,
                         sizeof(weather->wx_baro),
                         "%0.1f",
-                        (float)strtol(temp_data1,&temp_conv,16)/10.0);
+                        strtol(temp_data1,&temp_conv,16)/10.0);
                 } else
                     weather->wx_baro[0]=0;
 
@@ -2191,8 +2190,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                     substr(temp_data1,(char *)(data+52),4);
                     xastir_snprintf(weather->wx_hum,
                         sizeof(weather->wx_hum),
-                        "%03d",
-                        (int)((float)strtol(temp_data1,&temp_conv,16)/10.0));
+                        "%03.0f",
+                        strtol(temp_data1,&temp_conv,16)/10.0);
                 } else
                     weather->wx_hum[0]=0;
 
@@ -2219,8 +2218,8 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                     substr(temp_data1,(char *)(data+248),4);
                     xastir_snprintf(wx_high_wind,
                         sizeof(wx_high_wind),
-                        "%03d",
-                        (int)(0.5 + ((float)strtol(temp_data1,&temp_conv,16)/10.0)*0.62137));
+                        "%03.0f",
+                        0.5 + (strtol(temp_data1,&temp_conv,16)/10.0)*0.62137);
                     wx_high_wind_on = 1;
                 }
 
@@ -2465,7 +2464,7 @@ void wx_fill_data(int from, int type, unsigned char *data, DataRow *fill) {
                             "%0d%02d%0.1f",
                             (data[5]&0x0f),
                             rswnc(data[4]),
-                            ((float)rswnc(data[3])/10.0));
+                            rswnc(data[3])/10.0);
 
                         /* dew point in C */
                         temp_temp = (int)((rswnc(data[18])*1.8)+32);
@@ -3595,7 +3594,7 @@ time_t wx_tx_data1(char *st, int st_size) {
                         sizeof(temp),
                         "r   ");
                 }
-                if ((int)(atof(weather->wx_rain)) < 0) {
+                if (atoi(weather->wx_rain) < 0) {
                     if (debug_level & 1)
                         fprintf(stderr,"wx_rain out-of-bounds: %s\n", weather->wx_rain);
 
@@ -3624,7 +3623,7 @@ time_t wx_tx_data1(char *st, int st_size) {
                         sizeof(temp),
                         "P   ");
                 }
-                if ((int)(atof(weather->wx_prec_00)) < 0) {
+                if (atoi(weather->wx_prec_00) < 0) {
                     if (debug_level & 1)
                         fprintf(stderr,"wx_prec_00 out-of-bounds: %s\n", weather->wx_prec_00);
 
@@ -3653,7 +3652,7 @@ time_t wx_tx_data1(char *st, int st_size) {
                         sizeof(temp),
                         "p   ");
                 }
-                if ((int)(atof(weather->wx_prec_24)) < 0) {
+                if (atoi(weather->wx_prec_24) < 0) {
                     if (debug_level & 1)
                         fprintf(stderr,"wx_prec_24 out-of-bounds: %s\n", weather->wx_prec_24);
 

--- a/src/wx.c
+++ b/src/wx.c
@@ -290,7 +290,7 @@ void compute_rain(float rain_total) {
 /* compute_gust - compute max wind gust during last 5 minutes */
 /*                                                            */
 /**************************************************************/
-float compute_gust(float wx_speed, float last_speed, time_t *last_speed_time) {
+float compute_gust(float wx_speed, float UNUSED(last_speed), time_t *last_speed_time) {
     float computed_gust;
     int current, j;
 

--- a/src/wx_gui.c
+++ b/src/wx_gui.c
@@ -92,7 +92,7 @@ void wx_gui_init(void)
 
 
 
-void wx_detailed_alert_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void wx_detailed_alert_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
 
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
@@ -114,7 +114,7 @@ end_critical_section(&wx_detailed_alert_shell_lock, "wx_gui.c:wx_detailed_alert_
 // from both the Station Info "NWS" button and by double-clicking on
 // the view weather alerts window.
 //
-void wx_alert_finger_output( Widget widget, char *handle) {
+void wx_alert_finger_output( Widget UNUSED(widget), char *handle) {
     static Widget pane, my_form, mess, button_cancel,wx_detailed_alert_list;
     Atom delw;
     Arg al[50];             // Arg List
@@ -383,7 +383,7 @@ end_critical_section(&wx_detailed_alert_shell_lock, "wx_gui.c:wx_alert_double_cl
 
 
 
-void wx_alert_double_click_action( Widget widget, XtPointer clientData, XtPointer callData) {
+void wx_alert_double_click_action( Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
     char *choice;
     XmListCallbackStruct *selection = callData;
     char handle[14];
@@ -420,7 +420,7 @@ void wx_alert_double_click_action( Widget widget, XtPointer clientData, XtPointe
 
 
 
-void wx_alert_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void wx_alert_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
 
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
@@ -591,7 +591,7 @@ end_critical_section(&wx_alert_shell_lock, "wx_gui.c:wx_alert_update_list" );
 
 
 
-void Display_Wx_Alert( /*@unused@*/ Widget wdgt, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Display_Wx_Alert( /*@unused@*/ Widget UNUSED(wdgt), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget pane, my_form, mess, button_cancel;
     Atom delw;
     Arg al[50];                    /* Arg List */
@@ -763,7 +763,7 @@ Widget WX_high_wind_label;
 
 
 
-void WX_station_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void WX_station_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
 
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
@@ -792,7 +792,7 @@ void WX_station_change_data(Widget widget, XtPointer clientData, XtPointer callD
 
 // This is the "Own Weather Station" Dialog
 //
-void WX_station( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void WX_station( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, form1, button_close, frame, 
             WX_type, temp, wind_cse, wind_spd, wind_gst, 
             my_rain, to_rain, rain_h, my_rain_24, baro,

--- a/src/x_spider.c
+++ b/src/x_spider.c
@@ -1455,7 +1455,8 @@ void UDP_Server(int argc, char *argv[], char *envp[]) {
         //
 
         // Copy the entire buffer so that we can modify it
-        xastir_snprintf(buf2, sizeof(buf2), "%s", buf);
+        memcpy(buf2, buf, sizeof(buf2));
+        buf2[sizeof(buf2)-1] = '\0';  // Terminate string
         split_string(buf2, cptr, 10, ',');
 
         if (cptr[0] == NULL || cptr[0][0] == '\0') {    // callsign

--- a/src/x_spider.c
+++ b/src/x_spider.c
@@ -169,6 +169,8 @@
 #define SIGRET  void
 #endif  // SIGRET
 
+#include "xastir.h"
+
 // Must be last include file
 #include "leak_detection.h"
 
@@ -860,7 +862,7 @@ void clear_proc_title(void)
 #endif  // __linux__
 }
 
-void init_set_proc_title(int argc, char *argv[], char *envp[]) {
+void init_set_proc_title(int UNUSED(argc), char *argv[], char *envp[]) {
     int i, envpsize;
     char **p;
 
@@ -1369,7 +1371,7 @@ void send_udp_nack(int sock, struct sockaddr *from, int fromlen) {
 // Create a UDP listening port.  This allows scripts and other
 // programs to inject packets into Xastir via UDP protocol.
 //
-void UDP_Server(int argc, char *argv[], char *envp[]) {
+void UDP_Server(int UNUSED(argc), char * UNUSED(argv[]), char * UNUSED(envp[]) ) {
     int sock, n1, n2;
     socklen_t fromlen;
     struct sockaddr_storage from;

--- a/src/xastir.h
+++ b/src/xastir.h
@@ -34,6 +34,20 @@
 #define XTPOINTER_TO_INT(m_p)  ((int)((long)(m_p)))
 
 
+// Defines we can use to mark functions and parameters as "unused" to the compiler
+#ifdef __GNUC__
+#  define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
+#else
+#  define UNUSED(x) UNUSED_ ## x
+#endif
+
+#ifdef __GNUC__
+#  define UNUSED_FUNCTION(x) __attribute__((__unused__)) UNUSED_ ## x
+#else
+#  define UNUSED_FUNCTION(x) UNUSED_ ## x
+#endif
+
+
 #define SERIAL_KISS_RELAY_DIGI
 
 

--- a/src/xastir_udp_client.c
+++ b/src/xastir_udp_client.c
@@ -48,6 +48,7 @@
 
 #include <poll.h>
 
+#include "xastir.h"
 
 // Must be last include file
 #include "leak_detection.h"
@@ -55,7 +56,7 @@
 // Atttempt to send to one of the addresses, waiting for 10 seconds
 // for (hopefully) a response. Returns 1 on success or 0 if we didn't
 // get a response. (Any response is considered a success)
-int try_exchange(struct addrinfo *addr, char *buffer, int buflen)
+int try_exchange(struct addrinfo *addr, char *buffer, int UNUSED(buflen) )
 {
     int sockfd, n;
     socklen_t length;


### PR DESCRIPTION
These commits solve a BUNCH of compiler warnings with gcc7 and gcc8, even with adding a bunch more compiler options like:

`CFLAGS="-O2 -Wall -Wextra -Wpointer-arith -Wwrite-strings -Wcast-align -Wbad-function-cast -Wformat-security -Winline -Wstringop-truncation -Wno-format-truncation -funsigned-char -W -Wno-discarded-qualifiers"`

These are perhaps the final commits to solving the compiler warnings in Issue #24 