### PR TITLE
Remove ImageMagick version 6 deprecation warnings

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -90,7 +90,15 @@ char *xastir_version=VERSION;
   #undef PACKAGE_TARNAME
   #define XASTIR_PACKAGE_VERSION PACKAGE_VERSION
   #undef PACKAGE_VERSION
-  #include <magick/api.h>
+  #ifdef HAVE_MAGICK
+    #ifdef HAVE_MAGICKCORE_MAGICKCORE_H
+      #include <MagickCore/MagickCore.h>
+    #else
+      #ifdef HAVE_MAGICK_API_H
+        #include <magick/api.h>
+      #endif // HAVE_MAGICK_API_H
+    #endif //HAVE_MAGICKCORE_MAGICKCORE_H
+  #endif //HAVE_MAGICK
   #undef PACKAGE_BUGREPORT
   #define PACKAGE_BUGREPORT XASTIR_PACKAGE_BUGREPORT
   #undef XASTIR_PACKAGE_BUGREPORT
@@ -29822,8 +29830,12 @@ int main(int argc, char *argv[], char *envp[])
 #ifdef HAVE_IMAGEMAGICK
 #if (MagickLibVersion < 0x0538)
   MagickIncarnate(*argv);
-#else   // MagickLibVersion < 0x0538
-  InitializeMagick(*argv);
+#else   // 0x0538 < MagickLibVersion < 0x0669
+  #if (MagickLibVersion < 0x0669)
+    InitializeMagick(*argv);
+  #else // > 0x669
+    MagickCoreGenesis(*argv, MagickTrue);
+  #endif
 #endif  // MagickLibVersion < 0x0538
 #endif  // HAVE_IMAGEMAGICK
 #endif  //HAVE_GRAPHICSMAGICK

--- a/src/map_OSM.c
+++ b/src/map_OSM.c
@@ -114,12 +114,15 @@
   #undef PACKAGE_TARNAME
   #define XASTIR_PACKAGE_VERSION PACKAGE_VERSION
   #undef PACKAGE_VERSION
-  #ifdef HAVE_GRAPHICSMAGICK
-    /*#include <GraphicsMagick/magick/api.h>*/
-    #include <magick/api.h>
-  #else   // HAVE_GRAPHICSMAGICK
-    #include <magick/api.h>
-  #endif  // HAVE_GRAPHICSMAGICK
+  #ifdef HAVE_MAGICK
+    #ifdef HAVE_MAGICKCORE_MAGICKCORE_H
+      #include <MagickCore/MagickCore.h>
+    #else
+      #ifdef HAVE_MAGICK_API_H
+        #include <magick/api.h>
+      #endif // HAVE_MAGICK_API_H
+    #endif //HAVE_MAGICKCORE_MAGICKCORE_H
+  #endif //HAVE_MAGICK
   #undef PACKAGE_BUGREPORT
   #define PACKAGE_BUGREPORT XASTIR_PACKAGE_BUGREPORT
   #undef XASTIR_PACKAGE_BUGREPORT

--- a/src/map_WMS.c
+++ b/src/map_WMS.c
@@ -109,12 +109,15 @@
   #undef PACKAGE_TARNAME
   #define XASTIR_PACKAGE_VERSION PACKAGE_VERSION
   #undef PACKAGE_VERSION
-  #ifdef HAVE_GRAPHICSMAGICK
-    /*#include <GraphicsMagick/magick/api.h>*/
-    #include <magick/api.h>
-  #else   // HAVE_GRAPHICSMAGICK
-    #include <magick/api.h>
-  #endif  // HAVE_GRAPHICSMAGICK
+  #ifdef HAVE_MAGICK
+    #ifdef HAVE_MAGICKCORE_MAGICKCORE_H
+      #include <MagickCore/MagickCore.h>
+    #else
+      #ifdef HAVE_MAGICK_API_H
+        #include <magick/api.h>
+      #endif // HAVE_MAGICK_API_H
+    #endif //HAVE_MAGICKCORE_MAGICKCORE_H
+  #endif //HAVE_MAGICK
   #undef PACKAGE_BUGREPORT
   #define PACKAGE_BUGREPORT XASTIR_PACKAGE_BUGREPORT
   #undef XASTIR_PACKAGE_BUGREPORT

--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -124,7 +124,15 @@
   #undef PACKAGE_TARNAME
   #define XASTIR_PACKAGE_VERSION PACKAGE_VERSION
   #undef PACKAGE_VERSION
