### PR TITLE
Use MagickCore-config if available

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -398,10 +398,14 @@ BINPATH="${PATH}${EXTRA_BIN_PATH}"
 # because AC_CHECK_PROG will do nothing if the variable is already set!
 #
 use_imagemagick=no
-AC_PATH_PROG(MAGIC_BIN, [Magick-config], no, $BINPATH)
+AC_PATH_PROG(MAGIC_BIN, [MagickCore-config], no, $BINPATH)
 if test "$MAGIC_BIN" != "no"; then
   use_imagemagick=yes
-#else
+else
+  AC_PATH_PROG(MAGIC_BIN, [Magick-config], no, $BINPATH)
+  if test "$MAGIC_BIN" != "no"; then
+    use_imagemagick=yes
+  fi
 #  AC_MSG_WARN(*** Cannot find Magick-config:  Building w/o ImageMagick support. ***)
 fi
 


### PR DESCRIPTION
Since the earth was cooling and Xastir used ImageMagick, we've used
the existence of the script "Magick-config" to conclude whether
ImageMagick was installed or not, and if it was, we used this script
to get Magick to tell us what CFLAGS, LDFLAGS, and LIBS to use to
build with Magick support.

Magick 6 deprecated this script in favor of one called
MagickCore-config.  It works exactly like the older one did and in
ImageMagick 6 returns exactly the same values for all requested flags.

Magick 7 deleted the old script.

We now first look for MagickCore-config and
set MAGIC_BIN to that path if we find it.  If we don't find it, we
look for Magick-config and set MAGIC_BIN to that path if we find it.

This commit closes #147.

It does not in fact allow Magick 7 to work with Xastir, but that's
another issue (#148).  This one had to be cleared before we could even
start on the harder one.