### PR TITLE
No longer attempt to chmod *.py in scripts/Makefile

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -46,4 +46,4 @@ dist_scripts_DATA = \
 
 install-data-hook:
 	cd $(DESTDIR)$(scriptsdir) && \
-	chmod a+x *.pl *.py get-* gpx2* *.bash
+	chmod a+x *.pl get-* gpx2* *.bash


### PR DESCRIPTION
As of 93950da37ad18f2f50426b8008522e8b8115b75b, there is no longer a .py script to chmod.  (This prevents `make install-data-hook` from puking.)