### PR TITLE
Make dbfawk the only way to render shapefiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -160,11 +160,6 @@ matrix:
 #        - make
 #        - sudo make install
  
-##        - ./configure --without-pcre CPPFLAGS="-I/usr/include/geotiff"
-##        - make clean
-##        - make
-##        - sudo make install
- 
 #        - ./configure --without-geotiff CPPFLAGS="-I/usr/include/geotiff"
 #        - make clean
 #        - make
@@ -173,11 +168,6 @@ matrix:
 #        - ./configure --without-ax25 CPPFLAGS="-I/usr/include/geotiff"
 #        - make clean
 #        - make
-#        - sudo make install
- 
-        - ./configure --without-dbfawk CPPFLAGS="-I/usr/include/geotiff"
-#        - make clean
-        - make
 #        - sudo make install
  
 #        - ./configure --without-map-cache CPPFLAGS="-I/usr/include/geotiff"
@@ -200,7 +190,7 @@ matrix:
         - make
 #        - sudo make install
 
-        - ./configure --without-imagemagick --without-graphicsmagick --without-shapelib --without-pcre --without-dbfawk --without-map-cache --without-libcurl --without-ax25 --without-libproj --without-geotiff --without-festival --without-gpsman CPPFLAGS="-I/usr/include/geotiff"
+        - ./configure --without-imagemagick --without-graphicsmagick --without-shapelib --without-map-cache --without-libcurl --without-ax25 --without-libproj --without-geotiff --without-festival --without-gpsman CPPFLAGS="-I/usr/include/geotiff"
 #        - make clean
         - make
 #        - sudo make install

--- a/configure.ac
+++ b/configure.ac
@@ -377,13 +377,34 @@ if test "${shapelib_desired}" = "no"; then
 fi
 if test "${shapelib_desired}" = "yes" ; then
   use_shapelib=no