-  #include <magick/api.h>
+  #ifdef HAVE_MAGICK
+    #ifdef HAVE_MAGICKCORE_MAGICKCORE_H
+      #include <MagickCore/MagickCore.h>
+    #else
+      #ifdef HAVE_MAGICK_API_H
+        #include <magick/api.h>
+      #endif // HAVE_MAGICK_API_H
+    #endif //HAVE_MAGICKCORE_MAGICKCORE_H
+  #endif //HAVE_MAGICK
   #undef PACKAGE_BUGREPORT
   #define PACKAGE_BUGREPORT XASTIR_PACKAGE_BUGREPORT
   #undef XASTIR_PACKAGE_BUGREPORT
@@ -2304,7 +2312,11 @@ void draw_geo_image_map (Widget w,
     //        target=GetOnePixel(image,0,0);
     for (y=0; y < (long) image->rows; y++)
     {
+#if defined(HAVE_GRAPHICSMAGICK) || (MagickLibVersion < 0x0669)
       q=GetImagePixels(image,0,y,image->columns,1);
+#else
+      q=GetAuthenticPixels(image,0,y,image->columns,1,&exception);
+#endif
       if (q == (PixelPacket *) NULL)
       {
         fprintf(stderr, "GetImagePixels Failed....\n");
@@ -2318,10 +2330,17 @@ void draw_geo_image_map (Widget w,
         }
         q++;
       }
+#if defined(HAVE_GRAPHICSMAGICK) || (MagickLibVersion < 0x0669)
       if (!SyncImagePixels(image))
       {
         fprintf(stderr, "SyncImagePixels Failed....\n");
       }
+#else
+      if (!SyncAuthenticPixels(image,&exception))
+      {
+        fprintf(stderr, "SyncImagePixels Failed....\n");
+      }
+#endif
     }
   }
 
@@ -2355,7 +2374,11 @@ void draw_geo_image_map (Widget w,
     return;
   }
 
+#if defined(HAVE_GRAPHICSMAGICK) || (MagickLibVersion < 0x0669)
   pixel_pack = GetImagePixels(image, 0, 0, image->columns, image->rows);
+#else
+  pixel_pack = GetAuthenticPixels(image, 0, 0, image->columns, image->rows,&exception);
+#endif
   if (!pixel_pack)
   {
     fprintf(stderr,"pixel_pack == NULL!!!");

--- a/src/maps.c
+++ b/src/maps.c
@@ -76,12 +76,15 @@
   #undef PACKAGE_TARNAME
   #define XASTIR_PACKAGE_VERSION PACKAGE_VERSION
   #undef PACKAGE_VERSION
-  #ifdef HAVE_GRAPHICSMAGICK
-    /*#include <GraphicsMagick/magick/api.h>*/
-    #include <magick/api.h>
-  #else   // HAVE_GRAPHICSMAGICK
-    #include <magick/api.h>
-  #endif  // HAVE_GRAPHICSMAGICK
+  #ifdef HAVE_MAGICK
+    #ifdef HAVE_MAGICKCORE_MAGICKCORE_H
+      #include <MagickCore/MagickCore.h>
+    #else
+      #ifdef HAVE_MAGICK_API_H
+        #include <magick/api.h>
+      #endif // HAVE_MAGICK_API_H
+    #endif //HAVE_MAGICKCORE_MAGICKCORE_H
+  #endif //HAVE_MAGICK
   #undef PACKAGE_BUGREPORT
   #define PACKAGE_BUGREPORT XASTIR_PACKAGE_BUGREPORT
   #undef XASTIR_PACKAGE_BUGREPORT


### PR DESCRIPTION
Even after the fixes of #23 and #40, we missed some ImageMagick deprecation warnings in main.c and map_geo.c.

This PR fixes those so that Xastir builds cleanly with ImageMagick 6.

I was unable to get ImageMagick 7 to build with these changes, and so put code into acinclude.m4 to reject versions of Magick with MagickLibVersion greater than 0x0700.  This may have been overly conservative, because the errors I saw when trying to build Xastir with my system's ImageMagick 7 might have been due entirely to the default package being built with HDRI support.

Anyone willing to start looking into bug #148 would be well-advised to make sure to start from a version if IM7 that has HDRI support disabled.

We should also probably put a test into configure that checks how IM was built and rejects it if HDRI support is on, rather than the blanket "don't use 7" I put in.  We can't work with ANY version of IM that has HDRI support enabled, not just 7.

Fixes #150.
