### PR TITLE
Make "rtree" the only shapefile reading method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,11 +148,6 @@ matrix:
         - make
 #        - sudo make install
  
-#        - ./configure --without-rtree CPPFLAGS="-I/usr/include/geotiff"
-#        - make clean
-#        - make
-#        - sudo make install
- 
 #        - ./configure --without-map-cache CPPFLAGS="-I/usr/include/geotiff"
 #        - make clean
 #        - make
@@ -173,7 +168,7 @@ matrix:
         - make
 #        - sudo make install
 
-        - ./configure --without-imagemagick --without-graphicsmagick --without-shapelib --without-pcre --without-dbfawk --without-rtree --without-map-cache --without-libcurl --without-ax25 --without-libproj --without-geotiff --without-festival --without-gpsman CPPFLAGS="-I/usr/include/geotiff"
+        - ./configure --without-imagemagick --without-graphicsmagick --without-shapelib --without-pcre --without-dbfawk --without-map-cache --without-libcurl --without-ax25 --without-libproj --without-geotiff --without-festival --without-gpsman CPPFLAGS="-I/usr/include/geotiff"
 #        - make clean
         - make
 #        - sudo make install

--- a/configure.ac
+++ b/configure.ac
@@ -538,25 +538,6 @@ if test "${use_dbfawk}" = "yes"; then
 fi
 
 
-use_rtree=yes
-LIBRTREE=""
-SUBRTREE=""
-AC_ARG_WITH(rtree,[  --without-rtree           Disable spatial indexing of shapefiles.],[use_rtree=$withval])
-if test "${use_rtree}" = "yes" ; then
-  if test "${use_shapelib}" = "yes"; then
-    AC_DEFINE([USE_RTREE],1,[RTree spatial indexing])
-     LIBRTREE="-Lrtree -lrtree"
-     SUBRTREE="rtree"
-  else
-    echo "*** Warning: rtree requires shapelib."
-    use_rtree=no
-  fi
-fi
-AC_SUBST(SUBRTREE)
-AC_SUBST(LIBRTREE)
-
-
-
 
 AC_ARG_ENABLE(davis, [  --enable-davis          Turn on Davis support],
   [case "${enableval}" in
@@ -809,11 +790,6 @@ if test "${use_profiling}" = "yes"; then
 else
   ILIBS="$ILIBS          "
 fi
-if test "${use_rtree}" = "yes"; then
-  ILIBS="$ILIBS rtree"
-else
-  ILIBS="$ILIBS      "
-fi
 if test "${use_lsb}" = "yes"; then
   ILIBS="$ILIBS LSB"
 else
@@ -944,7 +920,6 @@ else
 fi
 echo "  pcre (Shapefile customization) ............ : $use_pcre"
 echo "  dbfawk (Shapefile customization) .......... : $use_dbfawk"
-echo "  rtree indexing (Shapefile speedups) ....... : $use_rtree"
 echo "  Berkeley DB map caching-Raster map speedups : $use_map_cache"
 echo "  internet map retrieval .................... : $use_retrieval"
 echo

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,7 @@
 
 bin_PROGRAMS = xastir xastir_udp_client testdbfawk
 
-SUBDIRS = @SUBRTREE@
+SUBDIRS = rtree
 DIST_SUBDIRS = rtree
 
 EXTRA_DIST=icon.xbm
@@ -91,7 +91,7 @@ compiledate.c: $(XASTIR_SRC)
 remove_compiledate:
 	rm -f compiledate.c compiledate.o
 
-xastir_LDADD=@LIBRTREE@
+xastir_LDADD=-Lrtree -lrtree
 
 xastir_LINK=$(CC) $(AM_CFLAGS) $(CFLAGS) $(LDFLAGS) -o $@
 

--- a/src/main.c
+++ b/src/main.c
@@ -11429,11 +11429,9 @@ void UpdateTime( XtPointer clientData, XtIntervalId UNUSED(id) ) {
             check_station_remove(current_time);         // remove old stations
             check_message_remove(current_time);         // remove old messages
 
-#ifdef USE_RTREE
   #ifdef HAVE_LIBSHP
             purge_shp_hash(current_time);               // purge stale rtrees
   #endif // HAVE_LIBSHP
-#endif // USE_RTREE
 
 
             // We need to always calculate the Aloha circle so that

--- a/src/shp_hash.c
+++ b/src/shp_hash.c
@@ -25,7 +25,6 @@
 #include "config.h"
 #endif  // HAVE_CONFIG_H
 
-#ifdef USE_RTREE
 #ifdef HAVE_LIBSHP
 
 #include <stdlib.h>
@@ -380,7 +379,6 @@ void purge_shp_hash(time_t secs_now) {
 }
 
 #endif  // HAVE_LIBSHP
-#endif // USE_RTREE
 
 
 // To get rid of "-pedantic" compiler warning:

--- a/src/shp_hash.h
+++ b/src/shp_hash.h
@@ -5,7 +5,6 @@
 #ifndef __XASTIR_SHP_HASH_H
 #define __XASTIR_SHP_HASH_H
 
-#ifdef USE_RTREE
 
 #ifdef HAVE_SHAPEFIL_H
 #include <shapefil.h>
@@ -34,5 +33,4 @@ void destroy_shpinfo(shpinfo *si);
 void purge_shp_hash(time_t secs_now);
 shpinfo *get_shp_from_hash(char *filename);
 
-#endif // USE_RTREE
 #endif // __XASTIR_SHP_HASH_H


### PR DESCRIPTION
Years ago, Xastir's shapefile support always read an entire shapefile
if any part of the shapefile's bounding box intersected the current
map screen.  That could be enormously expensive when a shapefile had a
very large number of objects in it, only a small number of which were
actually on screen.

In 2004 (commit 7c9a474) I added an experimental feature where instead
of sequentially reading an entire shapefile only to find that only a
few objects in it were visible, a spatial index (R-tree data
structure) would be built from a shapefile the first time it was
read.  From that point forward, all reading of the file is done by
searching the spatial index for shapes that intersect the screen's
bounding box, and these individual objects are read via random access.
At that time, because it was an experimental feature, it was made a
configure option (--with-rtree) until its value could be proven.

In 2006 (commit cf417d1), the value had been proven well enough that the default
behavior of configure was to enable rtree, and one had to *disable*
it (via "--without-rtree") if one didn't want it.  Disabling it just
slowed down the shapefile rendering (often by a lot) so it is pretty
much not done anymore.  I've spotted a number of packages out there
that explicitly include "--with-rtree" even though this is already
the default, presumably to make absolutely sure this optimization was
included.

After a little discussion, and 13 years of experience showing that the
rtree code is robust and an improvement over the older method, we're
making rtree the ONLY code for handling shapefiles.  The ifdef
handling the rtree stuff is now gone, as is the code that was selected
when "USE_RTREE" was not defined, as are the conditional compilation
options.

This commit closes issue #127.