-  AC_CHECK_HEADERS(shapefil.h libshp/shapefil.h, [AC_CHECK_LIB(shp, DBFOpen, use_shapelib=yes
-    LIBS="$LIBS -lshp"
-    AC_CHECK_LIB(shp,DBFGetFieldIndex,
-      AC_DEFINE(HAVE_DBFGETFIELDINDEX, 1, Define to 1 if your `shp' library has DBFGetFieldIndex. ) )
-    AC_DEFINE(HAVE_LIBSHP, 1, Define to 1 if you have the `shp' library (-lshp). )
-    break)])
+  AC_CHECK_HEADERS([shapefil.h libshp/shapefil.h],
+                   [AC_CHECK_LIB([shp], [DBFOpen],
+                                 [use_shapelib=yes
+                                  LIBS="$LIBS -lshp"
+                                  AC_DEFINE(HAVE_LIBSHP, 1,
+                                            [Define to 1 if you have the `shp' library (-lshp).])
+                                  ])
+                    break
+                   ])
 fi
+
+# Shapelib requires pcre now
+use_pcre=no
+if test "${shapelib_desired}" = "yes" -a "${use_shapelib}" = "yes"; then
+  AC_CHECK_HEADERS([pcre.h pcre/pcre.h],
+                   [AC_CHECK_LIB([pcre], [pcre_compile],
+                                 [use_pcre=yes
+                                  LIBS="$LIBS -lpcre"
+                                  AC_DEFINE(HAVE_LIBPCRE, 1, Define to 1 if you have the `pcre' library (-lpcre). )
+                                  ])
+                    break
+                    ])
+ if test "${use_pcre}" = "no"
+ then
+    AC_MSG_ERROR([Shapelib support requires PCRE, and we could not find PCRE.  Either disable shapelib by specifying "--without-shapelib" or install PCRE libraries and headers])
+ fi
+fi
+
 if test "${shapelib_desired}" = "yes" -a "${use_shapelib}" = "no"; then
  AC_MSG_WARN([**************************************************************** ])  
  AC_MSG_WARN([Your system does not have shapelib installed.                    ])
@@ -393,16 +414,6 @@ if test "${shapelib_desired}" = "yes" -a "${use_shapelib}" = "no"; then
 fi
 
 
-# Check for pcre
-use_pcre=yes
-AC_ARG_WITH(pcre,[  --without-pcre            Disable pcre features.],use_pcre=$withval)
-if test "${use_pcre}" = "yes"; then
-  use_pcre=no
-  AC_CHECK_HEADERS(pcre.h pcre/pcre.h, [AC_CHECK_LIB(pcre, pcre_compile, use_pcre=yes
-  LIBS="$LIBS -lpcre"
-  AC_DEFINE(HAVE_LIBPCRE, 1, Define to 1 if you have the `pcre' library (-lpcre). )
-  break)])
-fi
 
 
 # Check for XPM
@@ -518,21 +529,6 @@ if test "${use_ax25}" = "yes"; then
   AC_DEFINE(HAVE_LIBAX25, 1, Define to 1 if you have the `ax25' library (-lax25). )
   break)])
 fi
-
-
-# use dbfawk
-use_dbfawk=yes
-AC_ARG_WITH(dbfawk,[  --without-dbfawk          Disable dbfawk features.],use_dbfawk=$withval)
-# dbfawk requires shapelib and pcre.  Make sure:
-if test "${use_dbfawk}" = "yes"; then
-  if test "${use_pcre}" = "yes" -a "${use_shapelib}" = "yes"; then
-    AC_DEFINE(WITH_DBFAWK, 1, Define to 1 to use dbfawk features. )
-  else
-    echo "*** Warning: dbfawk requires both pcre and shapelib."
-    use_dbfawk=no
-  fi
-fi
-
 
 
 AC_ARG_ENABLE(davis, [  --enable-davis          Turn on Davis support],
@@ -761,11 +757,6 @@ if test "${use_pcre}" = "yes"; then
 else
   ILIBS="$ILIBS     "
 fi
-if test "${use_dbfawk}" = "yes"; then
-  ILIBS="$ILIBS Dbfawk"
-else
-  ILIBS="$ILIBS       "
-fi
 if test "${use_map_cache}" = "yes"; then
   ILIBS="$ILIBS map_caching"
 else
@@ -914,7 +905,6 @@ else
   fi
 fi
 echo "  pcre (Shapefile customization) ............ : $use_pcre"
-echo "  dbfawk (Shapefile customization) .......... : $use_dbfawk"
 echo "  Berkeley DB map caching-Raster map speedups : $use_map_cache"
 echo "  internet map retrieval .................... : $use_retrieval"
 echo

--- a/src/dbfawk.c
+++ b/src/dbfawk.c
@@ -51,7 +51,7 @@
   #include "config.h"
 #endif  // HAVE_CONFIG_H
 
-#if defined(WITH_DBFAWK) && defined(HAVE_LIBSHP) && defined(HAVE_LIBPCRE)
+#if defined(HAVE_LIBSHP) && defined(HAVE_LIBPCRE)
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
@@ -497,75 +497,6 @@ void dbfawk_parse_record(awk_program *rs,
   }
   awk_exec_end_record(rs); /* execute an END_RECORD rule if any */
 }
-
-
-
-
-
-#ifndef HAVE_DBFGETFIELDINDEX
-#include <ctype.h>
-/************************************************************************/
-/*                            str_to_upper()                            */
-/************************************************************************/
-
-static void str_to_upper (char *string)
-{
-  int len;
-  short i = -1;
-
-  len = strlen (string);
-
-  while (++i < len)
-    if (isalpha(string[i]) && islower(string[i]))
-    {
-      string[i] = toupper ((int)string[i]);
-    }
-}
-
-
-
-
-
-/************************************************************************/
-/*                          DBFGetFieldIndex()                          */
-/*                                                                      */
-/*      Get the index number for a field in a .dbf file.                */
-/*                                                                      */
-/*      Contributed by Jim Matthews.                                    */
-/************************************************************************/
-
-int DBFGetFieldIndex(DBFHandle psDBF, const char *pszFieldName)
-{
-  char          name[12], name1[12], name2[12];
-  int           i;
-
-  xastir_snprintf(name1,
-                  sizeof(name1),
-                  "%s",
-                  pszFieldName);
-
-  str_to_upper(name1);
-
-  for( i = 0; i < DBFGetFieldCount(psDBF); i++ )
-  {
-    DBFGetFieldInfo( psDBF, i, name, NULL, NULL );
-    xastir_snprintf(name2,
-                    sizeof(name2),
-                    "%s",
-                    name);
-    str_to_upper(name2);
-
-    if(!strncmp(name1,name2,10))
-    {
-      return(i);
-    }
-  }
-  return(-1);
-}
-
-
-
-#endif
 #endif /* HAVE_LIBSHP && HAVE_LIBPCRE */
 
 

--- a/src/maps.c
+++ b/src/maps.c
@@ -6303,9 +6303,7 @@ extern void draw_shapefile_map (Widget w,
                                 u_char alert_color,
                                 int destination_pixmap,
                                 map_draw_flags *draw_flags);
-#ifdef WITH_DBFAWK
   extern void clear_dbfawk_sigs(void);
-#endif /* WITH_DBFAWK */
 #endif /* HAVE_LIBSHP */
 #ifdef HAVE_LIBGEOTIFF
 extern void draw_geotiff_image_map(Widget w,
@@ -9006,10 +9004,8 @@ void map_indexer(int parameter)
   fprintf(stderr,"Indexing maps...\n");
 
 #ifdef HAVE_LIBSHP
-#ifdef WITH_DBFAWK
   // get rid of stored dbfawk signatures and force reload.
   clear_dbfawk_sigs();
-#endif
 #endif
 
   // Find the timestamp on the index file first.  Save it away so

--- a/src/testdbfawk.c
+++ b/src/testdbfawk.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-#ifdef WITH_DBFAWK
+#if defined(HAVE_LIBSHP) && defined(HAVE_LIBPCRE)
 
 #ifdef HAVE_SHAPEFIL_H
   #include <shapefil.h>
@@ -303,7 +303,7 @@ int main(int argc, char *argv[])
   awk_free_symtab(symtbl);
   exit(0);
 }
-#else /* !WITH_DBFAWK */
+#else /* defined(HAVE_LIBSHP) && defined(HAVE_LIBPCRE) */
 
 
 
@@ -314,6 +314,6 @@ int main(int argc, char *argv[])
   fprintf(stderr,"DBFAWK support not compiled.\n");
   exit(1);
 }
-#endif /* !WITH_DBFAWK */
+#endif /* defined(HAVE_LIBSHP) && defined(HAVE_LIBPCRE) */
 
 


### PR DESCRIPTION
This PR closes bug #128 

We now require PCRE if shapelib support is needed, and always enable dbfawk.

Configure now no longer allows the user to specifically request "--without-dbfawk" or "--without-pcre".  One can still request "--without-shapelib".

If shapelib support is requested and shapelib found at configure time, we look for pcre.  If pcre is found, all is good.  If pcre is NOT found, we error out and tell the user either to disable shapelib support OR install pcre.

I have also removed from the Travis-CI config all tests that try to use "--without-dbfawk" or "--without-pcre".  Only the one with "--without-shapelib" remains.