### PR TITLE
Remove lclint annotation "@unused@"

### DIFF
--- a/src/bulletin_gui.c
+++ b/src/bulletin_gui.c
@@ -527,7 +527,7 @@ void check_for_new_bulletins(int curr_sec) {
 
 
 
-void Display_bulletins_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Display_bulletins_destroy_shell(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     char *temp_ptr;
 
@@ -552,7 +552,7 @@ void Display_bulletins_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPoint
 
 
 
-void Display_bulletins_change_range(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Display_bulletins_change_range(Widget widget, XtPointer clientData, XtPointer callData) {
     char *temp_ptr;
 
 
@@ -572,7 +572,7 @@ void Display_bulletins_change_range(/*@unused@*/ Widget widget, /*@unused@*/ XtP
 
 
 
-void  Zero_Bulletin_Data_toggle( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData) {
+void  Zero_Bulletin_Data_toggle( Widget widget, XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -589,7 +589,7 @@ void  Zero_Bulletin_Data_toggle( /*@unused@*/ Widget widget, XtPointer clientDat
 
 
  
-void Bulletins(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Bulletins(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     Widget pane, form, button_range, button_close, dist, dist_units;
     unsigned int n;
     Arg args[50];

--- a/src/db.c
+++ b/src/db.c
@@ -3998,7 +3998,7 @@ void display_file(Widget w) {
 /*
  *  Delete Station Info PopUp
  */
-void Station_data_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Station_data_destroy_shell(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -4018,7 +4018,7 @@ void Station_data_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer cl
 /*
  *  Store track data for current station
  */
-void Station_data_store_track(Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Station_data_store_track(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callData) ) {
     DataRow *p_station = clientData;
 
     //busy_cursor(XtParent(w));
@@ -4046,7 +4046,7 @@ void Station_data_store_track(Widget UNUSED(w), XtPointer clientData, /*@unused@
 /*
  *  Delete tracklog for current station
  */
-void Station_data_destroy_track( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Station_data_destroy_track( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     DataRow *p_station = clientData;
 
     if (delete_trail(p_station))
@@ -4061,7 +4061,7 @@ void Station_data_destroy_track( /*@unused@*/ Widget UNUSED(widget), XtPointer c
 // call wx_alert_double_click_action, which expects the parameter in
 // calldata instead of in clientData.
 //
-void Station_data_wx_alert(Widget w, XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Station_data_wx_alert(Widget w, XtPointer clientData, XtPointer UNUSED(calldata) ) {
     //fprintf(stderr, "Station_data_wx_alert start\n");
     wx_alert_finger_output( w, clientData);
     //fprintf(stderr, "Station_data_wx_alert end\n");
@@ -4071,7 +4071,7 @@ void Station_data_wx_alert(Widget w, XtPointer clientData, /*@unused@*/ XtPointe
 
 
 
-void Station_data_add_fcc(Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Station_data_add_fcc(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     char temp[500];
     FccAppl my_data;
     char *station = (char *) clientData;
@@ -4099,7 +4099,7 @@ void Station_data_add_fcc(Widget UNUSED(w), XtPointer clientData, /*@unused@*/ X
 
 
 
-void Station_data_add_rac(Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Station_data_add_rac(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     char temp[512];
     char club[512];
     rac_record my_data;
@@ -4163,7 +4163,7 @@ void Station_data_add_rac(Widget UNUSED(w), XtPointer clientData, /*@unused@*/ X
 
 
 
-void Station_query_trace(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Station_query_trace(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     char *station = (char *) clientData;
     char temp[50];
     char call[25];
@@ -4181,7 +4181,7 @@ void Station_query_trace(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*
 
 
 
-void Station_query_messages(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Station_query_messages(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     char *station = (char *) clientData;
     char temp[50];
     char call[25];
@@ -4199,7 +4199,7 @@ void Station_query_messages(/*@unused@*/ Widget UNUSED(w), XtPointer clientData,
 
 
 
-void Station_query_direct(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Station_query_direct(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     char *station = (char *) clientData;
     char temp[50];
     char call[25];
@@ -4217,7 +4217,7 @@ void Station_query_direct(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /
 
 
 
-void Station_query_version(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Station_query_version(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     char *station = (char *) clientData;
     char temp[50];
     char call[25];
@@ -4235,7 +4235,7 @@ void Station_query_version(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, 
 
 
 
-void General_query(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void General_query(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     char *location = (char *) clientData;
     char temp[50];
 
@@ -4247,7 +4247,7 @@ void General_query(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unuse
 
 
 
-void IGate_query(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void IGate_query(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     output_my_data("?IGATE?",-1,0,0,0,NULL); // Not igating
 }
 
@@ -4255,7 +4255,7 @@ void IGate_query(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(cl
 
 
 
-void WX_query(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void WX_query(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     output_my_data("?WX?",-1,0,0,0,NULL);    // Not igating
 }
 
@@ -4269,7 +4269,7 @@ Widget tactical_text = (Widget)NULL;
 DataRow *tactical_pointer = NULL;
 
 
-void Change_tactical_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Change_tactical_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -4599,7 +4599,7 @@ void compute_decorations( void ) {
 
 
 // Enable/disable auto-update of Station_data dialog
-void station_data_auto_update_toggle ( /*@unused@*/ Widget UNUSED(widget), /*@unused@*/ XtPointer UNUSED(clientData), XtPointer callData) {
+void station_data_auto_update_toggle ( Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
     if(state->set)
@@ -4613,7 +4613,7 @@ void station_data_auto_update_toggle ( /*@unused@*/ Widget UNUSED(widget), /*@un
 
 
 // Fill in the station data window with real data
-void station_data_fill_in ( /*@unused@*/ Widget w, XtPointer clientData, XtPointer calldata ) {
+void station_data_fill_in ( Widget w, XtPointer clientData, XtPointer calldata ) {
     DataRow *p_station;
     char *station = (char *) clientData;
     char temp[300];
@@ -5543,7 +5543,7 @@ void station_data_fill_in ( /*@unused@*/ Widget w, XtPointer clientData, XtPoint
  * Called by Station_data function below from the Track Station
  * button in Station Info.
  */
-void Track_from_Station_data(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
+void Track_from_Station_data(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     DataRow *p_station = clientData;
  
     if (p_station->call_sign[0] != '\0') {
@@ -5564,7 +5564,7 @@ void Track_from_Station_data(/*@unused@*/ Widget UNUSED(w), XtPointer clientData
  * Called by Station_data function below from the Clear DF Bearing
  * button in Station Info.
  */
-void Clear_DF_from_Station_data(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
+void Clear_DF_from_Station_data(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     DataRow *p_station = clientData;
  
     if (strlen(p_station->bearing) == 3) {
@@ -5593,7 +5593,7 @@ void Clear_DF_from_Station_data(/*@unused@*/ Widget UNUSED(w), XtPointer clientD
  *               "4"  = Send Message To
  *
  */
-void Station_data(/*@unused@*/ Widget w, XtPointer clientData, XtPointer calldata) {
+void Station_data(Widget w, XtPointer clientData, XtPointer calldata) {
     DataRow *p_station;
     char *station = (char *) clientData;
     static char local_station[25];
@@ -6302,7 +6302,7 @@ void update_station_info(Widget w) {
 /*
  *  Station Info Selection PopUp window: Canceled
  */
-void Station_info_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Station_info_destroy_shell(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
 
     // We used to close the detailed Station Info dialog here too, which
@@ -6343,7 +6343,7 @@ XtPointer station_info_select_global = NULL;
 /*
  *  Station Info Selection PopUp window: Quit with selected station
  */
-void Station_info_select_destroy_shell(Widget widget, /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Station_info_select_destroy_shell(Widget widget, XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i,x;
     char *temp;
     char temp2[50];
@@ -6417,7 +6417,7 @@ void Station_info_select_destroy_shell(Widget widget, /*@unused@*/ XtPointer UNU
  *             "3"  = Assign Tactical Call
  *             "4"  = Send Message To
  */
-void Station_info(Widget w, /*@unused@*/ XtPointer clientData, XtPointer UNUSED(calldata) ) {
+void Station_info(Widget w, XtPointer clientData, XtPointer UNUSED(calldata) ) {
     DataRow *p_station;
     DataRow *p_found;
     int num_found = 0;
@@ -10347,7 +10347,7 @@ int extract_position(DataRow *p_station, char **info, int type) {
  * Returns 0 if the packet is NOT a properly compressed position
  * packet, returns 1 if ok.
  */
-int extract_comp_position(DataRow *p_station, char **info, /*@unused@*/ int UNUSED(type) ) {
+int extract_comp_position(DataRow *p_station, char **info, int UNUSED(type) ) {
     int ok;
     int x1, x2, x3, x4, y1, y2, y3, y4;
     int c = 0;
@@ -11173,7 +11173,7 @@ int extract_time(DataRow * UNUSED(p_station), char *data, int type) {
 //  T../C..  Area Object Descriptor
 
 /* Extract one of several possible APRS Data Extensions */
-void process_data_extension(DataRow *p_station, char *data, /*@unused@*/ int UNUSED(type) ) {
+void process_data_extension(DataRow *p_station, char *data, int UNUSED(type) ) {
     char temp1[7+1];
     char temp2[3+1];
     char temp3[10+1];
@@ -11354,7 +11354,7 @@ void process_data_extension(DataRow *p_station, char *data, /*@unused@*/ int UNU
 
 
 /* extract all available information from info field */
-void process_info_field(DataRow *p_station, char *info, /*@unused@*/ int UNUSED(type) ) {
+void process_info_field(DataRow *p_station, char *info, int UNUSED(type) ) {
     char temp_data[6+1];
     //    char time_data[MAX_TIME];
 
@@ -14163,7 +14163,7 @@ void compute_smart_beacon(char *current_course, char *current_speed) {
 
 
 // Speed is in knots
-void my_station_gps_change(char *pos_long, char *pos_lat, char *course, char *speed, /*@unused@*/ char UNUSED(speedu), char *alt, char *sats) {
+void my_station_gps_change(char *pos_long, char *pos_lat, char *course, char *speed, char UNUSED(speedu), char *alt, char *sats) {
     long pos_long_temp, pos_lat_temp;
     char temp_data[40];   // short term string storage
     char temp_lat[12];
@@ -15408,7 +15408,7 @@ int process_directed_query(char *call,char *path,char *message,char from) {
 // NOTE:  We may end up sending these to RF when the query came in
 // over the internet.  We should check that.
 //
-int process_query( /*@unused@*/ char *call_sign, /*@unused@*/ char * UNUSED(path), char *message,char from,int port, /*@unused@*/ int UNUSED(third_party) ) {
+int process_query( char *call_sign, char * UNUSED(path), char *message,char from,int port, int UNUSED(third_party) ) {
     char temp[100];
     int ok = 0;
     float randomize;
@@ -15545,7 +15545,7 @@ int process_query( /*@unused@*/ char *call_sign, /*@unused@*/ char * UNUSED(path
 /*
  *  Status Reports                              [APRS Reference, chapter 16]
  */
-int process_status( /*@unused@*/ char * UNUSED(call_sign), /*@unused@*/ char * UNUSED(path), /*@unused@*/ char * UNUSED(message), /*@unused@*/ char UNUSED(from), /*@unused@*/ int UNUSED(port), /*@unused@*/ int UNUSED(third_party) ) {
+int process_status( char * UNUSED(call_sign), char * UNUSED(path), char * UNUSED(message), char UNUSED(from), int UNUSED(port), int UNUSED(third_party) ) {
 
     //    popup_message(langcode("POPEM00018"),message);  // What is it ???
     return(1);

--- a/src/draw_symbols.c
+++ b/src/draw_symbols.c
@@ -3041,7 +3041,7 @@ void draw_multipoints(long UNUSED(x_long), long UNUSED(y_lat), int numpoints, lo
 
 
 
-void Select_symbol_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Select_symbol_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     int i;
 
@@ -3113,7 +3113,7 @@ void Select_symbol_change_data(Widget widget, XtPointer clientData, XtPointer ca
 
 
 
-void Select_symbol( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Select_symbol( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, my_form2, my_form3, button_cancel,
             frame, frame2, b1;
     int i;

--- a/src/forked_getaddrinfo.c
+++ b/src/forked_getaddrinfo.c
@@ -80,7 +80,7 @@
 /* (see  setjmp below).                                                  */
 /*************************************************************************/
 
-static void host_time_out( /*@unused@*/ int UNUSED(sig) ) {
+static void host_time_out( int UNUSED(sig) ) {
 #ifndef __LCLINT__
     siglongjmp(ret_place,0);
 #endif // __LCLINT__

--- a/src/geocoder_gui.c
+++ b/src/geocoder_gui.c
@@ -85,7 +85,7 @@ void geocoder_gui_init(void)
 
 /**** GEOCODER FIND PLACE ******/
 
-void Geocoder_place_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Geocoder_place_destroy_shell(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -248,7 +248,7 @@ fprintf(stderr,"%s\n%s\n%s\n%s\n%s\n",
 
 
 
-void  Show_dest_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Show_dest_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -264,7 +264,7 @@ void  Show_dest_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData
 
 
 
-void Geocoder_place(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Geocoder_place(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget pane, form, button_ok, button_cancel, sep,
         zip, state, locality, address, map_file, show_dest_toggle;
     Atom delw;

--- a/src/interface_gui.c
+++ b/src/interface_gui.c
@@ -96,7 +96,7 @@ int device_data_type;
 
 
 
-void speed_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void speed_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
 
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
@@ -110,7 +110,7 @@ void speed_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtP
 
 
 
-void style_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void style_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
 
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
@@ -125,7 +125,7 @@ void style_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtP
 
 
 
-void data_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void data_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
 
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
@@ -140,7 +140,7 @@ void data_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPo
 
 
 
-void rain_gauge_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void rain_gauge_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
 
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
@@ -155,7 +155,7 @@ void rain_gauge_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData
 
 
 
-void igate_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void igate_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
 
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
@@ -265,7 +265,7 @@ Widget TNC_relay_digipeat;
 
 
  
-void Config_TNC_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Config_TNC_destroy_shell( Widget UNUSED(widget), XtPointer clientData,  XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -606,7 +606,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Config_TNC_change_data" );
 
 
 
-void Config_TNC( /*@unused@*/ Widget UNUSED(w), int device_type, int config_type, int port) {
+void Config_TNC( Widget UNUSED(w), int device_type, int config_type, int port) {
     static Widget  pane, form, form2, button_ok, button_cancel,
                 frame, frame2, frame3, frame4,
                 setup1, setup3, setup4,
@@ -2003,7 +2003,7 @@ Widget GPS_set_time;
 
 
 
-void Config_GPS_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Config_GPS_destroy_shell( Widget UNUSED(widget), XtPointer clientData,  XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -2100,7 +2100,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Config_GPS_change_data" );
 
 
 
-void Config_GPS( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
+void Config_GPS( Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel,
                 frame, frame2,
                 device, comment, speed_box,
@@ -2588,7 +2588,7 @@ Widget WX_tenths, WX_hundredths, WX_millimeters;
 
 
 
-void Config_WX_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Config_WX_destroy_shell( Widget UNUSED(widget), XtPointer clientData,  XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -2685,7 +2685,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Config_WX_change_data" );
 
 
 
-void Config_WX( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
+void Config_WX( Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel,
                 frame, frame2, frame3, frame4, WX_none,
                 device, comment, speed_box,
@@ -3286,7 +3286,7 @@ Widget NWX_host_reconnect_data;
 
 
 
-void Config_NWX_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Config_NWX_destroy_shell( Widget UNUSED(widget), XtPointer clientData,  XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -3392,7 +3392,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Config_NWX_change_data" );
 
 
 
-void Config_NWX( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
+void Config_NWX( Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, frame3, frame4, WX_none,
                 button_ok, button_cancel,
                 hostn, portn, comment,
@@ -3822,7 +3822,7 @@ Widget NGPS_set_time;
 
 
 
-void Config_NGPS_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Config_NGPS_destroy_shell( Widget UNUSED(widget), XtPointer clientData,  XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -3928,7 +3928,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Config_NGPS_change_data" );
 
 
 
-void Config_NGPS( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
+void Config_NGPS( Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel,
                 hostn, portn, comment,
                 sep;
@@ -4232,7 +4232,7 @@ Widget AX25_relay_digipeat;
 
 
 
-void Config_AX25_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Config_AX25_destroy_shell( Widget UNUSED(widget), XtPointer clientData,  XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -4400,7 +4400,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Config_AX25_change_data" );
 
 
 
-void Config_AX25( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
+void Config_AX25( Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel, frame,
                 devn, comment,
                 proto, proto1, proto2, proto3,
@@ -4920,7 +4920,7 @@ int    Inet_port;
 
 
 
-void Inet_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Inet_destroy_shell( Widget UNUSED(widget), XtPointer clientData,  XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -5045,7 +5045,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Inet_change_data" );
 
 
 
-void Config_Inet( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
+void Config_Inet( Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel,
                 ihost, iport, password,
                 filter, comment, sep;
@@ -5426,7 +5426,7 @@ int    Database_port;
 
 
 
-void Database_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Database_destroy_shell( Widget UNUSED(widget), XtPointer clientData,  XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -5550,7 +5550,7 @@ end_critical_section(&devices_lock, "interface_gui.c:Database_change_data" );
 
 
 
-void Config_Database( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
+void Config_Database( Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel,
                 ihost, iport, password,
                 filter, sep, comment;
@@ -5945,7 +5945,7 @@ Widget Sql_Database_errormessage_data;   // display most recent error message on
 #ifdef HAVE_MYSQL
 // Set the values on the user interface to an appropriate set 
 // of defaults for connecting to a mysql database.
-void Sql_Database_set_defaults_mysql(/*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void Sql_Database_set_defaults_mysql(Widget widget, XtPointer clientData,  XtPointer callData) {
    XmString cb_item;
    //cb_item = XmStringCreateLtoR("MySQL (lat/long)", XmFONTLIST_DEFAULT_TAG);
    cb_item = XmStringCreateLtoR(&xastir_dbms_type[DB_MYSQL][0], XmFONTLIST_DEFAULT_TAG);
@@ -5985,7 +5985,7 @@ void Sql_Database_set_defaults_mysql(/*@unused@*/ Widget widget, XtPointer clien
 #ifdef HAVE_POSTGIS
 // Set the values on the user interface to an appropriate set 
 // of defaults for connecting to a postgresql database.
-void Sql_Database_set_defaults_postgis(/*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void Sql_Database_set_defaults_postgis(Widget widget, XtPointer clientData,  XtPointer callData) {
    XmString cb_item;
    //cb_item = XmStringCreateLtoR("Postgres/Postgis", XmFONTLIST_DEFAULT_TAG);
    cb_item = XmStringCreateLtoR(&xastir_dbms_type[DB_POSTGIS][0], XmFONTLIST_DEFAULT_TAG);
@@ -6019,7 +6019,7 @@ void Sql_Database_set_defaults_postgis(/*@unused@*/ Widget widget, XtPointer cli
 
 
 // Destroy the dialog used to set properties for a SQL database interface.
-void Sql_Database_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData,  /*@unused@*/ XtPointer callData) {
+void Sql_Database_destroy_shell( Widget widget, XtPointer clientData,  XtPointer callData) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -6242,7 +6242,7 @@ void sddd_menuCallback(Widget widget, XtPointer ptr, XtPointer callData) {
 /* dialog to obtain connection parameters for a SQL server (MySQL/Postgresql)
  * database for spatialy enabled database support 
  */
-void Config_sql_Database( /*@unused@*/ Widget w, int config_type, int port) {
+void Config_sql_Database( Widget w, int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel, label_dbms, label_schema_type,
                 ihost, iport, password, unix_socket, error_message,
                 sep, comment, username, schema_name;
@@ -7023,7 +7023,7 @@ int    AGWPE_port;
 
 
 
-void AGWPE_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void AGWPE_destroy_shell( Widget UNUSED(widget), XtPointer clientData,  XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -7212,7 +7212,7 @@ end_critical_section(&devices_lock, "interface_gui.c:AGWPE_change_data" );
 
 
 
-void Config_AGWPE( /*@unused@*/ Widget UNUSED(w), int config_type, int port) {
+void Config_AGWPE( Widget UNUSED(w), int config_type, int port) {
     static Widget  pane, form, button_ok, button_cancel,
                 ihost, iport, password, sep,
                 igate_box, igate_o_0, igate_o_1, igate_o_2,
@@ -7909,7 +7909,7 @@ int are_shells_up(void) {
 
 
 
-void Choose_interface_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Choose_interface_destroy_shell( Widget UNUSED(widget), XtPointer clientData,  XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     if (are_shells_up()==0) {
         XtPopdown(shell);
@@ -8184,7 +8184,7 @@ void update_interface_list(void) {
 
 
 
-void interface_setup(Widget w, XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void interface_setup(Widget w, XtPointer clientData,  XtPointer UNUSED(callData) ) {
     char *what = (char *)clientData;
     int x,i,do_w;
     char *temp;
@@ -8363,7 +8363,7 @@ end_critical_section(&devices_lock, "interface_gui.c:interface_setup" );
 //      1 = Delete
 //      2 = Properties
 //
-void interface_option(Widget w, XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void interface_option(Widget w, XtPointer clientData,  XtPointer UNUSED(callData) ) {
     Widget pane, form, label, button_add, button_cancel;
     char *what = (char *)clientData;
     int i,x,n,do_w;
@@ -8738,7 +8738,7 @@ extern void shutdown_all_active_or_defined_port(int port);
 
 
 
-void start_stop_interface( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void start_stop_interface( Widget UNUSED(widget), XtPointer clientData,  XtPointer UNUSED(callData) ) {
     char *which = (char *)clientData;
     int do_w;
     char temp2[50];
@@ -8808,7 +8808,7 @@ void start_stop_interface( /*@unused@*/ Widget UNUSED(widget), XtPointer clientD
 
 
 
-void start_stop_all_interfaces( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void start_stop_all_interfaces( Widget UNUSED(widget), XtPointer clientData,  XtPointer UNUSED(callData) ) {
     char *which = (char *)clientData;   // Whether to start or stop the interfaces
     int do_w;
 
@@ -8840,7 +8840,7 @@ void start_stop_all_interfaces( /*@unused@*/ Widget UNUSED(widget), XtPointer cl
 
 
 
-void Control_interface_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Control_interface_destroy_shell( Widget UNUSED(widget), XtPointer clientData,  XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -8857,7 +8857,7 @@ end_critical_section(&control_interface_dialog_lock, "interface_gui.c:Control_in
 
 
 
-void control_interface( /*@unused@*/ Widget UNUSED(w),  /*@unused@*/ XtPointer UNUSED(clientData),  /*@unused@*/ XtPointer UNUSED(callData) ) {
+void control_interface( Widget UNUSED(w),  XtPointer UNUSED(clientData),  XtPointer UNUSED(callData) ) {
     static Widget rowcol, form, button_start, button_stop, button_start_all, button_stop_all, button_cancel;
     static Widget button_add, button_delete, button_properties;
     Atom delw;

--- a/src/list_gui.c
+++ b/src/list_gui.c
@@ -376,7 +376,7 @@ int stations_types(int type) {
 
 
 
-void station_list_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void station_list_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     int type;
     int i;
 
@@ -405,7 +405,7 @@ void station_list_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer c
  * Callback for station icon in list.
  * Calls a function to center the map on the selected station from the list.
  */
-void Call_locate_station(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Call_locate_station(Widget w, XtPointer clientData, XtPointer UNUSED(callData) ) {
     if (clientData != NULL && strlen(clientData) > 0) { 
        locate_station(w, clientData, 1,1,1); 
     } 
@@ -417,7 +417,7 @@ void Call_locate_station(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@
  * *** This callback is not linked to a control on list yet. ***
  * Invokes the station information dialog for the selected station from the list.
  */
-void Call_Station_data(/*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Call_Station_data(Widget w, XtPointer clientData, XtPointer UNUSED(callData) ) {
     if (clientData != NULL && strlen(clientData) > 0) { 
        Station_data(w, clientData, NULL); 
     } 
@@ -1057,7 +1057,7 @@ void update_station_scroll_list(void) {         // called from UpdateTime() [mai
 
 
 
-void dragCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void dragCallback(Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     int i;
 
     XmScrollBarCallbackStruct *cbs = (XmScrollBarCallbackStruct *)callData;
@@ -1073,7 +1073,7 @@ void dragCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer
 
 
 
-void decrementCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void decrementCallback(Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     int i;
 
     XmScrollBarCallbackStruct *cbs = (XmScrollBarCallbackStruct *)callData;
@@ -1085,7 +1085,7 @@ void decrementCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPo
 
 
 
-void incrementCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void incrementCallback(Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     int i;
 
     XmScrollBarCallbackStruct *cbs = (XmScrollBarCallbackStruct *)callData;
@@ -1097,7 +1097,7 @@ void incrementCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPo
 
 
 
-void pageDecrementCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void pageDecrementCallback(Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     int i;
 
     XmScrollBarCallbackStruct *cbs = (XmScrollBarCallbackStruct *)callData;
@@ -1109,7 +1109,7 @@ void pageDecrementCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, 
 
 
 
-void pageIncrementCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void pageIncrementCallback(Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     int i;
 
     XmScrollBarCallbackStruct *cbs = (XmScrollBarCallbackStruct *)callData;
@@ -1152,7 +1152,7 @@ void mouseScrollHandler(Widget UNUSED(w), XtPointer clientData, XButtonEvent* ev
 
 
 
-void valueChangedCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void valueChangedCallback(Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     int i;
 
     XmScrollBarCallbackStruct *cbs = (XmScrollBarCallbackStruct *)callData;
@@ -1167,7 +1167,7 @@ void valueChangedCallback(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, X
 /*
  *  Setup the various list layouts
  */
-void Station_List(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Station_List(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callData) ) {
     int i;
     Widget pane, form, win_list, form2, button_close;
     Widget numl,call,sep,sep2;

--- a/src/locate_gui.c
+++ b/src/locate_gui.c
@@ -102,7 +102,7 @@ void locate_gui_init(void)
 
 /**** LOCATE STATION ******/
 
-void Locate_station_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Locate_station_destroy_shell(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -296,7 +296,7 @@ void Locate_station_now(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointe
 // Here we pass in a 1 in callData if it's an emergency locate,
 // for when we've received a Mic-E emergency packet.
 //
-void Locate_station(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), XtPointer callData) {
+void Locate_station(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer callData) {
     static Widget pane, form, button_locate, button_cancel, call,
         button_lookup, sep;
     Atom delw;
@@ -576,9 +576,9 @@ end_critical_section(&locate_place_chooser_lock, "locate_gui.c:Locate_place_choo
 
 
 
-void Locate_place_chooser(/*@unused@*/ Widget UNUSED(widget),
+void Locate_place_chooser(Widget UNUSED(widget),
         XtPointer UNUSED(clientData),
-        /*@unused@*/ XtPointer UNUSED(callData) ) {
+        XtPointer UNUSED(callData) ) {
 
     Widget pane, form, button_ok, button_cancel;
     Arg al[50];
@@ -723,7 +723,7 @@ end_critical_section(&locate_place_chooser_lock, "locate_gui.c:Locate_place_choo
 
 /**** LOCATE PLACE ******/
 
-void Locate_place_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Locate_place_destroy_shell(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -866,7 +866,7 @@ clear_dangerous();
 
 
 
-void Locate_place(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Locate_place(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget pane, form, button_ok, button_cancel, sep,
         place, state, county, quad, place_type, gnis_file;
     Atom delw;

--- a/src/location_gui.c
+++ b/src/location_gui.c
@@ -64,7 +64,7 @@ void location_gui_init(void)
 /************************************************/
 /* button fuction for last location             */
 /************************************************/
-void Last_location(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Last_location(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     map_pos_last_position();
 }
 
@@ -75,7 +75,7 @@ void Last_location(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(
 /************************************************/
 /* manage jump locations                        */
 /************************************************/
-void location_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void location_destroy_shell(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -95,7 +95,7 @@ end_critical_section(&location_dialog_lock, "location_gui.c:location_destroy_she
 /************************************************/
 /* jump to chosen location/zoom                 */
 /************************************************/
-void location_view(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void location_view(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i,x;
     char *location;
     XmString *list;
@@ -202,7 +202,7 @@ void jump_sort(void) {
 /************************************************/
 /* delete location/zoom                         */
 /************************************************/
-void location_delete(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void location_delete(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     int i,x;
     char *location;
     XmString *list;
@@ -297,7 +297,7 @@ void location_delete(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSE
 /************************************************/
 /* add location/zoom                            */
 /************************************************/
-void location_add(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void location_add(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callData) ) {
     char name[100];
     char s_long[20];
     char s_lat[20];
@@ -377,7 +377,7 @@ void location_add(/*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused
 /************************************************/
 /* manage jump locations                        */
 /************************************************/
-void Jump_location(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Jump_location(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane,form, button_ok, button_add, button_delete, button_cancel, locdata, location_name;
     int n;
     Arg al[50];           /* Arg List */

--- a/src/main.c
+++ b/src/main.c
@@ -418,7 +418,7 @@ Widget grid_on, grid_off;
 static void Grid_toggle( Widget w, XtPointer clientData, XtPointer calldata);
 int long_lat_grid;              // Switch for Map Lat and Long grid display
 
-void Map_border_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData);
+void Map_border_toggle( Widget w, XtPointer clientData, XtPointer callData);
 int draw_labeled_grid_border = FALSE;   // Toggle labeled border around map.
 
 
@@ -1210,7 +1210,7 @@ int moving_object = 0;
 
 
 
-void Smart_Beacon_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Smart_Beacon_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -1968,7 +1968,7 @@ void check_nws_weather_symbol(void) {
 
 
 
-void Coordinate_calc_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Coordinate_calc_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -3631,7 +3631,7 @@ void redraw_symbols(Widget w) {
 
 
 
-static void TrackMouse( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XEvent *event, /*@unused@*/ Boolean * UNUSED(flag) ) {
+static void TrackMouse( Widget UNUSED(w), XtPointer clientData, XEvent *event, Boolean * UNUSED(flag) ) {
     char my_text[70];
     char str_lat[20];
     char str_long[20];
@@ -3779,7 +3779,7 @@ static void TrackMouse( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XEv
 
 
 
-static void ClearTrackMouse( /*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(clientData), /*@unused@*/ XEvent * UNUSED(event), /*@unused@*/ Boolean * UNUSED(flag) ) {
+static void ClearTrackMouse( Widget UNUSED(w), XtPointer UNUSED(clientData), XEvent * UNUSED(event), Boolean * UNUSED(flag) ) {
 // N7TAP: In my opinion, it is handy to have the cursor position still displayed
 //        in the xastir window when I switch to another (like to write it down...)
 //    Widget textarea = (Widget) clientData;
@@ -3794,7 +3794,7 @@ static void ClearTrackMouse( /*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(cli
 /*
  *  Delete tracks of all stations
  */
-void Tracks_All_Clear( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Tracks_All_Clear( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     DataRow *p_station;
 
     p_station = n_first;
@@ -3836,7 +3836,7 @@ void clear_all_tactical(void) {
  *  Clear all tactical callsigns from the station records.  Comment
  *  out the active records in the log file.
  */
-void Tactical_Callsign_Clear( /*@unused@*/ Widget UNUSED(w) , /*@unused@*/ XtPointer UNUSED(clientData) , /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Tactical_Callsign_Clear( Widget UNUSED(w) , XtPointer UNUSED(clientData) , XtPointer UNUSED(callData) ) {
     char file[200];
     char file_temp[200];
     FILE *f;
@@ -3903,7 +3903,7 @@ void Tactical_Callsign_Clear( /*@unused@*/ Widget UNUSED(w) , /*@unused@*/ XtPoi
 /*
  *  Clear out tactical callsign log file
  */
-void Tactical_Callsign_History_Clear( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Tactical_Callsign_History_Clear( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     char file[MAX_VALUE];
     FILE *f;
 
@@ -4073,7 +4073,7 @@ void display_zoom_status(void) {
 
 
 
-void Change_debug_level_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Change_debug_level_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -4268,7 +4268,7 @@ void Change_Debug_Level(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointe
 
 
 #if !defined(NO_GRAPHICS) && defined(HAVE_MAGICK)
-void Gamma_adjust_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Gamma_adjust_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -4481,7 +4481,7 @@ void Load_station_font(void) {
 
 
 // chose map label font
-void Map_font_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Map_font_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
 
     xfontsel_query = 0;
@@ -5079,7 +5079,7 @@ void menu_link_for_mouse_menu(Widget UNUSED(w), XtPointer UNUSED(clientData), Xt
 
 
 
-void store_all_kml_callback(/*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
+void store_all_kml_callback(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     export_trail_as_kml(NULL);
     last_kmlsnapshot = sec_now();
 }
@@ -5087,7 +5087,7 @@ void store_all_kml_callback(/*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(clie
 
 
 
-void KML_Snapshots_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void KML_Snapshots_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -5106,7 +5106,7 @@ void KML_Snapshots_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, 
 
 
 
-void Snapshots_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Snapshots_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -5153,7 +5153,7 @@ Widget pan_up_menu, pan_down_menu,
 
 
  
-void create_appshell( /*@unused@*/ Display *display, char * UNUSED(app_name), /*@unused@*/ int UNUSED(app_argc), char ** UNUSED(app_argv) ) {
+void create_appshell( Display *display, char * UNUSED(app_name), int UNUSED(app_argc), char ** UNUSED(app_argv) ) {
     Pixmap icon_pixmap;
     Atom WM_DELETE_WINDOW;
     Widget children[9];         /* Children to manage */
@@ -10061,7 +10061,7 @@ void create_gc(Widget w) {
 // return to X.  If it did any map drawing, we'd make it
 // interruptable.
 //
-void da_expose(Widget w, /*@unused@*/ XtPointer UNUSED(client_data), XtPointer call_data) {
+void da_expose(Widget w, XtPointer UNUSED(client_data), XtPointer call_data) {
     Dimension width, height, margin_width, margin_height;
     XmDrawingAreaCallbackStruct *db = (XmDrawingAreaCallbackStruct *)call_data;
     XExposeEvent *event = (XExposeEvent *) db->event;
@@ -10191,7 +10191,7 @@ void da_resize_execute(Widget w) {
 // the interrupt_drawing_now flag periodically while doing the
 // resize drawing.
 //
-void da_resize(Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(client_data), /*@unused@*/ XtPointer UNUSED(call_data) ) {
+void da_resize(Widget UNUSED(w), XtPointer UNUSED(client_data), XtPointer UNUSED(call_data) ) {
 
     // Set the interrupt_drawing_now flag
     interrupt_drawing_now++;
@@ -11283,7 +11283,7 @@ static int last_alert_on_screen = -1;
 
 // This is the periodic process that updates the maps/symbols/tracks.
 // At the end of the function it schedules itself to be run again.
-void UpdateTime( XtPointer clientData, /*@unused@*/ XtIntervalId UNUSED(id) ) {
+void UpdateTime( XtPointer clientData, XtIntervalId UNUSED(id) ) {
     Widget w = (Widget) clientData;
     time_t nexttime;
 //  int do_time;
@@ -12853,7 +12853,7 @@ static int pid_file_check(int hold){
 
 
 /* handle segfault signal */
-void segfault(/*@unused@*/ int UNUSED(sig) ) {
+void segfault(int UNUSED(sig) ) {
     fprintf(stderr, "Caught Segfault! Xastir will terminate\n");
     fprintf(stderr, "Previous incoming line was: %s\n", incoming_data_copy_previous);
     fprintf(stderr, "    Last incoming line was: %s\n", incoming_data_copy);
@@ -13259,7 +13259,7 @@ void display_zoom_image(int recenter) {
 
 
 
-void Zoom_in( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Zoom_in( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13277,7 +13277,7 @@ void Zoom_in( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clien
 
 
 
-void Zoom_in_no_pan( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Zoom_in_no_pan( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up && !map_lock_pan_zoom) {
@@ -13295,7 +13295,7 @@ void Zoom_in_no_pan( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSE
 
 
 
-void Zoom_out(  /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Zoom_out(  Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13314,7 +13314,7 @@ void Zoom_out(  /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(cli
 
 
 
-void Zoom_out_no_pan( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Zoom_out_no_pan( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up && !map_lock_pan_zoom) {
@@ -13333,7 +13333,7 @@ void Zoom_out_no_pan( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUS
 
 
 
-void Custom_Zoom_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Custom_Zoom_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -13350,7 +13350,7 @@ static Widget custom_zoom_zoom_level;
 
 
 
-void Custom_Zoom_do_it( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Custom_Zoom_do_it( Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     char *temp_ptr;
 
     temp_ptr = XmTextFieldGetString(custom_zoom_zoom_level);
@@ -13368,7 +13368,7 @@ void Custom_Zoom_do_it( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(cli
 // Function to bring up a dialog.  User can then select zoom for the
 // display directly.
 //
-void Custom_Zoom( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Custom_Zoom( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     static Widget  pane,form, button_ok, button_cancel, zoom_label;
 //    Arg al[50];           /* Arg List */
 //    unsigned int ac = 0;           /* Arg Count */
@@ -13517,7 +13517,7 @@ void Custom_Zoom( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(c
 
 
 
-void Zoom_level( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer calldata) {
+void Zoom_level( Widget w, XtPointer clientData, XtPointer calldata) {
     Dimension width, height;
     int level;
 
@@ -13615,7 +13615,7 @@ void Zoom_level( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPoi
 
 
 
-void Pan_ctr( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Pan_ctr( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13631,7 +13631,7 @@ void Pan_ctr( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clien
 
 
 
-void Pan_up( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Pan_up( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13647,7 +13647,7 @@ void Pan_up( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(client
 
 
 
-void Pan_up_less( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Pan_up_less( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up && !map_lock_pan_zoom) {
@@ -13663,7 +13663,7 @@ void Pan_up_less( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(c
 
 
 
-void Pan_down( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Pan_down( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13679,7 +13679,7 @@ void Pan_down( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clie
 
 
 
-void Pan_down_less( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Pan_down_less( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up && !map_lock_pan_zoom) {
@@ -13695,7 +13695,7 @@ void Pan_down_less( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED
 
 
 
-void Pan_left( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Pan_left( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13711,7 +13711,7 @@ void Pan_left( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clie
 
 
 
-void Pan_left_less( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Pan_left_less( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up && !map_lock_pan_zoom) {
@@ -13727,7 +13727,7 @@ void Pan_left_less( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED
 
 
 
-void Pan_right( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Pan_right( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up) {
@@ -13743,7 +13743,7 @@ void Pan_right( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(cli
 
 
 
-void Pan_right_less( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Pan_right_less( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     Dimension width, height;
 
     if(display_up && !map_lock_pan_zoom) {
@@ -13759,7 +13759,7 @@ void Pan_right_less( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSE
 
 
 
-void Center_Zoom_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData)) {
+void Center_Zoom_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData)) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -13778,7 +13778,7 @@ static Widget center_zoom_latitude,
 
 
 
-void Center_Zoom_do_it( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Center_Zoom_do_it( Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     unsigned long x, y;
     char *temp_ptr;
 
@@ -13811,7 +13811,7 @@ void Center_Zoom_do_it( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(cli
 
 
 
-void Go_Home( Widget w, /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Go_Home( Widget w, XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     DataRow *p_station;
 
     if (!map_lock_pan_zoom) {
@@ -13832,7 +13832,7 @@ void Go_Home( Widget w, /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ 
 // could input lat/long in any of the supported formats.  Right now
 // it is DD.DDDD format only.
 //
-void Center_Zoom( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer calldata) {
+void Center_Zoom( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer calldata) {
     static Widget  pane,form, button_ok, button_cancel,
             lat_label, lon_label, zoom_label;
 //    Arg al[50];           /* Arg List */
@@ -14213,7 +14213,7 @@ void Center_Zoom( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(c
 
 
 
-void SetMyPosition( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void SetMyPosition( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     
     Dimension width, height;
     long my_new_latl, my_new_lonl;
@@ -14251,7 +14251,7 @@ void SetMyPosition( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED
 
 
 
-void Window_Quit( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(client), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Window_Quit( Widget UNUSED(w), XtPointer UNUSED(client), XtPointer UNUSED(calldata) ) {
     quit(0);
 }
 
@@ -14259,7 +14259,7 @@ void Window_Quit( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(c
 
 
 
-void Menu_Quit( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Menu_Quit( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     quit(0);
 }
 
@@ -14267,7 +14267,7 @@ void Menu_Quit( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(cli
 
 
 
-void save_state( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(client), /*@unused@*/ XtPointer calldata) {
+void save_state( Widget UNUSED(w), XtPointer UNUSED(client), XtPointer calldata) {
     if (((XtCheckpointToken)calldata)->shutdown) {
     save_data();
 
@@ -14284,7 +14284,7 @@ void save_state( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(cl
 
 
 // Turn on or off map border, callback from map_border_button.
-void Map_border_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer callData) {
+void Map_border_toggle( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
     
     if(state->set)
@@ -14297,7 +14297,7 @@ void Map_border_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(clientDa
 
 
 
-void Grid_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Grid_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14333,7 +14333,7 @@ void Grid_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer
 
 // Callback from menu buttons that allow user to turn on or off the 
 // global display of CAD objects and their metadata on the map.
-void  CAD_draw_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  CAD_draw_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14364,7 +14364,7 @@ void  CAD_draw_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,
 
 
 
-void  Map_lock_pan_zoom_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Map_lock_pan_zoom_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14392,7 +14392,7 @@ void  Map_lock_pan_zoom_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer cl
 
 
 
-void  Map_disable_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Map_disable_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14414,7 +14414,7 @@ void  Map_disable_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientDa
 
 
 
-void  Map_auto_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Map_auto_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14450,7 +14450,7 @@ void  Map_auto_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,
 
 
 
-void  Map_auto_skip_raster_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Map_auto_skip_raster_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14477,7 +14477,7 @@ void  Map_auto_skip_raster_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer
 
 
 
-void  Map_levels_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Map_levels_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14507,7 +14507,7 @@ void  Map_levels_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientDat
 
 
 
-void  Map_labels_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Map_labels_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14532,7 +14532,7 @@ void  Map_labels_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientDat
 
 
 
-void  Map_fill_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Map_fill_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14562,7 +14562,7 @@ void  Map_fill_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,
 
 
 
-void Map_background( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Map_background( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     int bgcolor;
     int i;
 
@@ -14632,7 +14632,7 @@ void Raster_intensity(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(c
 
 
 
-void Map_station_label( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Map_station_label( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     int style;
 
     style=atoi((char *)clientData);
@@ -14658,7 +14658,7 @@ void Map_station_label( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@
 
 
 
-void Map_icon_outline( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Map_icon_outline( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     int style;
 
     style=atoi((char *)clientData);
@@ -14697,7 +14697,7 @@ void Map_icon_outline( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@u
 
 
 
-void  Map_wx_alerts_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Map_wx_alerts_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -14725,7 +14725,7 @@ void  Map_wx_alerts_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer client
 
 
 
-void  Index_maps_on_startup_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer callData) {
+void  Index_maps_on_startup_toggle( Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
     if(state->set)
@@ -14738,7 +14738,7 @@ void  Index_maps_on_startup_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointe
 
 
 
-void TNC_Transmit_now( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void TNC_Transmit_now( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) ) {
     transmit_now = 1;              /* toggle transmission of station now*/
 }
 
@@ -15184,7 +15184,7 @@ void process_RINO_waypoints(void) {
 
 
  
-void GPS_operations_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void GPS_operations_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -15362,7 +15362,7 @@ void GPS_operations_cancel(Widget widget, XtPointer clientData, XtPointer callDa
 
 
 
-void  GPS_operations_color_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  GPS_operations_color_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16168,7 +16168,7 @@ static void* gps_transfer_thread(void *arg) {
 // transfer operation, to make sure we're not called again until the
 // first operation is over.
 //
-void GPS_operations( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void GPS_operations( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callData) ) {
     pthread_t gps_operations_thread;
     int parameter;
 
@@ -16251,7 +16251,7 @@ void Set_Log_Indicator(void) {
 
 
 
-void  TNC_Logging_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  TNC_Logging_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16266,7 +16266,7 @@ void  TNC_Logging_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientDa
 
 
 
-void Net_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Net_Logging_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16281,7 +16281,7 @@ void Net_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, Xt
 
 
 
-void IGate_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void IGate_Logging_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16296,7 +16296,7 @@ void IGate_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, 
 
 
 
-void Message_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Message_Logging_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16311,7 +16311,7 @@ void Message_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData
 
 
 
-void WX_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void WX_Logging_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16326,7 +16326,7 @@ void WX_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtP
 
 
 
-void WX_Alert_Logging_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void WX_Alert_Logging_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16489,7 +16489,7 @@ void set_sensitive_display(int sensitive)
 
 
 
-void Select_none_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_none_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16520,7 +16520,7 @@ void Select_none_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, Xt
 
 
 
-void Select_mine_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_mine_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16546,7 +16546,7 @@ void Select_mine_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, Xt
 
 
 
-void Select_tnc_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_tnc_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16579,7 +16579,7 @@ void Select_tnc_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtP
 
 
 
-void Select_direct_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_direct_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16605,7 +16605,7 @@ void Select_direct_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, 
 
 
 
-void Select_via_digi_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_via_digi_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16631,7 +16631,7 @@ void Select_via_digi_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData
 
 
 
-void Select_net_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_net_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16656,7 +16656,7 @@ void Select_net_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtP
 
 
 
-void Select_tactical_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_tactical_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16681,7 +16681,7 @@ void Select_tactical_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData
 
 
 
-void Select_old_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_old_data_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16697,7 +16697,7 @@ void Select_old_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData
 
 
 
-void Select_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_stations_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16725,7 +16725,7 @@ void Select_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData
 
 
 
-void Select_fixed_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_fixed_stations_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16741,7 +16741,7 @@ void Select_fixed_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clie
 
 
 
-void Select_moving_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_moving_stations_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16757,7 +16757,7 @@ void Select_moving_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer cli
 
 
 
-void Select_weather_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_weather_stations_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16777,7 +16777,7 @@ void Select_weather_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer cl
 
 
 
-void Select_CWOP_wx_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_CWOP_wx_stations_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16793,7 +16793,7 @@ void Select_CWOP_wx_stations_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer cl
 
 
 
-void Select_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_objects_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16821,7 +16821,7 @@ void Select_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData,
 
 
 
-void Select_weather_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_weather_objects_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16837,7 +16837,7 @@ void Select_weather_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer cli
 
 
 
-void Select_gauge_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_gauge_objects_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16850,7 +16850,7 @@ void Select_gauge_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clien
 }
 
 
-void Select_aircraft_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_aircraft_objects_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16862,7 +16862,7 @@ void Select_aircraft_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer cl
     redraw_on_new_data = 2;     // Immediate screen update
 }
 
-void Select_vessel_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_vessel_objects_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16874,7 +16874,7 @@ void Select_vessel_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clie
     redraw_on_new_data = 2;     // Immediate screen update
 }
 
-void Select_other_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Select_other_objects_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16892,7 +16892,7 @@ void Select_other_objects_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clien
 
 // Display Menu button callbacks
 
-void Display_callsign_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_callsign_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16912,7 +16912,7 @@ void Display_callsign_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientDat
 
 
 
-void Display_label_all_trackpoints_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_label_all_trackpoints_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16928,7 +16928,7 @@ void Display_label_all_trackpoints_toggle( /*@unused@*/ Widget UNUSED(w), XtPoin
 
 
 
-void Display_symbol_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_symbol_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16948,7 +16948,7 @@ void Display_symbol_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData,
 
 
 
-void Display_symbol_rotate_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_symbol_rotate_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16964,7 +16964,7 @@ void Display_symbol_rotate_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clie
 
 
 
-void Display_trail_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_trail_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16980,7 +16980,7 @@ void Display_trail_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, 
 
 
 
-void Display_course_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_course_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -16996,7 +16996,7 @@ void Display_course_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData,
 
 
 
-void Display_speed_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_speed_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17016,7 +17016,7 @@ void Display_speed_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, 
 
 
 
-void Display_speed_short_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_speed_short_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17032,7 +17032,7 @@ void Display_speed_short_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer client
 
 
 
-void Display_altitude_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_altitude_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17048,7 +17048,7 @@ void Display_altitude_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientDat
 
 
 
-void Display_weather_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_weather_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17072,7 +17072,7 @@ void Display_weather_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData
 
 
 
-void Display_weather_text_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_weather_text_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17092,7 +17092,7 @@ void Display_weather_text_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clien
 
 
 
-void Display_temperature_only_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_temperature_only_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17108,7 +17108,7 @@ void Display_temperature_only_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer c
 
 
 
-void Display_wind_barb_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_wind_barb_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17124,7 +17124,7 @@ void Display_wind_barb_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientDa
 
 
 
-void Display_aloha_circle_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_aloha_circle_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17140,7 +17140,7 @@ void Display_aloha_circle_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clien
 
 
 
-void Display_ambiguity_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_ambiguity_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17156,7 +17156,7 @@ void Display_ambiguity_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientDa
 
 
 
-void Display_phg_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_phg_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17178,7 +17178,7 @@ void Display_phg_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, Xt
 
 
 
-void Display_default_phg_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_default_phg_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17194,7 +17194,7 @@ void Display_default_phg_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer client
 
 
 
-void Display_phg_of_moving_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_phg_of_moving_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17210,7 +17210,7 @@ void Display_phg_of_moving_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clie
 
 
 
-void Display_df_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_df_data_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17227,7 +17227,7 @@ void Display_df_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData
     redraw_on_new_data = 2;     // Immediate screen update
 }
 
-void Display_df_beamwidth_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_df_beamwidth_data_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17239,7 +17239,7 @@ void Display_df_beamwidth_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer 
     redraw_on_new_data = 2;     // Immediate screen update
 }
 
-void Display_df_bearing_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_df_bearing_data_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17255,7 +17255,7 @@ void Display_df_bearing_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer cl
 
 
 
-void Display_dr_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_dr_data_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17279,7 +17279,7 @@ void Display_dr_data_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData
 
 
 
-void Display_dr_arc_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_dr_arc_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17295,7 +17295,7 @@ void Display_dr_arc_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData,
 
 
 
-void Display_dr_course_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_dr_course_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17311,7 +17311,7 @@ void Display_dr_course_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientDa
 
 
 
-void Display_dr_symbol_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_dr_symbol_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17327,7 +17327,7 @@ void Display_dr_symbol_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientDa
 
 
 
-void Display_dist_bearing_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_dist_bearing_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17343,7 +17343,7 @@ void Display_dist_bearing_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clien
 
 
 
-void Display_last_heard_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Display_last_heard_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17362,7 +17362,7 @@ void Display_last_heard_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientD
 /*
  *  Toggle unit system (button callbacks)
  */
-void  Units_choice_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Units_choice_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17383,7 +17383,7 @@ void  Units_choice_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientD
 /*
  *  Toggle dist/bearing status (button callbacks)
  */
-void  Dbstatus_choice_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Dbstatus_choice_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17452,7 +17452,7 @@ void update_units(void) {
 
 
 
-void  Auto_msg_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Auto_msg_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17466,7 +17466,7 @@ void  Auto_msg_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,
 
 
 
-void  Satellite_msg_ack_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Satellite_msg_ack_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17480,7 +17480,7 @@ void  Satellite_msg_ack_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer cl
 
 
 
-void  Transmit_disable_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Transmit_disable_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17502,7 +17502,7 @@ void  Transmit_disable_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer cli
 
 
 
-void  Posit_tx_disable_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Posit_tx_disable_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17516,7 +17516,7 @@ void  Posit_tx_disable_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer cli
 
 
 
-void  Object_tx_disable_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Object_tx_disable_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17530,7 +17530,7 @@ void  Object_tx_disable_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer cl
 
 
 
-void  Emergency_beacon_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Emergency_beacon_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17554,7 +17554,7 @@ void  Emergency_beacon_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer cli
 
 
 
-void  Server_port_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Server_port_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17581,7 +17581,7 @@ void  Server_port_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientDa
 
 
 
-void Help_About( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Help_About( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     Widget d;
     Widget child;
     XmString xms, xa, xb;
@@ -17709,7 +17709,7 @@ Widget GetTopShell(Widget w) {
 /*********************** Display incoming data*******************************/
 /****************************************************************************/
 
-void Display_data_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Display_data_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -17720,7 +17720,7 @@ void Display_data_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer c
 
 
 
-void  Display_packet_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Display_packet_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -17739,7 +17739,7 @@ void  Display_packet_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clien
 // Turn on or off "Station Capabilities", callback for capabilities
 // button.
 //
-void Capabilities_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer callData) {
+void Capabilities_toggle( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
     if(state->set)
@@ -17754,7 +17754,7 @@ void Capabilities_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(client
 
 // Turn on or off "Mine Only"
 //
-void Display_packet_mine_only_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer callData) {
+void Display_packet_mine_only_toggle( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
     if(state->set)
@@ -17767,7 +17767,7 @@ void Display_packet_mine_only_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer U
 
 
 
-void Display_data( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Display_data( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     Widget pane, my_form, button_close, option_box, tnc_data,
         net_data, tnc_net_data, capabilities_button,
         mine_only_button;
@@ -18019,7 +18019,7 @@ void Display_data( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(
 /****************************** Help menu ***********************************/
 /****************************************************************************/
 
-void help_view_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void help_view_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -18030,7 +18030,7 @@ void help_view_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clie
 
 
 
-void help_index_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void help_index_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
 
     if (help_view_dialog)
@@ -18047,7 +18047,7 @@ void help_index_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer cli
 
 
 
-void help_view( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void help_view( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     Widget pane, my_form, button_close,help_text;
     int i;
     Position x, y;
@@ -18212,7 +18212,7 @@ void help_view( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(cli
 
 
 
-void Help_Index( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Help_Index( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel;
     int n;
     char temp[600];
@@ -18360,7 +18360,7 @@ void Help_Index( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(cl
 /************************** Clear stations *******************************/
 /*************************************************************************/
 
-void Stations_Clear( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Stations_Clear( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
 
     delete_all_stations();
 
@@ -18383,7 +18383,7 @@ void Stations_Clear( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSE
 /*************************************************************************/
 
 // Destroys the Map Properties dialog
-void map_properties_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void map_properties_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -19465,7 +19465,7 @@ void map_properties_min_zoom_change(Widget UNUSED(widget), XtPointer UNUSED(clie
 // in-memory list and fetch it from file again.  OK would write the
 // in-memory list to disk.
 //
-void map_properties( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void map_properties( Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
 //    int i;
 //    int x;
 //    char *temp;
@@ -19905,7 +19905,7 @@ void map_properties( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(client
 /*************************************************************************/
 
 // Destroys the Map Chooser dialog
-void map_chooser_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void map_chooser_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -20653,7 +20653,7 @@ void map_chooser_fill_in (void) {
 
 ///////////////////////////////////////  Configure DRG Dialog //////////////////////////////////////////////
 #if defined(HAVE_LIBGEOTIFF)
-void Configure_DRG_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Configure_DRG_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
 
     if (configure_DRG_dialog) {
@@ -20810,7 +20810,7 @@ void Configure_DRG_none(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtP
 
 
 
-void Config_DRG( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Config_DRG( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget DRG_pane, DRG_form, button_ok, button_cancel,
         DRG_label1, sep1, sep2, button_all, button_none;
 
@@ -21329,7 +21329,7 @@ void Config_DRG( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(cl
 
 
 
-void Expand_Dirs_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer callData) {
+void Expand_Dirs_toggle( Widget w, XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -21350,7 +21350,7 @@ void Expand_Dirs_toggle( /*@unused@*/ Widget w, XtPointer clientData, XtPointer 
 
 
 
-void Map_chooser( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Map_chooser( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_clear, button_V,
             button_C, button_F, button_O,
             rowcol, expand_dirs_button, button_properties,
@@ -21661,7 +21661,7 @@ void Map_chooser( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(c
 
 /****** Read in file **********/
 
-void read_file_selection_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void read_file_selection_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtDestroyWidget(shell);
     read_selection_dialog = (Widget)NULL;
@@ -21703,7 +21703,7 @@ void read_file_selection_now(Widget w, XtPointer clientData, XtPointer callData)
 
 
 
-void Read_File_Selection( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Read_File_Selection( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     Arg al[50];                    /* Arg List */
     register unsigned int ac = 0;           /* Arg Count */
     Widget fs;
@@ -21875,7 +21875,7 @@ void Test(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callD
 
 /****** Save Config data **********/
 
-void Save_Config( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Save_Config( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     save_data();
 }
 
@@ -21886,7 +21886,7 @@ void Save_Config( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(c
 ///////////////////////////////////   Configure Defaults Dialog   //////////////////////////////////
 
 
-void Configure_defaults_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Configure_defaults_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -22035,7 +22035,7 @@ void Configure_defaults_change_data(Widget widget, XtPointer clientData, XtPoint
 
 
 /* Station_transmit type radio buttons */
-void station_type_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void station_type_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -22051,7 +22051,7 @@ void station_type_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientDa
 
 
 /* Igate type radio buttons */
-void igate_type_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void igate_type_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -22078,7 +22078,7 @@ void lpomff_menuCallback(Widget widget, XtPointer ptr, XtPointer callData) {
 
 
 
-void Configure_defaults( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Configure_defaults( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel,
                 frame4, frame5,
                 type_box,
@@ -22790,7 +22790,7 @@ void Configure_defaults( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer U
 ///////////////////////////////////   Configure Timing Dialog   //////////////////////////////////
 
 
-void Configure_timing_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Configure_timing_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -22861,7 +22861,7 @@ void Configure_timing_change_data(Widget widget, XtPointer clientData, XtPointer
 
 
 
-void Configure_timing( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Configure_timing( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel;
     Atom delw;
     XmString x_str;
@@ -23373,7 +23373,7 @@ XtSetSensitive(RINO_download_timeout, FALSE);
 
 ///////////////////////////////////   Configure Coordinates Dialog   //////////////////////////////////
 
-void coordinates_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void coordinates_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -23392,7 +23392,7 @@ void coordinates_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientDat
 
 
 
-void Configure_coordinates_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Configure_coordinates_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -23403,7 +23403,7 @@ void Configure_coordinates_destroy_shell( /*@unused@*/ Widget UNUSED(widget), Xt
 
 
 
-void Configure_coordinates( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Configure_coordinates( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel, frame,
                 coord_box, coord_0, coord_1, coord_2,
                 coord_3, coord_4, coord_5;
@@ -23637,7 +23637,7 @@ void Configure_coordinates( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointe
 
 /////////////////////////////////   Configure Audio Alarms Dialog   ////////////////////////////////
 
-void Configure_audio_alarm_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Configure_audio_alarm_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -23774,7 +23774,7 @@ void Configure_audio_alarm_change_data(Widget widget, XtPointer clientData, XtPo
 
 
 
-void Configure_audio_alarms( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Configure_audio_alarms( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel,
                 audio_play, file1, file2,
                 min1, max1,
@@ -24409,7 +24409,7 @@ void Configure_audio_alarms( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPoint
 /////////////////////////////////////   Configure Speech Dialog   //////////////////////////////////
 
 
-void Configure_speech_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Configure_speech_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     XtDestroyWidget(shell);
@@ -24476,7 +24476,7 @@ void Configure_speech_change_data(Widget widget, XtPointer clientData, XtPointer
 //that basicly pops up a box that says where to get Festival, have
 //it be ungrayed if Festival isn't installed.
 
-void Configure_speech( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Configure_speech( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel, file1,
         sep, button_test;
     Atom delw;
@@ -24794,7 +24794,7 @@ void Configure_speech( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNU
  *  Track_Me
  *
  */
-void Track_Me( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Track_Me( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -24825,7 +24825,7 @@ static Cursor cs_move_measure = (Cursor)NULL;
  *  Move_Object
  *
  */
-void  Move_Object( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Move_Object( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -24859,7 +24859,7 @@ void  Move_Object( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtP
  *  Measure_Distance
  *
  */
-void  Measure_Distance( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Measure_Distance( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -24894,7 +24894,7 @@ void  Measure_Distance( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData
 /*
  *  Destroy Configure Station Dialog Popup Window
  */
-void Configure_station_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_station_destroy_shell( Widget widget, XtPointer clientData, XtPointer callData) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     (void)XFreePixmap(XtDisplay(appshell),CS_icon0);  // ???? DK7IN: avoid possible memory leak ?
@@ -24917,7 +24917,7 @@ void Configure_station_destroy_shell( /*@unused@*/ Widget widget, XtPointer clie
 
 
 
-void  Configure_station_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Configure_station_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -25109,7 +25109,7 @@ void Configure_station_change_data(Widget widget, XtPointer clientData, XtPointe
 /*
  *  Update symbol picture for changed symbol or table
  */
-void updateSymbolPictureCallback( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void updateSymbolPictureCallback( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     char table, overlay;
     char symb, group;
     char *temp_ptr;
@@ -25144,7 +25144,7 @@ void updateSymbolPictureCallback( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ Xt
 
 
 /* Power radio buttons */
-void Power_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Power_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -25168,7 +25168,7 @@ void Power_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtP
 
 
 /* Height radio buttons */
-void Height_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Height_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -25188,7 +25188,7 @@ void Height_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, Xt
 
 
 /* Gain radio buttons */
-void Gain_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Gain_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -25208,7 +25208,7 @@ void Gain_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPo
 
 
 /* Directivity radio buttons */
-void Directivity_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Directivity_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -25226,7 +25226,7 @@ void Directivity_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientDat
 
 
 
-void Posit_compressed_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
+void Posit_compressed_toggle( Widget UNUSED(w), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -25260,7 +25260,7 @@ void Posit_compressed_toggle( /*@unused@*/ Widget UNUSED(w), XtPointer clientDat
 /*
  *  Select a symbol graphically
  */
-void Configure_change_symbol(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Configure_change_symbol(Widget widget, XtPointer clientData, XtPointer callData) {
 
     //fprintf(stderr,"Trying to change a symbol\n");
     symbol_change_requested_from = 1;   // Tell Select_symbol who to return the data to
@@ -25275,7 +25275,7 @@ void Configure_change_symbol(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer 
 /*
  *  Setup Configure Station dialog
  */
-void Configure_station( /*@unused@*/ Widget UNUSED(ww), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Configure_station( Widget UNUSED(ww), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, cs_form, cs_form1, button_ok, button_cancel, call, frame, frame2,
                 framephg, formphg,
                 power_box,poption0,poption1,poption2,poption3,poption4,poption5,poption6,poption7,poption8,poption9,poption10,

--- a/src/maps.c
+++ b/src/maps.c
@@ -3886,7 +3886,7 @@ void draw_centered_label_text (Widget w, int rotation, int x, int y, int label_l
 
 
 
-static void Print_postscript_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+static void Print_postscript_destroy_shell(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     char *temp_ptr;
 
@@ -3959,7 +3959,7 @@ end_critical_section(&print_postscript_dialog_lock, "maps.c:Print_postscript_des
 
 
 
-static void Print_properties_destroy_shell(/*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+static void Print_properties_destroy_shell(Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
 
     if (!shell)
@@ -4425,7 +4425,7 @@ static void Print_preview( Widget widget, XtPointer UNUSED(clientData), XtPointe
  *  Auto_rotate
  *
  */
-static void  Auto_rotate( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+static void  Auto_rotate( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -4447,7 +4447,7 @@ static void  Auto_rotate( /*@unused@*/ Widget UNUSED(widget), XtPointer clientDa
  *  Rotate_90
  *
  */
-static void  Rotate_90( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+static void  Rotate_90( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -4469,7 +4469,7 @@ static void  Rotate_90( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData
  *  Auto_scale
  *
  */
-static void  Auto_scale( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+static void  Auto_scale( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -4489,7 +4489,7 @@ static void  Auto_scale( /*@unused@*/ Widget UNUSED(widget), XtPointer clientDat
  *  Monochrome
  *
  */
-void  Monochrome( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Monochrome( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -4509,7 +4509,7 @@ void  Monochrome( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPo
  *  Invert
  *
  */
-static void  Invert( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+static void  Invert( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 

--- a/src/maps.h
+++ b/src/maps.h
@@ -169,7 +169,7 @@ extern void draw_label_text (Widget w, int x, int y, int label_length, int color
 extern void draw_rotated_label_text (Widget w, int rotation, int x, int y, int label_length, int color, char *label_text, int fontsize);
 extern int get_rotated_label_text_length_pixels(Widget w, char *label_text, int fontsize);
 extern void draw_centered_label_text (Widget w, int rotation, int x, int y, int label_length, int color, char *label_text, int fontsize);
-extern void  Monochrome( /*@unused@*/ Widget widget, XtPointer clientData, XtPointer callData);
+extern void  Monochrome( Widget widget, XtPointer clientData, XtPointer callData);
 extern void Snapshot(void);
 extern void clean_string(char *input);
 extern int print_rotated;

--- a/src/messages_gui.c
+++ b/src/messages_gui.c
@@ -839,7 +839,7 @@ void get_send_message_path(char *callsign, char *path, int path_size) {
 
 
 
-void Send_message_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData)) {
+void Send_message_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData)) {
     int ii;
 //    char *temp_ptr;
 //    char temp1[MAX_LINE_SIZE+1];
@@ -904,7 +904,7 @@ end_critical_section(&send_message_dialog_lock, "messages_gui.c:Send_message_des
 
 
 
-void Check_new_call_messages( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Check_new_call_messages( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callData) ) {
     int pos;
     intptr_t i;
 
@@ -943,7 +943,7 @@ end_critical_section(&send_message_dialog_lock, "messages_gui.c:Check_new_call_m
 
 
 
-void Clear_messages( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Clear_messages( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     clear_outgoing_messages();
 }
 
@@ -951,7 +951,7 @@ void Clear_messages( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSE
 
 
 
-void Send_message_now( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Send_message_now( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callData) ) {
     char temp1[MAX_CALLSIGN+1];
     char temp2[121];
     char temp_line1[68] = "";
@@ -1182,7 +1182,7 @@ end_critical_section(&send_message_dialog_lock, "messages_gui.c:Send_message_now
 
 
 
-void Clear_message_from( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Clear_message_from( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callData) ) {
     char temp1[MAX_CALLSIGN+1];
     int i;
     char *temp_ptr;
@@ -1219,7 +1219,7 @@ end_critical_section(&send_message_dialog_lock, "messages_gui.c:Clear_message_fr
 
 
 
-void Clear_message_to( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Clear_message_to( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callData) ) {
     char temp1[MAX_CALLSIGN+1];
     int i;
     char *temp_ptr;
@@ -1255,7 +1255,7 @@ end_critical_section(&send_message_dialog_lock, "messages_gui.c:Clear_message_to
 
 
 
-void Clear_message_to_from( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Clear_message_to_from( Widget w, XtPointer clientData, XtPointer callData) {
     int i, pos;
 
     Clear_message_to(w, clientData, callData);
@@ -1295,7 +1295,7 @@ end_critical_section(&send_message_dialog_lock, "messages_gui.c:Clear_message_to
 
 
 
-void Kick_timer( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Kick_timer( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callData) ) {
     char *temp_ptr;
     char temp1[MAX_CALLSIGN+1];
 
@@ -1318,7 +1318,7 @@ void Kick_timer( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@
 
 
 
-void Clear_messages_to( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Clear_messages_to( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callData) ) {
     char *temp_ptr;
     char temp1[MAX_CALLSIGN+1];
 
@@ -1342,7 +1342,7 @@ void Clear_messages_to( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@
 
 
 
-void Send_message_call( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Send_message_call( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callData) ) {
     char call[20];
 
     if(clientData != NULL) {
@@ -1363,16 +1363,16 @@ void Send_message_call( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@
 // last two parameters of an XtAddCallback() or XtRemoveCallback()
 // must be unique.
 //
-void Send_message_now_1( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Send_message_now_1( Widget w, XtPointer clientData, XtPointer callData) {
     Send_message_now( w, clientData, callData);
 }
-void Send_message_now_2( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Send_message_now_2( Widget w, XtPointer clientData, XtPointer callData) {
     Send_message_now( w, clientData, callData);
 }
-void Send_message_now_3( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Send_message_now_3( Widget w, XtPointer clientData, XtPointer callData) {
     Send_message_now( w, clientData, callData);
 }
-void Send_message_now_4( /*@unused@*/ Widget w, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Send_message_now_4( Widget w, XtPointer clientData, XtPointer callData) {
     Send_message_now( w, clientData, callData);
 }
 
@@ -1743,7 +1743,7 @@ void rebuild_send_message_input_boxes(int ii, int hamhud, int d700, int d7) {
 
 
 
-void HamHUD_Msg( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
+void HamHUD_Msg( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     intptr_t ii =(intptr_t)clientData;
     int hamhud;
 
@@ -1760,7 +1760,7 @@ void HamHUD_Msg( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPoi
 
 
 
-void D700_Msg( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
+void D700_Msg( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     intptr_t ii = (intptr_t)clientData;
     int d700;
 
@@ -1777,7 +1777,7 @@ void D700_Msg( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPoint
 
 
 
-void D7_Msg( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
+void D7_Msg( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     intptr_t ii = (intptr_t)clientData;
     int d7;
 
@@ -1945,7 +1945,7 @@ void select_station_type(int ii) {
 //   on first read capability."
 //
 //
-void Send_message( /*@unused@*/ Widget UNUSED(w), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Send_message( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Arg args[50];
     char temp[60];
     unsigned int n;
@@ -2454,7 +2454,7 @@ end_critical_section(&send_message_dialog_lock, "messages_gui.c:Send_message" );
 // Bring up a Send Message dialog for each QSO that has pending
 // outbound messages.
 //
-void Show_pending_messages( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Show_pending_messages( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     intptr_t ii;
     int msgs_found = 0;
 
@@ -2488,7 +2488,7 @@ void Show_pending_messages( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointe
 
 /************************* Auto msg **************************************/
 /*************************************************************************/
-void Auto_msg_option( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer UNUSED(calldata) ) {
+void Auto_msg_option( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     int item_no = XTPOINTER_TO_INT(clientData);
 
     if (item_no)
@@ -2501,7 +2501,7 @@ void Auto_msg_option( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer clie
 
 
 
-void Auto_msg_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) { 
+void Auto_msg_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) { 
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -2537,7 +2537,7 @@ void Auto_msg_set_now(Widget w, XtPointer clientData, XtPointer callData) {
 
 
 
-void Auto_msg_set( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Auto_msg_set( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, button_ok, button_cancel, reply;
     Atom delw;
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -219,7 +219,7 @@ int valid_item(char *name) {
 /*
  *  Clear out object/item history log file
  */
-void Object_History_Clear( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Object_History_Clear( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     char *file;
     FILE *f;
     char temp_file_path[MAX_VALUE];
@@ -245,7 +245,7 @@ void Object_History_Clear( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer
 /*
  *  Re-read object/item history log file
  */
-void Object_History_Refresh( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Object_History_Refresh( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
 
     // Reload saved objects and items from previous runs.
     reload_object_item();
@@ -2839,7 +2839,7 @@ void free_cs_CAD(void)
 
 // This is the callback for the Draw togglebutton
 //
-void Draw_CAD_Objects_mode( /*@unused@*/ Widget UNUSED(widget),
+void Draw_CAD_Objects_mode( Widget UNUSED(widget),
         XtPointer UNUSED(clientData),
         XtPointer callData) {
 
@@ -3110,9 +3110,9 @@ void Restore_CAD_Objects_from_file(void) {
 
 // popdown and destroy the cad_erase_dialog.
 //
-void Draw_CAD_Objects_erase_dialog_close ( /*@unused@*/ Widget UNUSED(w),
-        /*@unused@*/ XtPointer UNUSED(clientData),
-        /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Draw_CAD_Objects_erase_dialog_close ( Widget UNUSED(w),
+        XtPointer UNUSED(clientData),
+        XtPointer UNUSED(callData) ) {
 
     if (cad_erase_dialog!=NULL) {
         // close cad_erase_dialog
@@ -3131,9 +3131,9 @@ void Draw_CAD_Objects_erase_dialog_close ( /*@unused@*/ Widget UNUSED(w),
 // Draw_CAD_Objects_erase_dialog.  Iterates through the list of
 // selected CAD objects and deletes them.
 //
-void Draw_CAD_Objects_erase_selected ( /*@unused@*/ Widget w,
-        /*@unused@*/ XtPointer clientData,
-        /*@unused@*/ XtPointer callData) {
+void Draw_CAD_Objects_erase_selected ( Widget w,
+        XtPointer clientData,
+        XtPointer callData) {
     int itemCount;       // number of items in list of CAD objects.
     XmString *listItems; // names of CAD objects on list 
     char *cadName;       // the text name of a CAD object
@@ -3217,9 +3217,9 @@ void Draw_CAD_Objects_erase_selected ( /*@unused@*/ Widget w,
 // users to delete all CAD objects or select individual CAD objects
 // to delete.
 //
-void Draw_CAD_Objects_erase_dialog( /*@unused@*/ Widget UNUSED(w),
-        /*@unused@*/ XtPointer UNUSED(clientData),
-        /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Draw_CAD_Objects_erase_dialog( Widget UNUSED(w),
+        XtPointer UNUSED(clientData),
+        XtPointer UNUSED(callData) ) {
 
     Widget cad_erase_pane, cad_erase_form, cad_erase_label,
            button_delete_all, button_delete_selected, button_cancel;
@@ -3394,9 +3394,9 @@ void Draw_CAD_Objects_erase_dialog( /*@unused@*/ Widget UNUSED(w),
 
 // popdown and destroy the cad_list_dialog
 //
-void Draw_CAD_Objects_list_dialog_close ( /*@unused@*/ Widget UNUSED(w),
-        /*@unused@*/ XtPointer UNUSED(clientData),
-        /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Draw_CAD_Objects_list_dialog_close ( Widget UNUSED(w),
+        XtPointer UNUSED(clientData),
+        XtPointer UNUSED(callData) ) {
 
     if (cad_list_dialog!=NULL) {
         // close cad_list_dialog
@@ -3414,9 +3414,9 @@ void Draw_CAD_Objects_list_dialog_close ( /*@unused@*/ Widget UNUSED(w),
 // Show details for selected CAD object.  Callback for the show/edit
 // details button on the Draw_CAD_Objects_list dialog.
 //
-void Show_selected_CAD_object_details ( /*@unused@*/ Widget UNUSED(w),
-        /*@unused@*/ XtPointer UNUSED(clientData),
-        /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Show_selected_CAD_object_details ( Widget UNUSED(w),
+        XtPointer UNUSED(clientData),
+        XtPointer UNUSED(callData) ) {
 
     static int sizeof_area_description = 200;
     int itemCount;       // number of items in list of CAD objects.
@@ -3488,9 +3488,9 @@ void Show_selected_CAD_object_details ( /*@unused@*/ Widget UNUSED(w),
 // Callback for edit CAD objects menu option.  Dialog to allow users
 // to select individual CAD objects in order to edit their metadata.
 //
-void Draw_CAD_Objects_list_dialog( /*@unused@*/ Widget UNUSED(w),
-        /*@unused@*/ XtPointer UNUSED(clientData),
-        /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Draw_CAD_Objects_list_dialog( Widget UNUSED(w),
+        XtPointer UNUSED(clientData),
+        XtPointer UNUSED(callData) ) {
 
     Widget cad_list_pane, cad_list_form, cad_list_label,
            button_list_selected, button_close;
@@ -3649,9 +3649,9 @@ void Draw_CAD_Objects_list_dialog( /*@unused@*/ Widget UNUSED(w),
 // Free the object and vertice lists then do a screen update.
 // callback from delete all button on cad_erase_dialog.
 //
-void Draw_CAD_Objects_erase( /*@unused@*/ Widget w,
-        /*@unused@*/ XtPointer clientData,
-        /*@unused@*/ XtPointer callData) {
+void Draw_CAD_Objects_erase( Widget w,
+        XtPointer clientData,
+        XtPointer callData) {
     
     // if we were called from the cad_erase_dialog, make sure it is closed properly
     if (cad_erase_dialog) 
@@ -3760,9 +3760,9 @@ void Format_area_for_output(double *area_km2, char *area_description, int sizeof
 // the computed_area field in the Object, and to a dialog that pops
 // up on the screen.
 //
-void Draw_CAD_Objects_close_polygon( /*@unused@*/ Widget UNUSED(widget),
+void Draw_CAD_Objects_close_polygon( Widget UNUSED(widget),
         XtPointer UNUSED(clientData),
-        /*@unused@*/ XtPointer UNUSED(callData) ) {
+        XtPointer UNUSED(callData) ) {
     static int sizeof_area_description = 200;
     VerticeRow *tmp;
     double area;
@@ -4023,7 +4023,7 @@ void Draw_All_CAD_Objects(Widget w) {
 /*
  *  Destroy Object Dialog Popup Window
  */
-void Object_destroy_shell( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Object_destroy_shell( Widget widget, XtPointer clientData, XtPointer callData) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
     (void)XFreePixmap(XtDisplay(appshell),Ob_icon0);
@@ -5679,7 +5679,7 @@ int Setup_item_data(char *line, int line_length, DataRow *p_station) {
 /*
  *  Set an Object
  */
-void Object_change_data_set(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Object_change_data_set(Widget widget, XtPointer clientData, XtPointer UNUSED(callData) ) {
     char line[43+1+40];                 // ???
     DataRow *p_station = global_parameter1;
 
@@ -5737,7 +5737,7 @@ void Object_change_data_set(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer c
 /*
  *  Set an Item
  */
-void Item_change_data_set(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Item_change_data_set(Widget widget, XtPointer clientData, XtPointer UNUSED(callData) ) {
     char line[43+1+40];                 // ???
     DataRow *p_station = global_parameter1;
 
@@ -5875,7 +5875,7 @@ void Item_confirm_data_set(Widget widget, XtPointer clientData, XtPointer callDa
 /*
  *  Delete an Object
  */
-void Object_change_data_del(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Object_change_data_del(Widget widget, XtPointer clientData, XtPointer UNUSED(callData) ) {
     char line[43+1+40];                 // ???
     DataRow *p_station = global_parameter1;
 
@@ -5912,7 +5912,7 @@ void Object_change_data_del(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer c
 /*
  *  Delete an Item
  */
-void Item_change_data_del(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Item_change_data_del(Widget widget, XtPointer clientData, XtPointer UNUSED(callData) ) {
     char line[43+1+40];                 // ???
     int i, done;
     DataRow *p_station = global_parameter1;
@@ -5958,7 +5958,7 @@ void Item_change_data_del(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer cli
 /*
  *  Select a symbol graphically
  */
-void Ob_change_symbol(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void Ob_change_symbol(Widget widget, XtPointer clientData, XtPointer callData) {
     //fprintf(stderr,"Trying to change a symbol\n");
     symbol_change_requested_from = 2;   // Tell Select_symbol who to return the data to
     Select_symbol(widget, clientData, callData);
@@ -5971,7 +5971,7 @@ void Ob_change_symbol(/*@unused@*/ Widget widget, /*@unused@*/ XtPointer clientD
 /*
  *  Update symbol picture for changed symbol or table
  */
-void updateObjectPictureCallback(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void updateObjectPictureCallback(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     char table, overlay;
     char symb, group;
     char *temp_ptr;
@@ -6018,7 +6018,7 @@ void updateObjectPictureCallback(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtP
 
 
 // Handler for "Signpost" toggle button
-void Signpost_object_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
+void Signpost_object_toggle( Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
     char temp_data[40];
     char comment[43+1];     // max 43 characters of comment
@@ -6111,7 +6111,7 @@ void Signpost_object_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(client
 
 
 // Handler for "Probability Circles" toggle button
-void Probability_circle_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
+void Probability_circle_toggle( Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
     char temp_data[40];
     char comment[43+1];     // max 43 characters of comment
@@ -6204,7 +6204,7 @@ void Probability_circle_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(cli
 
 
 // Handler for "Enable Area Type" toggle button
-void  Area_object_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
+void  Area_object_toggle( Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
     char temp_data[40];
     char comment[43+1];     // max 43 characters of comment
@@ -6308,7 +6308,7 @@ void  Area_object_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(clientDat
 
 
 // Handler for "DF Bearing Object" toggle button
-void  DF_bearing_object_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
+void  DF_bearing_object_toggle( Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
     char temp_data[40];
     char comment[43+1];     // max 43 characters of comment
@@ -6410,7 +6410,7 @@ void  DF_bearing_object_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(cli
 
 
 // Handler for "Map View Object" toggle button
-void  Map_View_object_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
+void  Map_View_object_toggle( Widget widget, XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
     char temp_data[40];
     char comment[43+1];     // max 43 characters of comment
@@ -6516,7 +6516,7 @@ void  Map_View_object_toggle( /*@unused@*/ Widget widget, XtPointer UNUSED(clien
 
 
 /* Area object type radio buttons */
-void Area_type_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Area_type_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6549,7 +6549,7 @@ void Area_type_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,
 
 
 /* Area object color radio buttons */
-void Area_color_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Area_color_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6571,7 +6571,7 @@ void Area_color_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData
 
 
 /* Area bright color enable button */
-void Area_bright_dim_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Area_bright_dim_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6590,7 +6590,7 @@ void Area_bright_dim_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clien
 
 
 /* Area filled enable button */
-void Area_open_filled_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Area_open_filled_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6609,7 +6609,7 @@ void Area_open_filled_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clie
 
 
 // Handler for "Omni Antenna" toggle button
-void  Omni_antenna_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer callData) {
+void  Omni_antenna_toggle( Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
  
     if(state->set) {
@@ -6632,7 +6632,7 @@ void  Omni_antenna_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(
 
 
 // Handler for "Beam Antenna" toggle button
-void  Beam_antenna_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer callData) {
+void  Beam_antenna_toggle( Widget UNUSED(widget), XtPointer UNUSED(clientData), XtPointer callData) {
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
  
     if(state->set) {
@@ -6655,7 +6655,7 @@ void  Beam_antenna_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer UNUSED(
 
 
 /* Object signal radio buttons */
-void Ob_signal_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Ob_signal_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6675,7 +6675,7 @@ void Ob_signal_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,
 
 
 /* Object height radio buttons */
-void Ob_height_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Ob_height_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6695,7 +6695,7 @@ void Ob_height_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData,
 
 
 /* Object gain radio buttons */
-void Ob_gain_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Ob_gain_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6715,7 +6715,7 @@ void Ob_gain_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, X
 
 
 /* Object directivity radio buttons */
-void Ob_directivity_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Ob_directivity_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -6735,7 +6735,7 @@ void Ob_directivity_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer client
 
 
 /* Object beamwidth radio buttons */
-void Ob_width_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void Ob_width_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -7059,7 +7059,7 @@ void Populate_predefined_objects(predefinedObject *predefinedObjects) {
    clientData is pointer to an integer representing the index of a 
    predefined object in the predefinedObjects array
    */
-void Create_SAR_Object(/*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer clientData, XtPointer UNUSED(calldata) ) {
+void Create_SAR_Object(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(calldata) ) {
     Dimension width, height;
     char call[MAX_CALLSIGN+1];
     long x_lat,x_lon;
@@ -7323,7 +7323,7 @@ fprintf(stderr, "No more iterations left\n");
  *  at the top of this function, then the dialog will build properly for
  *  the type of object initially.
  */
-void Set_Del_Object( /*@unused@*/ Widget w, /*@unused@*/ XtPointer clientData, XtPointer calldata) {
+void Set_Del_Object( Widget w, XtPointer clientData, XtPointer calldata) {
     Dimension width, height;
     long lat,lon;
     char lat_str[MAX_LAT];

--- a/src/popup_gui.c
+++ b/src/popup_gui.c
@@ -85,9 +85,9 @@ end_critical_section(&popup_message_dialog_lock, "popup_gui.c:clear_popup_messag
 
 
 
-static void popup_message_destroy_shell(/*@unused@*/ Widget UNUSED(w),
+static void popup_message_destroy_shell(Widget UNUSED(w),
                                 XtPointer clientData,
-                                /*@unused@*/ XtPointer UNUSED(callData) ) {
+                                XtPointer UNUSED(callData) ) {
     int i;
 
     i=atoi((char *)clientData);

--- a/src/track_gui.c
+++ b/src/track_gui.c
@@ -109,7 +109,7 @@ void track_gui_init(void)
 /**** Track STATION ******/
 
 
-void track_station_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void track_station_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -197,7 +197,7 @@ void Track_station_now(Widget w, XtPointer clientData, XtPointer callData) {
 
 
 
-void Track_station( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Track_station( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget pane, my_form, button_ok, button_close, button_clear, call, sep;
     Atom delw;
 
@@ -626,7 +626,7 @@ static void* findu_transfer_thread(void *arg) {
 
 
 
-void Download_trail_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Download_trail_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
 
@@ -795,7 +795,7 @@ void Reset_posit_length_max(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPo
 
 
 
-void Download_findu_trail( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Download_findu_trail( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget pane, my_form, button_ok, button_cancel, call, sep;
     Atom delw;
     XmString x_str;

--- a/src/view_message_gui.c
+++ b/src/view_message_gui.c
@@ -361,7 +361,7 @@ end_critical_section(&All_messages_dialog_lock, "view_message_gui.c:all_messages
 
 
 
-void All_messages_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void All_messages_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
     Widget shell = (Widget) clientData;
     char *temp_ptr;
 
@@ -385,7 +385,7 @@ end_critical_section(&All_messages_dialog_lock, "view_message_gui.c:All_messages
 
 
 
-void All_messages_change_range( /*@unused@*/ Widget widget, XtPointer clientData, /*@unused@*/ XtPointer callData) {
+void All_messages_change_range( Widget widget, XtPointer clientData, XtPointer callData) {
     Widget shell = (Widget) clientData;
     char *temp_ptr;
 
@@ -404,7 +404,7 @@ void All_messages_change_range( /*@unused@*/ Widget widget, XtPointer clientData
 
 
 
-void  Read_messages_packet_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Read_messages_packet_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -424,7 +424,7 @@ Widget button_range;
 
 
 
-void  Read_messages_mine_only_toggle( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
+void  Read_messages_mine_only_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer callData) {
     char *which = (char *)clientData;
     XmToggleButtonCallbackStruct *state = (XmToggleButtonCallbackStruct *)callData;
 
@@ -442,7 +442,7 @@ void  Read_messages_mine_only_toggle( /*@unused@*/ Widget UNUSED(widget), XtPoin
 
 
 
-void view_all_messages( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void view_all_messages( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     Widget pane, my_form, button_close, dist, dist_units;
     Widget option_box, tnc_data, net_data, tnc_net_data,
         read_mine_only_button;

--- a/src/wx_gui.c
+++ b/src/wx_gui.c
@@ -92,7 +92,7 @@ void wx_gui_init(void)
 
 
 
-void wx_detailed_alert_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void wx_detailed_alert_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
 
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
@@ -420,7 +420,7 @@ void wx_alert_double_click_action( Widget widget, XtPointer UNUSED(clientData), 
 
 
 
-void wx_alert_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void wx_alert_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
 
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
@@ -591,7 +591,7 @@ end_critical_section(&wx_alert_shell_lock, "wx_gui.c:wx_alert_update_list" );
 
 
 
-void Display_Wx_Alert( /*@unused@*/ Widget UNUSED(wdgt), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void Display_Wx_Alert( Widget UNUSED(wdgt), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget pane, my_form, mess, button_cancel;
     Atom delw;
     Arg al[50];                    /* Arg List */
@@ -763,7 +763,7 @@ Widget WX_high_wind_label;
 
 
 
-void WX_station_destroy_shell( /*@unused@*/ Widget UNUSED(widget), XtPointer clientData, /*@unused@*/ XtPointer UNUSED(callData) ) {
+void WX_station_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPointer UNUSED(callData) ) {
 
     Widget shell = (Widget) clientData;
     XtPopdown(shell);
@@ -792,7 +792,7 @@ void WX_station_change_data(Widget widget, XtPointer clientData, XtPointer callD
 
 // This is the "Own Weather Station" Dialog
 //
-void WX_station( /*@unused@*/ Widget UNUSED(w), /*@unused@*/ XtPointer UNUSED(clientData), /*@unused@*/ XtPointer UNUSED(callData) ) {
+void WX_station( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) ) {
     static Widget  pane, my_form, form1, button_close, frame, 
             WX_type, temp, wind_cse, wind_spd, wind_gst, 
             my_rain, to_rain, rain_h, my_rain_24, baro,


### PR DESCRIPTION
We don't currently use lclint, the compiler find unused parameters
anyway and we have notation already in the code for that. The lclint
annotations add extra clutter to the function declarations. These
annotations are out-of-date as well. Solves issue #136.