### PR TITLE
Correct a spelling error in source output messages

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -8121,14 +8121,14 @@ void output_my_aprs_data(void)
                strlen(data_txt)) != (int)strlen(data_txt))
     {
       fprintf(stderr,
-              "my_aprs_data: Writen error: %d\n",
+              "my_aprs_data: Written error: %d\n",
               errno);
     }
     // Terminate it with a linefeed
     if (writen(pipe_xastir_to_tcp_server, "\n", 1) != 1)
     {
       fprintf(stderr,
-              "my_aprs_data: Writen error: %d\n",
+              "my_aprs_data: Written error: %d\n",
               errno);
     }
   }
@@ -8762,14 +8762,14 @@ void output_my_data(char *message, int incoming_port, int type, int loopback_onl
                strlen(data_txt)) != (int)strlen(data_txt))
     {
       fprintf(stderr,
-              "output_my_data: Writen error: %d\n",
+              "output_my_data: Written error: %d\n",
               errno);
     }
     // Terminate it with a linefeed
     if (writen(pipe_xastir_to_tcp_server, "\n", 1) != 1)
     {
       fprintf(stderr,
-              "output_my_data: Writen error: %d\n",
+              "output_my_data: Written error: %d\n",
               errno);
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -13625,7 +13625,7 @@ void UpdateTime( XtPointer clientData, XtIntervalId UNUSED(id) )
                   if (errno != EPIPE)
                   {
                     fprintf(stderr,
-                            "UpdateTime: Writen error (Net send x_spider): %d\n",
+                            "UpdateTime: Written error (Net send x_spider): %d\n",
                             errno);
                   }
                 }
@@ -13696,7 +13696,7 @@ void UpdateTime( XtPointer clientData, XtIntervalId UNUSED(id) )
                            data_length+1) != data_length+1)
                 {
                   fprintf(stderr,
-                          "UpdateTime: Writen error (TNC Send x_spider): %d\n",
+                          "UpdateTime: Written error (TNC Send x_spider): %d\n",
                           errno);
                 }
               }
@@ -13753,7 +13753,7 @@ void UpdateTime( XtPointer clientData, XtIntervalId UNUSED(id) )
                              data_length+1) != data_length+1)
                   {
                     fprintf(stderr,
-                            "UpdateTime: Writen error(HSP data): %d\n",
+                            "UpdateTime: Written error(HSP data): %d\n",
                             errno);
                   }
                 }
@@ -13813,7 +13813,7 @@ void UpdateTime( XtPointer clientData, XtIntervalId UNUSED(id) )
                              data_length+1) != data_length+1)
                   {
                     fprintf(stderr,
-                            "UpdateTime: Writen error(TNC/GPS data): %d\n",
+                            "UpdateTime: Written error(TNC/GPS data): %d\n",
                             errno);
                   }
                 }

--- a/src/x_spider.c
+++ b/src/x_spider.c
@@ -346,7 +346,7 @@ void str_echo(int sockfd) {
         }
 
         if (writen(sockfd, line, n) != n) {
-            fprintf(stderr,"str_echo: Writen error\n");
+            fprintf(stderr,"str_echo: Written error\n");
         }
     }
 }
@@ -423,7 +423,7 @@ void str_echo2(int sockfd, int pipe_from_parent, int pipe_to_parent)
       //            fprintf(stderr,"str_echo2: %s\n",line);
       if (writen(pipe_to_parent, line, n) != n)
       {
-        fprintf(stderr,"str_echo2: Writen error socket: %d\n",errno);
+        fprintf(stderr,"str_echo2: Written error socket: %d\n",errno);
         //close(sockfd);
         return;
       }
@@ -464,7 +464,7 @@ void str_echo2(int sockfd, int pipe_from_parent, int pipe_to_parent)
 
       if (writen(sockfd, line, n) != n)
       {
-        fprintf(stderr,"str_echo2: Writen error pipe: %d\n",errno);
+        fprintf(stderr,"str_echo2: Written error pipe: %d\n",errno);
         //close(pipe_from_parent);
         return;
       }
@@ -729,7 +729,7 @@ int pipe_check(char *client_address)
         {
           if (writen(q->to_child[1], line, n) != n)
           {
-            fprintf(stderr,"pipe_check: Writen error1: %d\n",errno);
+            fprintf(stderr,"pipe_check: Written error1: %d\n",errno);
           }
         }
         q = q->next;
@@ -767,7 +767,7 @@ int pipe_check(char *client_address)
 
         if (writen(pipe_tcp_server_to_xastir, line, n) != n)
         {
-          fprintf(stderr, "pipe_check: Writen error2: %d\n", errno);
+          fprintf(stderr, "pipe_check: Written error2: %d\n", errno);
         }
       }
     }
@@ -876,7 +876,7 @@ int pipe_check(char *client_address)
 
       if (writen(q->to_child[1], line, n) != n)
       {
-        fprintf(stderr,"pipe_check: Writen error1: %d\n",errno);
+        fprintf(stderr,"pipe_check: Written error1: %d\n",errno);
       }
       q = q->next;
     }
@@ -1739,7 +1739,7 @@ void UDP_Server(int UNUSED(argc), char * UNUSED(argv[]), char * UNUSED(envp[]) )
     //fprintf(stderr,"Sending to Xastir itself\n");
     if (writen(pipe_udp_server_to_xastir, message2, n2) != n2)
     {
-      fprintf(stderr,"UDP_Server: Writen error1: %d\n", errno);
+      fprintf(stderr,"UDP_Server: Written error1: %d\n", errno);
     }
 
     // Send to the x_spider TCP server, so it can go to all
@@ -1747,7 +1747,7 @@ void UDP_Server(int UNUSED(argc), char * UNUSED(argv[]), char * UNUSED(envp[]) )
     //fprintf(stderr,"Sending to TCP clients\n");
     if (writen(pipe_xastir_to_tcp_server, message, n1) != n1)
     {
-      fprintf(stderr, "UDP_Server: Writen error2: %d\n", errno);
+      fprintf(stderr, "UDP_Server: Written error2: %d\n", errno);
     }
 
     // Send an ACK back to the xastir_udp_client program


### PR DESCRIPTION
Hi.  This corrects a minor typo found while updating the Debian package to a snapshot based on bb66a7721ad6e6234edbbd0ff9f97c5c096721ef.

Cheers,
tony