### PR TITLE
Dialogs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -266,6 +266,7 @@ matrix:
             - shapelib
             - wget
 #            - mysql
+          update: true
 
 
 

--- a/config/language-Dutch.sys
+++ b/config/language-Dutch.sys
@@ -223,7 +223,7 @@ PULDNDP049|Wis alle gemarkeerde bijnamen||
 PULDNDP050|Wis gemarkeerde bijnamen geschiedenis||
 PULDNDP051|Selecteer alleen gemarkeerde bijnamen||
 PULDNDP052|- Label route punten||
-PULDNDP055|Export all|E|
+PULDNDP055|Export All|E|
 PULDNDP056|Export to KML File||
 #
 # Units

--- a/config/language-English.sys
+++ b/config/language-English.sys
@@ -212,7 +212,7 @@ PULDNDP049|Clear All Tactical Calls||
 PULDNDP050|Clear Tactical Call History||
 PULDNDP051|Select Tactical Calls Only||
 PULDNDP052|- Label Trailpoints||
-PULDNDP055|Export all|E|
+PULDNDP055|Export All|E|
 PULDNDP056|Export to KML File||
 #
 # Units

--- a/config/language-French.sys
+++ b/config/language-French.sys
@@ -213,7 +213,7 @@ PULDNDP049|Effacer indicatifs tactiques||
 PULDNDP050|Effacer historique des indicatifs tactiques||
 PULDNDP051|Choisir seulement les indicatifs tactiques||
 PULDNDP052|- Annoter les points de piste||
-PULDNDP055|Exporter tout|E|
+PULDNDP055|Exporter Tout|E|
 PULDNDP056|Exporter vers fichier KML||
 #
 # Units

--- a/config/language-Italian.sys
+++ b/config/language-Italian.sys
@@ -211,7 +211,7 @@ PULDNDP049|Cancella tutte le chiamate tattiche||
 PULDNDP050|Cancella lo storico delle chiamate tattiche||
 PULDNDP051|Seleziona solo chiamate tattiche||
 PULDNDP052|- Etichetta i punti percorso||
-PULDNDP055|Export all|E|
+PULDNDP055|Export All|E|
 PULDNDP056|Export to KML File||
 #
 # Sistema di misura

--- a/config/language-Portuguese.sys
+++ b/config/language-Portuguese.sys
@@ -212,7 +212,7 @@ PULDNDP049|Limpar todos os indicativos tacticos||
 PULDNDP050|Limpar a historia dos indicativos tacticos||
 PULDNDP051|Seleccionar unicamente indicativos tacticos||
 PULDNDP052|- Etiquetas de pontos de pista||
-PULDNDP055|Export all|E|
+PULDNDP055|Export All|E|
 PULDNDP056|Export to KML File||
 #
 # Inglesa/metrica

--- a/config/language-Spanish.sys
+++ b/config/language-Spanish.sys
@@ -210,7 +210,7 @@ PULDNDP049|Clear All Tactical Calls||
 PULDNDP050|Clear Tactical Call History||
 PULDNDP051|Select Tactical Calls Only||
 PULDNDP052|- Label Trailpoints||
-PULDNDP055|Export all|E|
+PULDNDP055|Export All|E|
 PULDNDP056|Export to KML File||
 #
 # Inglesa/Métrica

--- a/src/db.c
+++ b/src/db.c
@@ -5072,7 +5072,7 @@ void Change_tactical(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer U
     XtManageChild(pane);
 
     XtPopup(change_tactical_dialog,XtGrabNone);
-    fix_dialog_size(change_tactical_dialog);
+    //fix_dialog_size(change_tactical_dialog);
 
     // Move focus to the Close button.  This appears to
     // highlight the

--- a/src/db.c
+++ b/src/db.c
@@ -5093,7 +5093,6 @@ void Change_tactical(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer U
     }
 
     XtPopup(change_tactical_dialog,XtGrabNone);
-    //fix_dialog_size(change_tactical_dialog);
 
     // Move focus to the Close button.  This appears to
     // highlight the
@@ -7131,10 +7130,9 @@ void Station_data(Widget w, XtPointer clientData, XtPointer calldata)
 
       XtPopup(db_station_info,XtGrabNone);
 
-      //            fix_dialog_size(db_station_info);
       XmTextShowPosition(si_text,0);
 
-      // Move focus to the Cancel button.  This appears to highlight t
+      // Move focus to the Cancel button.  This appears to highlight the
       // button fine, but we're not able to hit the <Enter> key to
       // have that default function happen.  Note:  We _can_ hit the
       // <SPACE> key, and that activates the option.
@@ -7560,7 +7558,7 @@ void Station_info(Widget w, XtPointer clientData, XtPointer UNUSED(calldata) )
 
         XtPopup(db_station_popup,XtGrabNone);
 
-        // Move focus to the Cancel button.  This appears to highlight t
+        // Move focus to the Cancel button.  This appears to highlight the
         // button fine, but we're not able to hit the <Enter> key to
         // have that default function happen.  Note:  We _can_ hit the
         // <SPACE> key, and that activates the option.

--- a/src/db.c
+++ b/src/db.c
@@ -4932,7 +4932,8 @@ void Change_tactical_change_data(Widget widget, XtPointer clientData, XtPointer 
 
 void Change_tactical(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget pane, my_form, button_ok, button_close, label;
+  static Widget pane, my_form, button_ok, button_close, label, scrollwindow;
+  Dimension width, height;
   Atom delw;
   Arg al[50];                     // Arg List
   register unsigned int ac = 0;   // Arg Count
@@ -4955,9 +4956,15 @@ void Change_tactical(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer U
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("Change Tactical scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Change Tactical my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 3,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -5070,6 +5077,20 @@ void Change_tactical(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer U
 
     XtManageChild(my_form);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(change_tactical_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Change_tactical dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     XtPopup(change_tactical_dialog,XtGrabNone);
     //fix_dialog_size(change_tactical_dialog);
@@ -6389,7 +6410,8 @@ void Station_data(Widget w, XtPointer clientData, XtPointer calldata)
          button_direct, button_version, station_icon, station_call,
          station_type, station_data_auto_update_w,
          button_tactical, button_change_trail_color,
-         button_track_station,button_clear_df;
+         button_track_station,button_clear_df,scrollwindow;
+  Dimension width, height;
   Arg args[50];
   Pixmap icon;
   Position x,y;    // For saving current dialog position
@@ -6505,8 +6527,15 @@ void Station_data(Widget w, XtPointer clientData, XtPointer calldata)
                             XmNbackground, colors[0xff],
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("State Data scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     form =  XtVaCreateWidget("Station Data form",
-                             xmFormWidgetClass, pane,
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 4,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
@@ -7076,6 +7105,20 @@ void Station_data(Widget w, XtPointer clientData, XtPointer calldata)
     XtManageChild(si_text);
     XtVaSetValues(si_text, XmNbackground, colors[0x0f], NULL);
     XtManageChild(pane);
+
+   // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(db_station_info,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Station Info dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     if (station_data_auto_update)
     {

--- a/src/draw_symbols.c
+++ b/src/draw_symbols.c
@@ -3519,7 +3519,8 @@ void Select_symbol_change_data(Widget widget, XtPointer clientData, XtPointer ca
 void Select_symbol( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
   static Widget  pane, my_form, my_form2, my_form3, button_cancel,
-         frame, frame2, b1;
+         frame, frame2, b1, scrollwindow;
+  Dimension width, height;
   int i;
   Atom delw;
 
@@ -3545,9 +3546,15 @@ void Select_symbol( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UN
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("Select_symbol scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Select_symbol my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 5,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -3722,6 +3729,20 @@ void Select_symbol( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UN
     XtManageChild(my_form2);
     XtManageChild(my_form);
     XtManageChild(pane);
+
+   // Resize dialog to exactly fit my_form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(select_symbol_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Select_symbol dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     XtPopup(select_symbol_dialog,XtGrabNone);
     //fix_dialog_size(select_symbol_dialog);

--- a/src/draw_symbols.c
+++ b/src/draw_symbols.c
@@ -3724,7 +3724,7 @@ void Select_symbol( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UN
     XtManageChild(pane);
 
     XtPopup(select_symbol_dialog,XtGrabNone);
-    fix_dialog_size(select_symbol_dialog);
+    //fix_dialog_size(select_symbol_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/draw_symbols.c
+++ b/src/draw_symbols.c
@@ -3745,7 +3745,6 @@ void Select_symbol( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UN
     }
 
     XtPopup(select_symbol_dialog,XtGrabNone);
-    //fix_dialog_size(select_symbol_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/geocoder_gui.c
+++ b/src/geocoder_gui.c
@@ -574,7 +574,7 @@ void Geocoder_place(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UN
     end_critical_section(&geocoder_place_dialog_lock, "geocoder_gui.c:Geocoder_place" );
 
     XtPopup(geocoder_place_dialog,XtGrabNone);
-    fix_dialog_size(geocoder_place_dialog);
+    //fix_dialog_size(geocoder_place_dialog);
 
     XmProcessTraversal(button_ok, XmTRAVERSE_CURRENT);
 

--- a/src/geocoder_gui.c
+++ b/src/geocoder_gui.c
@@ -597,7 +597,6 @@ void Geocoder_place(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UN
     end_critical_section(&geocoder_place_dialog_lock, "geocoder_gui.c:Geocoder_place" );
 
     XtPopup(geocoder_place_dialog,XtGrabNone);
-    //fix_dialog_size(geocoder_place_dialog);
 
     XmProcessTraversal(button_ok, XmTRAVERSE_CURRENT);
 

--- a/src/geocoder_gui.c
+++ b/src/geocoder_gui.c
@@ -277,8 +277,9 @@ void  Show_dest_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer c
 
 void Geocoder_place(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget pane, form, button_ok, button_cancel, sep,
+  static Widget pane, scrollwindow, form, button_ok, button_cancel, sep,
          zip, state, locality, address, map_file, show_dest_toggle;
+  Dimension width, height;
   Atom delw;
 
   if (!geocoder_place_dialog)
@@ -298,7 +299,15 @@ void Geocoder_place(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UN
                             XmNbackground, colors[0xff],
                             NULL);
 
-    form =  XtVaCreateWidget("Geocoder_place form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("Geocoder_place scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    form =  XtVaCreateWidget("Geocoder_place form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 2,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
@@ -570,6 +579,20 @@ void Geocoder_place(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UN
 
     XtManageChild(form);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(geocoder_place_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Change_tactical dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     end_critical_section(&geocoder_place_dialog_lock, "geocoder_gui.c:Geocoder_place" );
 

--- a/src/interface_gui.c
+++ b/src/interface_gui.c
@@ -2143,7 +2143,6 @@ void Config_TNC( Widget UNUSED(w), int device_type, int config_type, int port)
     }
 
     XtPopup(config_TNC_dialog,XtGrabNone);
-    //fix_dialog_size(config_TNC_dialog);
   }
   else
   {
@@ -2782,7 +2781,6 @@ void Config_GPS( Widget UNUSED(w), int config_type, int port)
     }
 
     XtPopup(config_GPS_dialog,XtGrabNone);
-    //fix_dialog_size(config_GPS_dialog);
   }
   else
   {
@@ -3534,7 +3532,6 @@ void Config_WX( Widget UNUSED(w), int config_type, int port)
     }
 
     XtPopup(config_WX_dialog,XtGrabNone);
-    //fix_dialog_size(config_WX_dialog);
   }
   else
   {
@@ -4120,7 +4117,6 @@ void Config_NWX( Widget UNUSED(w), int config_type, int port)
     }
 
     XtPopup(config_NWX_dialog,XtGrabNone);
-    //fix_dialog_size(config_NWX_dialog);
   }
   else
   {
@@ -4589,7 +4585,6 @@ void Config_NGPS( Widget UNUSED(w), int config_type, int port)
     }
 
     XtPopup(config_NGPS_dialog,XtGrabNone);
-    //fix_dialog_size(config_NGPS_dialog);
   }
   else
   {
@@ -5343,7 +5338,6 @@ void Config_AX25( Widget UNUSED(w), int config_type, int port)
     }
 
     XtPopup(config_AX25_dialog,XtGrabNone);
-    //fix_dialog_size(config_AX25_dialog);
   }
   else
   {
@@ -5908,7 +5902,6 @@ void Config_Inet( Widget UNUSED(w), int config_type, int port)
     }
 
     XtPopup(config_Inet_dialog,XtGrabNone);
-    //fix_dialog_size(config_Inet_dialog);
   }
   else
   {
@@ -6467,7 +6460,6 @@ void Config_Database( Widget UNUSED(w), int config_type, int port)
     }
 
     XtPopup(config_Database_dialog,XtGrabNone);
-    //fix_dialog_size(config_Database_dialog);
   }
   else
   {
@@ -7664,7 +7656,6 @@ void Config_sql_Database( Widget w, int config_type, int port)
     }
 
     XtPopup(config_Sql_Database_dialog,XtGrabNone);
-    //fix_dialog_size(config_Sql_Database_dialog);
   }
   else
   {
@@ -8581,7 +8572,6 @@ void Config_AGWPE( Widget UNUSED(w), int config_type, int port)
     }
 
     XtPopup(config_AGWPE_dialog,XtGrabNone);
-    //fix_dialog_size(config_AGWPE_dialog);
   }
   else
   {
@@ -9354,7 +9344,6 @@ void interface_option(Widget w, XtPointer clientData,  XtPointer UNUSED(callData
         }
 
         XtPopup(choose_interface_dialog,XtGrabNone);
-        //fix_dialog_size(choose_interface_dialog);
 
         // Move focus to the Cancel button.  This appears to highlight the
         // button fine, but we're not able to hit the <Enter> key to
@@ -10025,7 +10014,6 @@ void control_interface( Widget UNUSED(w),  XtPointer UNUSED(clientData),  XtPoin
     end_critical_section(&control_interface_dialog_lock, "interface_gui.c:control_interface" );
 
     XtPopup(control_interface_dialog,XtGrabNone);
-    //fix_dialog_size(control_interface_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/interface_gui.c
+++ b/src/interface_gui.c
@@ -687,13 +687,14 @@ void Config_TNC_change_data(Widget widget, XtPointer clientData, XtPointer callD
 
 void Config_TNC( Widget UNUSED(w), int device_type, int config_type, int port)
 {
-  static Widget  pane, form, form2, button_ok, button_cancel,
+  static Widget  pane, scrollwindow, form, form2, button_ok, button_cancel,
          frame, frame2, frame3, frame4,
          setup1, setup3, setup4,
          device, converse, comment, speed_box,
          speed_300, speed_1200, speed_2400, speed_4800, speed_9600,
          speed_19200, speed_38400;
 //  static Widget setup, setup2, speed;
+  Dimension width, height;
 #ifndef __LSB__
   static Widget speed_57600, speed_115200, speed_230400;
 #endif  // __LSB__
@@ -762,7 +763,15 @@ void Config_TNC( Widget UNUSED(w), int device_type, int config_type, int port)
                             XmNbackground, colors[0xff],
                             NULL);
 
-    form =  XtVaCreateWidget("Config_TNC form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    form =  XtVaCreateWidget("Config_TNC form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 5,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
@@ -2119,6 +2128,20 @@ void Config_TNC( Widget UNUSED(w), int device_type, int config_type, int port)
     XtManageChild(igate_box);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(config_TNC_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Config TNC dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(config_TNC_dialog,XtGrabNone);
     //fix_dialog_size(config_TNC_dialog);
   }
@@ -2261,12 +2284,13 @@ void Config_GPS_change_data(Widget widget, XtPointer clientData, XtPointer callD
 
 void Config_GPS( Widget UNUSED(w), int config_type, int port)
 {
-  static Widget  pane, form, button_ok, button_cancel,
+  static Widget  pane, scrollwindow, form, button_ok, button_cancel,
          frame, frame2,
          device, comment, speed_box,
          speed_300, speed_1200, speed_2400, speed_4800, speed_9600,
          speed_19200, speed_38400;
 //  static Widget speed;
+  Dimension width, height;
 #ifndef __LSB__
   static Widget speed_57600, speed_115200, speed_230400;
 #endif  // __LSB__
@@ -2292,7 +2316,15 @@ void Config_GPS( Widget UNUSED(w), int config_type, int port)
                             XmNbackground, colors[0xff],
                             NULL);
 
-    form =  XtVaCreateWidget("Config_GPS form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    form =  XtVaCreateWidget("Config_GPS form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 5,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
@@ -2735,6 +2767,20 @@ void Config_GPS( Widget UNUSED(w), int config_type, int port)
     XtManageChild(style_box);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(config_GPS_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Config GPS dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(config_GPS_dialog,XtGrabNone);
     //fix_dialog_size(config_GPS_dialog);
   }
@@ -2875,12 +2921,13 @@ void Config_WX_change_data(Widget widget, XtPointer clientData, XtPointer callDa
 
 void Config_WX( Widget UNUSED(w), int config_type, int port)
 {
-  static Widget  pane, form, button_ok, button_cancel,
+  static Widget  pane, scrollwindow, form, button_ok, button_cancel,
          frame, frame2, frame3, frame4, WX_none,
          device, comment, speed_box,
          speed_300, speed_1200, speed_2400, speed_4800, speed_9600,
          speed_19200, speed_38400;
 //  static Widget speed;
+  Dimension width, height;
 #ifndef __LSB__
   static Widget speed_57600, speed_115200, speed_230400;
 #endif  // __LSB__
@@ -2910,7 +2957,15 @@ void Config_WX( Widget UNUSED(w), int config_type, int port)
                             XmNbackground, colors[0xff],
                             NULL);
 
-    form =  XtVaCreateWidget("Config_WX form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    form =  XtVaCreateWidget("Config_WX form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 5,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
@@ -3464,6 +3519,20 @@ void Config_WX( Widget UNUSED(w), int config_type, int port)
     XtManageChild(gauge_box);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(config_WX_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Config WX dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(config_WX_dialog,XtGrabNone);
     //fix_dialog_size(config_WX_dialog);
   }
@@ -3613,7 +3682,7 @@ void Config_NWX_change_data(Widget widget, XtPointer clientData, XtPointer callD
 
 void Config_NWX( Widget UNUSED(w), int config_type, int port)
 {
-  static Widget  pane, form, frame3, frame4, WX_none,
+  static Widget  pane, scrollwindow, form, frame3, frame4, WX_none,
          button_ok, button_cancel,
          hostn, portn, comment,
          data_box,
@@ -3621,6 +3690,7 @@ void Config_NWX( Widget UNUSED(w), int config_type, int port)
          gauge_box,
          sep;
 //  static Widget data_type, gauge_type;
+  Dimension width, height;
   char temp[20];
   Arg al[50];                    /* Arg List */
   register unsigned int ac = 0;           /* Arg Count */
@@ -3640,7 +3710,15 @@ void Config_NWX( Widget UNUSED(w), int config_type, int port)
                             XmNbackground, colors[0xff],
                             NULL);
 
-    form =  XtVaCreateWidget("Config_NWX form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    form =  XtVaCreateWidget("Config_NWX form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 5,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
@@ -4027,6 +4105,20 @@ void Config_NWX( Widget UNUSED(w), int config_type, int port)
     XtManageChild(gauge_box);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(config_NWX_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Config Networked Weather dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(config_NWX_dialog,XtGrabNone);
     //fix_dialog_size(config_NWX_dialog);
   }
@@ -4185,9 +4277,10 @@ void Config_NGPS_change_data(Widget widget, XtPointer clientData, XtPointer call
 
 void Config_NGPS( Widget UNUSED(w), int config_type, int port)
 {
-  static Widget  pane, form, button_ok, button_cancel,
+  static Widget  pane, scrollwindow, form, button_ok, button_cancel,
          hostn, portn, comment,
          sep;
+  Dimension width, height;
   char temp[20];
   Atom delw;
 
@@ -4205,7 +4298,15 @@ void Config_NGPS( Widget UNUSED(w), int config_type, int port)
                             XmNbackground, colors[0xff],
                             NULL);
 
-    form =  XtVaCreateWidget("Config_NGPS form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    form =  XtVaCreateWidget("Config_NGPS form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 5,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
@@ -4473,6 +4574,20 @@ void Config_NGPS( Widget UNUSED(w), int config_type, int port)
     XtManageChild(form);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(config_NGPS_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Config Networked GPS dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(config_NGPS_dialog,XtGrabNone);
     //fix_dialog_size(config_NGPS_dialog);
   }
@@ -4697,7 +4812,7 @@ void Config_AX25_change_data(Widget widget, XtPointer clientData, XtPointer call
 
 void Config_AX25( Widget UNUSED(w), int config_type, int port)
 {
-  static Widget  pane, form, button_ok, button_cancel, frame,
+  static Widget  pane, scrollwindow, form, button_ok, button_cancel, frame,
          devn, comment,
          proto, proto1, proto2, proto3,
          igate_box,
@@ -4705,6 +4820,7 @@ void Config_AX25( Widget UNUSED(w), int config_type, int port)
          igate_label,
          sep;
 //  static Widget igate;
+  Dimension width, height;
 
   char temp[50];
   Atom delw;
@@ -4725,7 +4841,15 @@ void Config_AX25( Widget UNUSED(w), int config_type, int port)
                             XmNbackground, colors[0xff],
                             NULL);
 
-    form =  XtVaCreateWidget("Config_AX25 form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    form =  XtVaCreateWidget("Config_AX25 form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 5,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
@@ -5204,6 +5328,20 @@ void Config_AX25( Widget UNUSED(w), int config_type, int port)
     XtManageChild(igate_box);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(config_AX25_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Config AX25 dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(config_AX25_dialog,XtGrabNone);
     //fix_dialog_size(config_AX25_dialog);
   }
@@ -5382,10 +5520,11 @@ void Inet_change_data(Widget widget, XtPointer clientData, XtPointer callData)
 
 void Config_Inet( Widget UNUSED(w), int config_type, int port)
 {
-  static Widget  pane, form, button_ok, button_cancel,
+  static Widget  pane, scrollwindow, form, button_ok, button_cancel,
          ihost, iport, password,
          filter, comment, sep;
 //  static Widget password_fl;
+  Dimension width, height;
 
   Atom delw;
   char temp[40];
@@ -5404,7 +5543,15 @@ void Config_Inet( Widget UNUSED(w), int config_type, int port)
                             XmNbackground, colors[0xff],
                             NULL);
 
-    form =  XtVaCreateWidget("Config_Inet form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    form =  XtVaCreateWidget("Config_Inet form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 5,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
@@ -5746,6 +5893,20 @@ void Config_Inet( Widget UNUSED(w), int config_type, int port)
     XtManageChild(form);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(config_Inet_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Config INET dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(config_Inet_dialog,XtGrabNone);
     //fix_dialog_size(config_Inet_dialog);
   }
@@ -5924,10 +6085,11 @@ void Database_change_data(Widget widget, XtPointer clientData, XtPointer callDat
 
 void Config_Database( Widget UNUSED(w), int config_type, int port)
 {
-  static Widget  pane, form, button_ok, button_cancel,
+  static Widget  pane, scrollwindow, form, button_ok, button_cancel,
          ihost, iport, password,
          filter, sep, comment;
 //  static Widget password_fl;
+  Dimension width, height;
 
   Atom delw;
   char temp[40];
@@ -5946,7 +6108,15 @@ void Config_Database( Widget UNUSED(w), int config_type, int port)
                             XmNbackground, colors[0xff],
                             NULL);
 
-    form =  XtVaCreateWidget("Config_Database form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    form =  XtVaCreateWidget("Config_Database form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 5,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
@@ -6281,6 +6451,20 @@ void Config_Database( Widget UNUSED(w), int config_type, int port)
     }
     XtManageChild(form);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(config_Database_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Config database dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     XtPopup(config_Database_dialog,XtGrabNone);
     //fix_dialog_size(config_Database_dialog);
@@ -6675,11 +6859,12 @@ void sddd_menuCallback(Widget widget, XtPointer ptr, XtPointer callData)
  */
 void Config_sql_Database( Widget w, int config_type, int port)
 {
-  static Widget  pane, form, button_ok, button_cancel, label_dbms, label_schema_type,
+  static Widget  pane, scrollwindow, form, button_ok, button_cancel, label_dbms, label_schema_type,
          ihost, iport, password, unix_socket, error_message,
          sep, comment, username, schema_name;
   static Widget button_mysql_defaults;    // set form values to defaults for mysql
   static Widget button_postgis_defaults;  // set form values to deaults for postgresql/postgis
+  Dimension width, height;
   int defaults_set;  // Have defaults been set on form for new interface?
   // Used to make only a single set defaults call when
   // support for multiple types of dbms are available.
@@ -6735,7 +6920,15 @@ void Config_sql_Database( Widget w, int config_type, int port)
                             XmNbackground, colors[0xff],
                             NULL);
 
-    form =  XtVaCreateWidget("Config_Database form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    form =  XtVaCreateWidget("Config_Database form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase,    13,
                              XmNbackground,      colors[0xff],
                              XmNautoUnmanage,    FALSE,
@@ -7456,6 +7649,20 @@ void Config_sql_Database( Widget w, int config_type, int port)
     XtManageChild(form);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(config_Sql_Database_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Config SQL database dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(config_Sql_Database_dialog,XtGrabNone);
     //fix_dialog_size(config_Sql_Database_dialog);
   }
@@ -7707,12 +7914,13 @@ void AGWPE_change_data(Widget widget, XtPointer clientData, XtPointer callData)
 
 void Config_AGWPE( Widget UNUSED(w), int config_type, int port)
 {
-  static Widget  pane, form, button_ok, button_cancel,
+  static Widget  pane, scrollwindow, form, button_ok, button_cancel,
          ihost, iport, password, sep,
          igate_box, igate_o_0, igate_o_1, igate_o_2,
          igate_label, frame, proto, proto1, proto2, proto3,
          radioport_label, comment;
 //  static Widget igate, password_fl;
+  Dimension width, height;
   Atom delw;
   char temp[40];
   Arg al[50];                      // Arg list
@@ -7732,7 +7940,15 @@ void Config_AGWPE( Widget UNUSED(w), int config_type, int port)
                             XmNbackground, colors[0xff],
                             NULL);
 
-    form =  XtVaCreateWidget("Config_AGWPE form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    form =  XtVaCreateWidget("Config_AGWPE form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 5,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
@@ -8350,6 +8566,20 @@ void Config_AGWPE( Widget UNUSED(w), int config_type, int port)
     XtManageChild(form);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(config_AGWPE_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Config AGWPE dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(config_AGWPE_dialog,XtGrabNone);
     //fix_dialog_size(config_AGWPE_dialog);
   }
@@ -8962,7 +9192,8 @@ void interface_setup(Widget w, XtPointer clientData,  XtPointer UNUSED(callData)
 //
 void interface_option(Widget w, XtPointer clientData,  XtPointer UNUSED(callData) )
 {
-  Widget pane, form, label, button_add, button_cancel;
+  Widget pane, scrollwindow, form, label, button_add, button_cancel;
+  Dimension width, height;
   char *what = (char *)clientData;
   int i,x,n,do_w;
   char *temp;
@@ -8997,7 +9228,15 @@ void interface_option(Widget w, XtPointer clientData,  XtPointer UNUSED(callData
                                 XmNbackground, colors[0xff],
                                 NULL);
 
-        form =  XtVaCreateWidget("interface_option form",xmFormWidgetClass, pane,
+        scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                               xmScrolledWindowWidgetClass,
+                                               pane,
+                                               XmNscrollingPolicy, XmAUTOMATIC,
+                                               NULL);
+
+        form =  XtVaCreateWidget("interface_option form",
+                                 xmFormWidgetClass,
+                                 scrollwindow,
                                  XmNfractionBase, 5,
                                  XmNbackground, colors[0xff],
                                  XmNautoUnmanage, FALSE,
@@ -9099,6 +9338,20 @@ void interface_option(Widget w, XtPointer clientData,  XtPointer UNUSED(callData
         XtManageChild(interface_type_list);
         XtVaSetValues(interface_type_list, XmNbackground, colors[0x0f], NULL);
         XtManageChild(pane);
+
+        // Resize dialog to exactly fit form w/o scrollbars
+        XtVaGetValues(form,
+                      XmNwidth, &width,
+                      XmNheight, &height,
+                      NULL);
+        XtVaSetValues(choose_interface_dialog,
+                      XmNwidth, width+10,
+                      XmNheight, height+10,
+                      NULL);
+        if (debug_level & 1)
+        {
+          fprintf(stderr,"Choose interface dialog size: X:%d\tY:%d\n", width, height);
+        }
 
         XtPopup(choose_interface_dialog,XtGrabNone);
         //fix_dialog_size(choose_interface_dialog);
@@ -9532,8 +9785,9 @@ void Control_interface_destroy_shell( Widget UNUSED(widget), XtPointer clientDat
 
 void control_interface( Widget UNUSED(w),  XtPointer UNUSED(clientData),  XtPointer UNUSED(callData) )
 {
-  static Widget rowcol, form, button_start, button_stop, button_start_all, button_stop_all, button_cancel;
+  static Widget scrollwindow, rowcol, form, button_start, button_stop, button_start_all, button_stop_all, button_cancel;
   static Widget button_add, button_delete, button_properties;
+  Dimension width, height;
   Atom delw;
   Arg al[50];                    /* Arg List */
   register unsigned int ac = 0;           /* Arg Count */
@@ -9552,7 +9806,15 @@ void control_interface( Widget UNUSED(w),  XtPointer UNUSED(clientData),  XtPoin
                                XmNfontList, fontlist1,
                                NULL);
 
-    rowcol =  XtVaCreateWidget("control_interface rowcol",xmRowColumnWidgetClass, control_interface_dialog,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           control_interface_dialog,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    rowcol =  XtVaCreateWidget("control_interface rowcol",
+                               xmRowColumnWidgetClass,
+                               scrollwindow,
                                XmNorientation, XmVERTICAL,
                                XmNnumColumns, 1,
                                XmNpacking, XmPACK_TIGHT,
@@ -9745,6 +10007,20 @@ void control_interface( Widget UNUSED(w),  XtPointer UNUSED(clientData),  XtPoin
     XtManageChild(control_iface_list);
     XtManageChild(form);
     XtManageChild(rowcol);
+
+   // Resize dialog to exactly fit rowcol w/o scrollbars
+    XtVaGetValues(rowcol,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(control_interface_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Interface dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     end_critical_section(&control_interface_dialog_lock, "interface_gui.c:control_interface" );
 

--- a/src/interface_gui.c
+++ b/src/interface_gui.c
@@ -2120,7 +2120,7 @@ void Config_TNC( Widget UNUSED(w), int device_type, int config_type, int port)
     XtManageChild(pane);
 
     XtPopup(config_TNC_dialog,XtGrabNone);
-    fix_dialog_size(config_TNC_dialog);
+    //fix_dialog_size(config_TNC_dialog);
   }
   else
   {
@@ -2736,7 +2736,7 @@ void Config_GPS( Widget UNUSED(w), int config_type, int port)
     XtManageChild(pane);
 
     XtPopup(config_GPS_dialog,XtGrabNone);
-    fix_dialog_size(config_GPS_dialog);
+    //fix_dialog_size(config_GPS_dialog);
   }
   else
   {
@@ -3465,7 +3465,7 @@ void Config_WX( Widget UNUSED(w), int config_type, int port)
     XtManageChild(pane);
 
     XtPopup(config_WX_dialog,XtGrabNone);
-    fix_dialog_size(config_WX_dialog);
+    //fix_dialog_size(config_WX_dialog);
   }
   else
   {
@@ -4028,7 +4028,7 @@ void Config_NWX( Widget UNUSED(w), int config_type, int port)
     XtManageChild(pane);
 
     XtPopup(config_NWX_dialog,XtGrabNone);
-    fix_dialog_size(config_NWX_dialog);
+    //fix_dialog_size(config_NWX_dialog);
   }
   else
   {
@@ -4474,7 +4474,7 @@ void Config_NGPS( Widget UNUSED(w), int config_type, int port)
     XtManageChild(pane);
 
     XtPopup(config_NGPS_dialog,XtGrabNone);
-    fix_dialog_size(config_NGPS_dialog);
+    //fix_dialog_size(config_NGPS_dialog);
   }
   else
   {
@@ -5205,7 +5205,7 @@ void Config_AX25( Widget UNUSED(w), int config_type, int port)
     XtManageChild(pane);
 
     XtPopup(config_AX25_dialog,XtGrabNone);
-    fix_dialog_size(config_AX25_dialog);
+    //fix_dialog_size(config_AX25_dialog);
   }
   else
   {
@@ -5747,7 +5747,7 @@ void Config_Inet( Widget UNUSED(w), int config_type, int port)
     XtManageChild(pane);
 
     XtPopup(config_Inet_dialog,XtGrabNone);
-    fix_dialog_size(config_Inet_dialog);
+    //fix_dialog_size(config_Inet_dialog);
   }
   else
   {
@@ -6283,7 +6283,7 @@ void Config_Database( Widget UNUSED(w), int config_type, int port)
     XtManageChild(pane);
 
     XtPopup(config_Database_dialog,XtGrabNone);
-    fix_dialog_size(config_Database_dialog);
+    //fix_dialog_size(config_Database_dialog);
   }
   else
   {
@@ -7457,7 +7457,7 @@ void Config_sql_Database( Widget w, int config_type, int port)
     XtManageChild(pane);
 
     XtPopup(config_Sql_Database_dialog,XtGrabNone);
-    fix_dialog_size(config_Sql_Database_dialog);
+    //fix_dialog_size(config_Sql_Database_dialog);
   }
   else
   {
@@ -8351,7 +8351,7 @@ void Config_AGWPE( Widget UNUSED(w), int config_type, int port)
     XtManageChild(pane);
 
     XtPopup(config_AGWPE_dialog,XtGrabNone);
-    fix_dialog_size(config_AGWPE_dialog);
+    //fix_dialog_size(config_AGWPE_dialog);
   }
   else
   {
@@ -9101,7 +9101,7 @@ void interface_option(Widget w, XtPointer clientData,  XtPointer UNUSED(callData
         XtManageChild(pane);
 
         XtPopup(choose_interface_dialog,XtGrabNone);
-        fix_dialog_size(choose_interface_dialog);
+        //fix_dialog_size(choose_interface_dialog);
 
         // Move focus to the Cancel button.  This appears to highlight the
         // button fine, but we're not able to hit the <Enter> key to
@@ -9749,7 +9749,7 @@ void control_interface( Widget UNUSED(w),  XtPointer UNUSED(clientData),  XtPoin
     end_critical_section(&control_interface_dialog_lock, "interface_gui.c:control_interface" );
 
     XtPopup(control_interface_dialog,XtGrabNone);
-    fix_dialog_size(control_interface_dialog);
+    //fix_dialog_size(control_interface_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/locate_gui.c
+++ b/src/locate_gui.c
@@ -519,7 +519,6 @@ void Locate_station(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer ca
     end_critical_section(&locate_station_dialog_lock, "locate_gui.c:Locate_station" );
 
     XtPopup(locate_station_dialog,XtGrabNone);
-    //fix_dialog_size(locate_station_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -1298,7 +1297,6 @@ void Locate_place(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUS
     end_critical_section(&locate_place_dialog_lock, "locate_gui.c:Locate_place" );
 
     XtPopup(locate_place_dialog,XtGrabNone);
-    //fix_dialog_size(locate_place_dialog);
 
     // Move focus to the Locate Now! button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/locate_gui.c
+++ b/src/locate_gui.c
@@ -496,7 +496,7 @@ void Locate_station(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer ca
     end_critical_section(&locate_station_dialog_lock, "locate_gui.c:Locate_station" );
 
     XtPopup(locate_station_dialog,XtGrabNone);
-    fix_dialog_size(locate_station_dialog);
+    //fix_dialog_size(locate_station_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -1252,7 +1252,7 @@ void Locate_place(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUS
     end_critical_section(&locate_place_dialog_lock, "locate_gui.c:Locate_place" );
 
     XtPopup(locate_place_dialog,XtGrabNone);
-    fix_dialog_size(locate_place_dialog);
+    //fix_dialog_size(locate_place_dialog);
 
     // Move focus to the Locate Now! button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/locate_gui.c
+++ b/src/locate_gui.c
@@ -308,8 +308,9 @@ void Locate_station_now(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointe
 //
 void Locate_station(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer callData)
 {
-  static Widget pane, form, button_locate, button_cancel, call,
+  static Widget pane, scrollwindow, form, button_locate, button_cancel, call,
          button_lookup, sep;
+  Dimension width, height;
   Atom delw;
   int emergency_flag = XTPOINTER_TO_INT(callData);
 
@@ -344,7 +345,15 @@ void Locate_station(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer ca
                             XmNbackground, colors[0xff],
                             NULL);
 
-    form =  XtVaCreateWidget("Locate_station form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    form =  XtVaCreateWidget("Locate_station form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 3,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
@@ -492,6 +501,20 @@ void Locate_station(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer ca
 
     XtManageChild(form);
     XtManageChild(pane);
+
+   // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(locate_station_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Location station dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     end_critical_section(&locate_station_dialog_lock, "locate_gui.c:Locate_station" );
 
@@ -916,8 +939,9 @@ void Locate_place_now(Widget w, XtPointer clientData, XtPointer callData)
 
 void Locate_place(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget pane, form, button_ok, button_cancel, sep,
+  static Widget pane, scrollwindow, form, button_ok, button_cancel, sep,
          place, state, county, quad, place_type, gnis_file;
+  Dimension width, height;
   Atom delw;
 
   if (!locate_place_dialog)
@@ -936,7 +960,15 @@ void Locate_place(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUS
                             XmNbackground, colors[0xff],
                             NULL);
 
-    form =  XtVaCreateWidget("Locate_place form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    form =  XtVaCreateWidget("Locate_place form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 2,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
@@ -1248,6 +1280,20 @@ void Locate_place(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUS
 
     XtManageChild(form);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(locate_place_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Locate place dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     end_critical_section(&locate_place_dialog_lock, "locate_gui.c:Locate_place" );
 

--- a/src/location_gui.c
+++ b/src/location_gui.c
@@ -436,7 +436,8 @@ void location_add(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(callD
 /************************************************/
 void Jump_location(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget  pane,form, button_ok, button_add, button_delete, button_cancel, locdata, location_name;
+  static Widget  pane, scrollwindow, form, button_ok, button_add, button_delete, button_cancel, locdata, location_name;
+  Dimension width, height;
   int n;
   Arg al[50];           /* Arg List */
   unsigned int ac = 0;           /* Arg Count */
@@ -467,9 +468,15 @@ void Jump_location(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNU
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     form =  XtVaCreateWidget("Jump_location form",
                              xmFormWidgetClass,
-                             pane,
+                             scrollwindow,
                              XmNfractionBase, 5,
                              XmNautoUnmanage, FALSE,
                              XmNshadowThickness, 1,
@@ -638,6 +645,20 @@ void Jump_location(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNU
     XtManageChild(location_list);
     XtVaSetValues(location_list, XmNbackground, colors[0x0f], NULL);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(location_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Location dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     end_critical_section(&location_dialog_lock, "location_gui.c:location_destroy_shell" );
 

--- a/src/location_gui.c
+++ b/src/location_gui.c
@@ -663,7 +663,6 @@ void Jump_location(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNU
     end_critical_section(&location_dialog_lock, "location_gui.c:location_destroy_shell" );
 
     XtPopup(location_dialog,XtGrabNone);
-    //fix_dialog_size(location_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/location_gui.c
+++ b/src/location_gui.c
@@ -642,7 +642,7 @@ void Jump_location(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNU
     end_critical_section(&location_dialog_lock, "location_gui.c:location_destroy_shell" );
 
     XtPopup(location_dialog,XtGrabNone);
-    fix_dialog_size(location_dialog);
+    //fix_dialog_size(location_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/main.c
+++ b/src/main.c
@@ -90,15 +90,7 @@ char *xastir_version=VERSION;
   #undef PACKAGE_TARNAME
   #define XASTIR_PACKAGE_VERSION PACKAGE_VERSION
   #undef PACKAGE_VERSION
-  #ifdef HAVE_MAGICK
-    #ifdef HAVE_MAGICKCORE_MAGICKCORE_H
-      #include <MagickCore/MagickCore.h>
-    #else
-      #ifdef HAVE_MAGICK_API_H
-        #include <magick/api.h>
-      #endif // HAVE_MAGICK_API_H
-    #endif //HAVE_MAGICKCORE_MAGICKCORE_H
-  #endif //HAVE_MAGICK
+  #include <magick/api.h>
   #undef PACKAGE_BUGREPORT
   #define PACKAGE_BUGREPORT XASTIR_PACKAGE_BUGREPORT
   #undef XASTIR_PACKAGE_BUGREPORT
@@ -1760,7 +1752,7 @@ void Smart_Beacon(Widget w, XtPointer UNUSED(clientData), XtPointer callData)
     XtManageChild(form);
     XtManageChild(pane);
     XtPopup(smart_beacon_dialog,XtGrabNone);
-    fix_dialog_size(smart_beacon_dialog);
+    //fix_dialog_size(smart_beacon_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -3201,7 +3193,7 @@ void Coordinate_calc(Widget w, XtPointer clientData, XtPointer callData)
     XtManageChild(form);
     XtManageChild(pane);
     XtPopup(coordinate_calc_dialog,XtGrabNone);
-    fix_dialog_size(coordinate_calc_dialog);
+    //fix_dialog_size(coordinate_calc_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -4548,7 +4540,7 @@ void Change_Debug_Level(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointe
     XtManageChild(pane);
 
     XtPopup(change_debug_level_dialog,XtGrabNone);
-    fix_dialog_size(change_debug_level_dialog);
+    //fix_dialog_size(change_debug_level_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -4723,7 +4715,7 @@ void Gamma_adjust(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUS
     XtManageChild(pane);
 
     XtPopup(gamma_adjust_dialog, XtGrabNone);
-    fix_dialog_size(gamma_adjust_dialog);
+    //fix_dialog_size(gamma_adjust_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -5203,7 +5195,7 @@ void Map_font(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(c
     XtManageChild(pane);
 
     XtPopup(map_font_dialog, XtGrabNone);
-    fix_dialog_size(map_font_dialog);
+    //fix_dialog_size(map_font_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -14324,6 +14316,7 @@ void pos_dialog(Widget w)
 
 /*********************  fix dialog size *************************/
 
+/*
 void fix_dialog_size(Widget w)
 {
   Dimension wd, ht;
@@ -14343,6 +14336,7 @@ void fix_dialog_size(Widget w)
                   NULL);
   }
 }
+*/
 
 
 
@@ -14927,7 +14921,7 @@ void Custom_Zoom( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUS
     XtManageChild(pane);
 
     XtPopup(custom_zoom_dialog,XtGrabNone);
-    fix_dialog_size(custom_zoom_dialog);
+    //fix_dialog_size(custom_zoom_dialog);
 
     // Move focus to the Close button.  This appears to
     // highlight the
@@ -15667,7 +15661,7 @@ void Center_Zoom( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer call
     XtManageChild(pane);
 
     XtPopup(center_zoom_dialog,XtGrabNone);
-    fix_dialog_size(center_zoom_dialog);
+    //fix_dialog_size(center_zoom_dialog);
 
     // Move focus to the Close button.  This appears to
     // highlight the
@@ -17314,7 +17308,7 @@ void GPS_transfer_select( void )
     XtManageChild(pane);
 
     XtPopup(GPS_operations_dialog,XtGrabNone);
-    fix_dialog_size(GPS_operations_dialog);
+    //fix_dialog_size(GPS_operations_dialog);
 
     // Move focus to the Select button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -19684,7 +19678,7 @@ void Help_About( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
 
   XtManageChild(d);
   pos_dialog(d);
-  fix_dialog_size(d);
+  //fix_dialog_size(d);
 }
 
 
@@ -20302,7 +20296,7 @@ void help_view( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED
       XtManageChild(pane);
 
       XtPopup(help_view_dialog,XtGrabNone);
-      fix_dialog_size(help_view_dialog);
+      //fix_dialog_size(help_view_dialog);
       XmTextShowPosition(help_text,0);
     }
     XtFree(temp);   // Free up the space allocated
@@ -20463,7 +20457,7 @@ void Help_Index( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
     XtManageChild(pane);
 
     XtPopup(help_index_dialog,XtGrabNone);
-    fix_dialog_size(help_index_dialog);
+    //fix_dialog_size(help_index_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -23758,7 +23752,7 @@ void Config_DRG( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
     XtManageChild(DRG_pane);
 
     XtPopup(configure_DRG_dialog,XtGrabNone);
-    fix_dialog_size(configure_DRG_dialog);
+    //fix_dialog_size(configure_DRG_dialog);
 
     XmProcessTraversal(button_ok, XmTRAVERSE_CURRENT);
 
@@ -25341,7 +25335,7 @@ void Configure_defaults( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPoint
     XtManageChild(pane);
 
     XtPopup(configure_defaults_dialog,XtGrabNone);
-    fix_dialog_size(configure_defaults_dialog);
+    //fix_dialog_size(configure_defaults_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -25932,7 +25926,7 @@ void Configure_timing( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer
     XtManageChild(pane);
 
     XtPopup(configure_timing_dialog,XtGrabNone);
-    fix_dialog_size(configure_timing_dialog);
+    //fix_dialog_size(configure_timing_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -26210,7 +26204,7 @@ void Configure_coordinates( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPo
     XtManageChild(pane);
 
     XtPopup(configure_coordinates_dialog,XtGrabNone);
-    fix_dialog_size(configure_coordinates_dialog);
+    //fix_dialog_size(configure_coordinates_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -27028,7 +27022,7 @@ void Configure_audio_alarms( Widget UNUSED(w), XtPointer UNUSED(clientData), XtP
     XtManageChild(pane);
 
     XtPopup(configure_audio_alarm_dialog,XtGrabNone);
-    fix_dialog_size(configure_audio_alarm_dialog);
+    //fix_dialog_size(configure_audio_alarm_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -27476,7 +27470,7 @@ void Configure_speech( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer
     XtManageChild(pane);
 
     XtPopup(configure_speech_dialog,XtGrabNone);
-    fix_dialog_size(configure_speech_dialog);
+    //fix_dialog_size(configure_speech_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -29558,7 +29552,7 @@ void Configure_station( Widget UNUSED(ww), XtPointer UNUSED(clientData), XtPoint
 
     XtPopup(configure_station_dialog,XtGrabNone);
 
-    fix_dialog_size(configure_station_dialog);
+    //fix_dialog_size(configure_station_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -29830,12 +29824,8 @@ int main(int argc, char *argv[], char *envp[])
 #ifdef HAVE_IMAGEMAGICK
 #if (MagickLibVersion < 0x0538)
   MagickIncarnate(*argv);
-#else   // 0x0538 < MagickLibVersion < 0x0669
-  #if (MagickLibVersion < 0x0669)
-    InitializeMagick(*argv);
-  #else // > 0x669
-    MagickCoreGenesis(*argv, MagickTrue);
-  #endif
+#else   // MagickLibVersion < 0x0538
+  InitializeMagick(*argv);
 #endif  // MagickLibVersion < 0x0538
 #endif  // HAVE_IMAGEMAGICK
 #endif  //HAVE_GRAPHICSMAGICK

--- a/src/main.c
+++ b/src/main.c
@@ -1336,11 +1336,11 @@ void Smart_Beacon_change_data(Widget widget, XtPointer clientData, XtPointer cal
 
 void Smart_Beacon(Widget w, XtPointer UNUSED(clientData), XtPointer callData)
 {
-  static Widget  pane, form, label1, label2, label3,
+  static Widget  pane, scrollwindow, form, label1, label2, label3,
          label4, label5, label6,
          button_ok, button_cancel;
 //  static Widget label7;
-
+  Dimension width, height;
   Atom delw;
   char temp_string[10];
   char temp_label_string[100];
@@ -1370,9 +1370,15 @@ void Smart_Beacon(Widget w, XtPointer UNUSED(clientData), XtPointer callData)
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     form =  XtVaCreateWidget("Smart_Beacon form",
                              xmFormWidgetClass,
-                             pane,
+                             scrollwindow,
                              XmNfractionBase, 2,
                              XmNautoUnmanage, FALSE,
                              XmNshadowThickness, 1,
@@ -1751,6 +1757,21 @@ void Smart_Beacon(Widget w, XtPointer UNUSED(clientData), XtPointer callData)
 
     XtManageChild(form);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(smart_beacon_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Smart beacon dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(smart_beacon_dialog,XtGrabNone);
     //fix_dialog_size(smart_beacon_dialog);
 
@@ -2867,9 +2888,10 @@ void Coordinate_calc_change_data(Widget widget, XtPointer clientData, XtPointer 
 //
 void Coordinate_calc(Widget w, XtPointer clientData, XtPointer callData)
 {
-  static Widget  pane, form, label1, label4,
+  static Widget  pane, scrollwindow, form, label1, label4,
          button_clear, button_calculate, button_cancel;
 //  static Widget label2, label3, label5, label6;
+  Dimension width, height;
   Atom delw;
   Arg args[50];                    // Arg List
   register unsigned int n = 0;    // Arg Count
@@ -2903,9 +2925,15 @@ void Coordinate_calc(Widget w, XtPointer clientData, XtPointer callData)
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     form =  XtVaCreateWidget("Coordinate_calc form",
                              xmFormWidgetClass,
-                             pane,
+                             scrollwindow,
                              XmNfractionBase, 4,
                              XmNautoUnmanage, FALSE,
                              XmNshadowThickness, 1,
@@ -3192,6 +3220,21 @@ void Coordinate_calc(Widget w, XtPointer clientData, XtPointer callData)
 
     XtManageChild(form);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(coordinate_calc_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Coordinate calc dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(coordinate_calc_dialog,XtGrabNone);
     //fix_dialog_size(coordinate_calc_dialog);
 
@@ -4540,7 +4583,7 @@ void Change_Debug_Level(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointe
     XtManageChild(pane);
 
     XtPopup(change_debug_level_dialog,XtGrabNone);
-    //fix_dialog_size(change_debug_level_dialog);
+    fix_dialog_size(change_debug_level_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -4715,7 +4758,7 @@ void Gamma_adjust(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUS
     XtManageChild(pane);
 
     XtPopup(gamma_adjust_dialog, XtGrabNone);
-    //fix_dialog_size(gamma_adjust_dialog);
+    fix_dialog_size(gamma_adjust_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -4958,8 +5001,9 @@ void Map_font_change_data(Widget UNUSED(widget), XtPointer clientData, XtPointer
 
 void Map_font(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget  pane, my_form, fontname[FONT_MAX], button_ok,
+  static Widget  pane, scrollwindow, my_form, fontname[FONT_MAX], button_ok,
          button_cancel,button_xfontsel[FONT_MAX];
+  Dimension width, height;
   Atom delw;
   int i;
   Arg al[50];                 /* Arg List */
@@ -4981,8 +5025,15 @@ void Map_font(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(c
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Map font my_form",
-                                xmFormWidgetClass,  pane,
+                                xmFormWidgetClass,
+                                scrollwindow,
                                 XmNfractionBase,    3,
                                 XmNautoUnmanage,    FALSE,
                                 XmNshadowThickness, 1,
@@ -5193,6 +5244,20 @@ void Map_font(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(c
 
     XtManageChild(my_form);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(map_font_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"map_font_dialog dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     XtPopup(map_font_dialog, XtGrabNone);
     //fix_dialog_size(map_font_dialog);
@@ -14316,7 +14381,6 @@ void pos_dialog(Widget w)
 
 /*********************  fix dialog size *************************/
 
-/*
 void fix_dialog_size(Widget w)
 {
   Dimension wd, ht;
@@ -14336,7 +14400,6 @@ void fix_dialog_size(Widget w)
                   NULL);
   }
 }
-*/
 
 
 
@@ -14793,7 +14856,7 @@ void Custom_Zoom_do_it( Widget UNUSED(widget), XtPointer UNUSED(clientData), XtP
 //
 void Custom_Zoom( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(calldata) )
 {
-  static Widget  pane,form, button_ok, button_cancel, zoom_label;
+  static Widget  pane, form, button_ok, button_cancel, zoom_label;
 //    Arg al[50];           /* Arg List */
 //    unsigned int ac = 0;           /* Arg Count */
   Atom delw;
@@ -14921,7 +14984,7 @@ void Custom_Zoom( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUS
     XtManageChild(pane);
 
     XtPopup(custom_zoom_dialog,XtGrabNone);
-    //fix_dialog_size(custom_zoom_dialog);
+    fix_dialog_size(custom_zoom_dialog);
 
     // Move focus to the Close button.  This appears to
     // highlight the
@@ -15661,7 +15724,7 @@ void Center_Zoom( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer call
     XtManageChild(pane);
 
     XtPopup(center_zoom_dialog,XtGrabNone);
-    //fix_dialog_size(center_zoom_dialog);
+    fix_dialog_size(center_zoom_dialog);
 
     // Move focus to the Close button.  This appears to
     // highlight the
@@ -17028,11 +17091,12 @@ void  GPS_operations_color_toggle( Widget UNUSED(widget), XtPointer clientData, 
 //
 void GPS_transfer_select( void )
 {
-  static Widget pane, my_form, button_select, button_cancel,
+  static Widget pane, scrollwindow, my_form, button_select, button_cancel,
          frame,  type_box, ctyp0, ctyp1,
          ctyp2, ctyp3, ctyp4, ctyp5, ctyp6, ctyp7,
          gpsfilename_label;
 //  static Widget color_type;
+  Dimension width, height;
   Atom delw;
   Arg al[50];                      // Arg List
   register unsigned int ac = 0;   // Arg Count
@@ -17066,10 +17130,16 @@ void GPS_transfer_select( void )
              MY_BACKGROUND_COLOR,
              NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget(
                  "GPS_transfer_select my_form",
                  xmFormWidgetClass,
-                 pane,
+                 scrollwindow,
                  XmNfractionBase, 5,
                  XmNautoUnmanage, FALSE,
                  XmNshadowThickness, 1,
@@ -17306,6 +17376,20 @@ void GPS_transfer_select( void )
     XtManageChild(my_form);
     XtManageChild(type_box);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(GPS_operations_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"GPS_operations_dialog dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     XtPopup(GPS_operations_dialog,XtGrabNone);
     //fix_dialog_size(GPS_operations_dialog);
@@ -19567,7 +19651,7 @@ void  Server_port_toggle( Widget UNUSED(widget), XtPointer clientData, XtPointer
 
 void Help_About( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  Widget d;
+  Widget about_dialog;
   Widget child;
   XmString xms, xa, xb;
   Arg al[400];
@@ -19668,17 +19752,17 @@ void Help_About( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
   ac++;
 
   // "About Xastir"
-  d = XmCreateInformationDialog(appshell, langcode("PULDNHEL05"), al, ac);
+  about_dialog = XmCreateInformationDialog(appshell, langcode("PULDNHEL05"), al, ac);
   XmStringFree(xms);
-  XtDestroyWidget(XmMessageBoxGetChild(d, (unsigned char)XmDIALOG_CANCEL_BUTTON));
-  XtDestroyWidget(XmMessageBoxGetChild(d, (unsigned char)XmDIALOG_HELP_BUTTON));
+  XtDestroyWidget(XmMessageBoxGetChild(about_dialog, (unsigned char)XmDIALOG_CANCEL_BUTTON));
+  XtDestroyWidget(XmMessageBoxGetChild(about_dialog, (unsigned char)XmDIALOG_HELP_BUTTON));
 
-  child = XmMessageBoxGetChild(d, XmDIALOG_MESSAGE_LABEL);
+  child = XmMessageBoxGetChild(about_dialog, XmDIALOG_MESSAGE_LABEL);
   XtVaSetValues(child, XmNfontList, fontlist1, NULL);
 
-  XtManageChild(d);
-  pos_dialog(d);
-  //fix_dialog_size(d);
+  XtManageChild(about_dialog);
+  pos_dialog(about_dialog);
+  //fix_dialog_size(about_dialog);
 }
 
 
@@ -19778,9 +19862,10 @@ void Display_packet_mine_only_toggle( Widget UNUSED(w), XtPointer UNUSED(clientD
 
 void Display_data( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  Widget pane, my_form, button_close, option_box, tnc_data,
+  Widget pane, scrollwindow, my_form, button_close, option_box, tnc_data,
          net_data, tnc_net_data, capabilities_button,
          mine_only_button;
+  Dimension width, height;
   unsigned int n;
   Arg args[50];
   Atom delw;
@@ -19801,9 +19886,15 @@ void Display_data( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNU
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Display_data my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 5,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -20045,6 +20136,20 @@ void Display_data( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNU
     XtManageChild(my_form);
     XtManageChild(pane);
 
+    // Resize my_form to exactly fit option_box w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(Display_data_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Display_data_dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     redraw_on_new_packet_data=1;
     XtPopup(Display_data_dialog,XtGrabNone);
 
@@ -20106,7 +20211,8 @@ void help_index_destroy_shell( Widget UNUSED(widget), XtPointer clientData, XtPo
 
 void help_view( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  Widget pane, my_form, button_close,help_text;
+  Widget pane, scrollwindow, my_form, button_close,help_text;
+  Dimension width, height;
   int i;
   Position x, y;
   unsigned int n;
@@ -20168,9 +20274,15 @@ void help_view( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED
                               MY_BACKGROUND_COLOR,
                               NULL);
 
+      scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
       my_form =  XtVaCreateWidget("help_view my_form",
                                   xmFormWidgetClass,
-                                  pane,
+                                  scrollwindow,
                                   XmNfractionBase, 5,
                                   XmNautoUnmanage, FALSE,
                                   XmNshadowThickness, 1,
@@ -20295,6 +20407,20 @@ void help_view( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED
       XtVaSetValues(help_text, XmNbackground, colors[0x0f], NULL);
       XtManageChild(pane);
 
+      // Resize dialog to exactly fit form w/o scrollbars
+      XtVaGetValues(my_form,
+                    XmNwidth, &width,
+                    XmNheight, &height,
+                    NULL);
+      XtVaSetValues(help_view_dialog,
+                    XmNwidth, width+10,
+                    XmNheight, height+10,
+                    NULL);
+      if (debug_level & 1)
+      {
+        fprintf(stderr,"help_view_dialog size: X:%d\tY:%d\n", width, height);
+      }
+
       XtPopup(help_view_dialog,XtGrabNone);
       //fix_dialog_size(help_view_dialog);
       XmTextShowPosition(help_text,0);
@@ -20310,7 +20436,8 @@ void help_view( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED
 
 void Help_Index( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget  pane, my_form, button_ok, button_cancel;
+  static Widget pane, scrollwindow, my_form, button_ok, button_cancel;
+  Dimension width, height;
   int n;
   char temp[600];
   FILE *f;
@@ -20338,9 +20465,15 @@ void Help_Index( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Help_Index my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 5,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -20455,6 +20588,20 @@ void Help_Index( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
     XtManageChild(help_list);
     XtVaSetValues(help_list, XmNbackground, colors[0x0f], NULL);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(help_index_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"help_index_dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     XtPopup(help_index_dialog,XtGrabNone);
     //fix_dialog_size(help_index_dialog);
@@ -23192,9 +23339,9 @@ void Configure_DRG_none(Widget UNUSED(widget), XtPointer UNUSED(clientData), XtP
 
 void Config_DRG( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget DRG_pane, DRG_form, button_ok, button_cancel,
+  static Widget DRG_pane, scrollwindow, DRG_form, button_ok, button_cancel,
          DRG_label1, sep1, sep2, button_all, button_none;
-
+  Dimension width, height;
   Atom delw;
 
   if (!configure_DRG_dialog)
@@ -23214,9 +23361,15 @@ void Config_DRG( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
                                 MY_BACKGROUND_COLOR,
                                 NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           DRG_pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     DRG_form =  XtVaCreateWidget("Configure_DRG DRG_form",
                                  xmFormWidgetClass,
-                                 DRG_pane,
+                                 scrollwindow,
                                  XmNfractionBase, 3,
                                  XmNautoUnmanage, FALSE,
                                  XmNshadowThickness, 1,
@@ -23751,6 +23904,20 @@ void Config_DRG( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
     XtManageChild(DRG_form);
     XtManageChild(DRG_pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(DRG_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(configure_DRG_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"configure_DRG_dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(configure_DRG_dialog,XtGrabNone);
     //fix_dialog_size(configure_DRG_dialog);
 
@@ -23796,10 +23963,11 @@ void Expand_Dirs_toggle( Widget w, XtPointer clientData, XtPointer callData)
 
 void Map_chooser( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget  pane, my_form, button_clear, button_V,
+  static Widget pane, scrollwindow, my_form, button_clear, button_V,
          button_C, button_F, button_O,
          rowcol, expand_dirs_button, button_properties,
          maps_selected_label, button_apply;
+  Dimension width, height;
   Atom delw;
 //    int i;
   Arg al[50];                    /* Arg List */
@@ -23825,9 +23993,15 @@ void Map_chooser( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUS
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Map_chooser my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 7,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -24095,6 +24269,20 @@ void Map_chooser( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUS
     XtManageChild(map_list);
     XtVaSetValues(map_list, XmNbackground, colors[0x0f], NULL);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(map_chooser_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"map_chooser_dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     XtPopup(map_chooser_dialog,XtGrabNone);
 
@@ -24584,13 +24772,14 @@ void lpomff_menuCallback(Widget widget, XtPointer ptr, XtPointer callData)
 
 void Configure_defaults( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget  pane, my_form, button_ok, button_cancel,
+  static Widget  pane, scrollwindow, my_form, button_ok, button_cancel,
          frame4, frame5,
          type_box,
          styp1, styp2, styp3, styp4, styp5, styp6,
          igate_box,
          igtyp0, igtyp1, igtyp2, altnet_label;
 //  static Widget station_type, igate_option;
+  Dimension width, height;
   Atom delw;
   Arg al[50];                      /* Arg List */
   register unsigned int ac = 0;   /* Arg Count */
@@ -24638,9 +24827,15 @@ void Configure_defaults( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPoint
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Configure_defaults my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 5,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -25334,6 +25529,20 @@ void Configure_defaults( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPoint
     XtManageChild(igate_box);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(configure_defaults_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"configure_defaults_dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(configure_defaults_dialog,XtGrabNone);
     //fix_dialog_size(configure_defaults_dialog);
 
@@ -25433,7 +25642,8 @@ void Configure_timing_change_data(Widget widget, XtPointer clientData, XtPointer
 
 void Configure_timing( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget  pane, my_form, button_ok, button_cancel;
+  static Widget  pane, scrollwindow, my_form, button_ok, button_cancel;
+  Dimension width, height;
   Atom delw;
   XmString x_str;
 
@@ -25454,9 +25664,15 @@ void Configure_timing( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Configure_timing my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 2,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -25925,6 +26141,20 @@ void Configure_timing( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer
     XtManageChild(my_form);
     XtManageChild(pane);
 
+   // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(configure_timing_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"configure_timing_dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(configure_timing_dialog,XtGrabNone);
     //fix_dialog_size(configure_timing_dialog);
 
@@ -25986,10 +26216,11 @@ void Configure_coordinates_destroy_shell( Widget UNUSED(widget), XtPointer clien
 
 void Configure_coordinates( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget  pane, my_form, button_ok, button_cancel, frame,
+  static Widget pane, scrollwindow, my_form, button_ok, button_cancel, frame,
          coord_box, coord_0, coord_1, coord_2,
          coord_3, coord_4, coord_5;
 //  static Widget label;
+  Dimension width, height;
   Atom delw;
   Arg al[50];                    /* Arg List */
   register unsigned int ac = 0;           /* Arg Count */
@@ -26010,9 +26241,15 @@ void Configure_coordinates( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPo
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Configure_coordinates my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 5,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -26203,6 +26440,20 @@ void Configure_coordinates( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPo
     XtManageChild(coord_box);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(configure_coordinates_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"configure_coordinates_dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(configure_coordinates_dialog,XtGrabNone);
     //fix_dialog_size(configure_coordinates_dialog);
 
@@ -26388,12 +26639,13 @@ void Configure_audio_alarm_change_data(Widget widget, XtPointer clientData, XtPo
 
 void Configure_audio_alarms( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget  pane, my_form, button_ok, button_cancel,
+  static Widget pane, scrollwindow, my_form, button_ok, button_cancel,
          audio_play, file1, file2,
          min1, max1,
          minb1, maxb2,
          sep;
 //  static Widget min2, max2, minb2, maxb1;
+  Dimension width, height;
   Atom delw;
 
   if (!configure_audio_alarm_dialog)
@@ -26412,9 +26664,15 @@ void Configure_audio_alarms( Widget UNUSED(w), XtPointer UNUSED(clientData), XtP
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Configure_audio_alarms my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 3,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -27021,6 +27279,20 @@ void Configure_audio_alarms( Widget UNUSED(w), XtPointer UNUSED(clientData), XtP
     XtManageChild(my_form);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(configure_audio_alarm_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"configure_audio_alarm_dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(configure_audio_alarm_dialog,XtGrabNone);
     //fix_dialog_size(configure_audio_alarm_dialog);
 
@@ -27146,8 +27418,9 @@ void Configure_speech_change_data(Widget widget, XtPointer clientData, XtPointer
 
 void Configure_speech( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget  pane, my_form, button_ok, button_cancel, file1,
+  static Widget pane, scrollwindow, my_form, button_ok, button_cancel, file1,
          sep, button_test;
+  Dimension width, height;
   Atom delw;
 
   if (!configure_speech_dialog)
@@ -27166,9 +27439,15 @@ void Configure_speech( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Configure_speech my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 5,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -27468,6 +27747,20 @@ void Configure_speech( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer
 
     XtManageChild(my_form);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(configure_speech_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"configure_speech_dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     XtPopup(configure_speech_dialog,XtGrabNone);
     //fix_dialog_size(configure_speech_dialog);
@@ -28056,7 +28349,7 @@ void Configure_change_symbol(Widget widget, XtPointer clientData, XtPointer call
  */
 void Configure_station( Widget UNUSED(ww), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget  pane, cs_form, cs_form1, button_ok, button_cancel, call, frame, frame2,
+  static Widget pane, scrollwindow, cs_form, cs_form1, button_ok, button_cancel, call, frame, frame2,
          framephg, formphg,
          power_box,poption0,poption1,poption2,poption3,poption4,poption5,poption6,poption7,poption8,poption9,poption10,
          height_box,hoption1,hoption2,hoption3,hoption4,hoption5,hoption6,hoption7,hoption8,hoption9,hoption10,
@@ -28069,6 +28362,7 @@ void Configure_station( Widget UNUSED(ww), XtPointer UNUSED(clientData), XtPoint
          option_box,
          sep, configure_button_symbol, compute_button;
 //  static Widget pg2, slat_ns, slong, sts, posamb;
+  Dimension width, height;
   char temp_data[40];
   Atom delw;
   Arg al[50];                    /* Arg List */
@@ -28091,9 +28385,15 @@ void Configure_station( Widget UNUSED(ww), XtPointer UNUSED(clientData), XtPoint
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     cs_form =  XtVaCreateWidget("Configure_station cs_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase,            5,
                                 XmNautoUnmanage,            FALSE,
                                 XmNshadowThickness,         1,
@@ -29545,10 +29845,39 @@ void Configure_station( Widget UNUSED(ww), XtPointer UNUSED(clientData), XtPoint
     XtManageChild(option_box);
     XtManageChild(power_box);
     XtManageChild(height_box);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(cs_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(configure_station_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"configure_station_dialog size: X:%d\tY:%d\n", width, height);
+    }
+
     XtManageChild(gain_box);
     XtManageChild(directivity_box);
     XtManageChild(formphg);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(cs_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(configure_station_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"configure_station_dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     XtPopup(configure_station_dialog,XtGrabNone);
 

--- a/src/main.c
+++ b/src/main.c
@@ -90,7 +90,15 @@ char *xastir_version=VERSION;
   #undef PACKAGE_TARNAME
   #define XASTIR_PACKAGE_VERSION PACKAGE_VERSION
   #undef PACKAGE_VERSION
-  #include <magick/api.h>
+  #ifdef HAVE_MAGICK
+    #ifdef HAVE_MAGICKCORE_MAGICKCORE_H
+      #include <MagickCore/MagickCore.h>
+    #else
+      #ifdef HAVE_MAGICK_API_H
+        #include <magick/api.h>
+      #endif // HAVE_MAGICK_API_H
+    #endif //HAVE_MAGICKCORE_MAGICKCORE_H
+  #endif //HAVE_MAGICK
   #undef PACKAGE_BUGREPORT
   #define PACKAGE_BUGREPORT XASTIR_PACKAGE_BUGREPORT
   #undef XASTIR_PACKAGE_BUGREPORT
@@ -1773,7 +1781,6 @@ void Smart_Beacon(Widget w, XtPointer UNUSED(clientData), XtPointer callData)
     }
 
     XtPopup(smart_beacon_dialog,XtGrabNone);
-    //fix_dialog_size(smart_beacon_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -3236,7 +3243,6 @@ void Coordinate_calc(Widget w, XtPointer clientData, XtPointer callData)
     }
 
     XtPopup(coordinate_calc_dialog,XtGrabNone);
-    //fix_dialog_size(coordinate_calc_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -5260,7 +5266,6 @@ void Map_font(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(c
     }
 
     XtPopup(map_font_dialog, XtGrabNone);
-    //fix_dialog_size(map_font_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -14403,27 +14408,6 @@ void fix_dialog_size(Widget w)
 
 
 
-/******************** fix dialog size vertically only *************/
-
-void fix_dialog_vsize(Widget w)
-{
-  Dimension ht;
-
-  if (XtIsRealized(w))
-  {
-    XtVaGetValues(w,
-                  XmNheight, &ht,
-                  NULL);
-
-    XtVaSetValues(w,
-                  XmNminHeight,ht,
-                  XmNmaxHeight,ht,
-                  NULL);
-  }
-}
-
-
-
 /**************************************** Button CallBacks *************************************/
 /***********************************************************************************************/
 
@@ -17392,7 +17376,6 @@ void GPS_transfer_select( void )
     }
 
     XtPopup(GPS_operations_dialog,XtGrabNone);
-    //fix_dialog_size(GPS_operations_dialog);
 
     // Move focus to the Select button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -19762,7 +19745,6 @@ void Help_About( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
 
   XtManageChild(about_dialog);
   pos_dialog(about_dialog);
-  //fix_dialog_size(about_dialog);
 }
 
 
@@ -20153,8 +20135,6 @@ void Display_data( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNU
     redraw_on_new_packet_data=1;
     XtPopup(Display_data_dialog,XtGrabNone);
 
-//        fix_dialog_vsize(Display_data_dialog);
-
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
     // have that default function happen.  Note:  We _can_ hit the
@@ -20422,7 +20402,6 @@ void help_view( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED
       }
 
       XtPopup(help_view_dialog,XtGrabNone);
-      //fix_dialog_size(help_view_dialog);
       XmTextShowPosition(help_text,0);
     }
     XtFree(temp);   // Free up the space allocated
@@ -20604,7 +20583,6 @@ void Help_Index( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
     }
 
     XtPopup(help_index_dialog,XtGrabNone);
-    //fix_dialog_size(help_index_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -23919,7 +23897,6 @@ void Config_DRG( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
     }
 
     XtPopup(configure_DRG_dialog,XtGrabNone);
-    //fix_dialog_size(configure_DRG_dialog);
 
     XmProcessTraversal(button_ok, XmTRAVERSE_CURRENT);
 
@@ -24285,9 +24262,6 @@ void Map_chooser( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUS
     }
 
     XtPopup(map_chooser_dialog,XtGrabNone);
-
-    // Fix the dialog height only, allow the width to vary.
-//        fix_dialog_vsize(map_chooser_dialog);
 
     // Move focus to the OK button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -25544,7 +25518,6 @@ void Configure_defaults( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPoint
     }
 
     XtPopup(configure_defaults_dialog,XtGrabNone);
-    //fix_dialog_size(configure_defaults_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -26156,7 +26129,6 @@ void Configure_timing( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer
     }
 
     XtPopup(configure_timing_dialog,XtGrabNone);
-    //fix_dialog_size(configure_timing_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -26455,7 +26427,6 @@ void Configure_coordinates( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPo
     }
 
     XtPopup(configure_coordinates_dialog,XtGrabNone);
-    //fix_dialog_size(configure_coordinates_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -27294,7 +27265,6 @@ void Configure_audio_alarms( Widget UNUSED(w), XtPointer UNUSED(clientData), XtP
     }
 
     XtPopup(configure_audio_alarm_dialog,XtGrabNone);
-    //fix_dialog_size(configure_audio_alarm_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -27763,7 +27733,6 @@ void Configure_speech( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer
     }
 
     XtPopup(configure_speech_dialog,XtGrabNone);
-    //fix_dialog_size(configure_speech_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -29845,21 +29814,6 @@ void Configure_station( Widget UNUSED(ww), XtPointer UNUSED(clientData), XtPoint
     XtManageChild(option_box);
     XtManageChild(power_box);
     XtManageChild(height_box);
-
-    // Resize dialog to exactly fit form w/o scrollbars
-    XtVaGetValues(cs_form,
-                  XmNwidth, &width,
-                  XmNheight, &height,
-                  NULL);
-    XtVaSetValues(configure_station_dialog,
-                  XmNwidth, width+10,
-                  XmNheight, height+10,
-                  NULL);
-    if (debug_level & 1)
-    {
-      fprintf(stderr,"configure_station_dialog size: X:%d\tY:%d\n", width, height);
-    }
-
     XtManageChild(gain_box);
     XtManageChild(directivity_box);
     XtManageChild(formphg);
@@ -29880,8 +29834,6 @@ void Configure_station( Widget UNUSED(ww), XtPointer UNUSED(clientData), XtPoint
     }
 
     XtPopup(configure_station_dialog,XtGrabNone);
-
-    //fix_dialog_size(configure_station_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -30153,8 +30105,12 @@ int main(int argc, char *argv[], char *envp[])
 #ifdef HAVE_IMAGEMAGICK
 #if (MagickLibVersion < 0x0538)
   MagickIncarnate(*argv);
-#else   // MagickLibVersion < 0x0538
-  InitializeMagick(*argv);
+#else   // 0x0538 < MagickLibVersion < 0x0669
+  #if (MagickLibVersion < 0x0669)
+    InitializeMagick(*argv);
+  #else // > 0x669
+    MagickCoreGenesis(*argv, MagickTrue);
+  #endif
 #endif  // MagickLibVersion < 0x0538
 #endif  // HAVE_IMAGEMAGICK
 #endif  //HAVE_GRAPHICSMAGICK

--- a/src/maps.c
+++ b/src/maps.c
@@ -5499,7 +5499,6 @@ void Print_properties( Widget w, XtPointer UNUSED(clientData), XtPointer UNUSED(
 
 
     XtPopup(print_properties_dialog,XtGrabNone);
-    //fix_dialog_size(print_properties_dialog);
 
 
     // Move focus to the Cancel button.  This appears to highlight the
@@ -5711,8 +5710,6 @@ void Print_Postscript( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer
     }
 
     XtPopup(print_postscript_dialog,XtGrabNone);
-    //fix_dialog_size(print_postscript_dialog);
-
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -6342,9 +6339,7 @@ extern void draw_shapefile_map (Widget w,
                                 u_char alert_color,
                                 int destination_pixmap,
                                 map_draw_flags *draw_flags);
-#ifdef WITH_DBFAWK
   extern void clear_dbfawk_sigs(void);
-#endif /* WITH_DBFAWK */
 #endif /* HAVE_LIBSHP */
 #ifdef HAVE_LIBGEOTIFF
 extern void draw_geotiff_image_map(Widget w,
@@ -9045,10 +9040,8 @@ void map_indexer(int parameter)
   fprintf(stderr,"Indexing maps...\n");
 
 #ifdef HAVE_LIBSHP
-#ifdef WITH_DBFAWK
   // get rid of stored dbfawk signatures and force reload.
   clear_dbfawk_sigs();
-#endif
 #endif
 
   // Find the timestamp on the index file first.  Save it away so

--- a/src/maps.c
+++ b/src/maps.c
@@ -76,12 +76,15 @@
   #undef PACKAGE_TARNAME
   #define XASTIR_PACKAGE_VERSION PACKAGE_VERSION
   #undef PACKAGE_VERSION
-  #ifdef HAVE_GRAPHICSMAGICK
-    /*#include <GraphicsMagick/magick/api.h>*/
-    #include <magick/api.h>
-  #else   // HAVE_GRAPHICSMAGICK
-    #include <magick/api.h>
-  #endif  // HAVE_GRAPHICSMAGICK
+  #ifdef HAVE_MAGICK
+    #ifdef HAVE_MAGICKCORE_MAGICKCORE_H
+      #include <MagickCore/MagickCore.h>
+    #else
+      #ifdef HAVE_MAGICK_API_H
+        #include <magick/api.h>
+      #endif // HAVE_MAGICK_API_H
+    #endif //HAVE_MAGICKCORE_MAGICKCORE_H
+  #endif //HAVE_MAGICK
   #undef PACKAGE_BUGREPORT
   #define PACKAGE_BUGREPORT XASTIR_PACKAGE_BUGREPORT
   #undef XASTIR_PACKAGE_BUGREPORT

--- a/src/maps.c
+++ b/src/maps.c
@@ -5031,11 +5031,12 @@ static void  Invert( Widget UNUSED(widget), XtPointer clientData, XtPointer call
 //
 void Print_properties( Widget w, XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget pane, form, button_ok, button_cancel,
+  static Widget pane, scrollwindow, form, button_ok, button_cancel,
          sep, auto_scale,
 //            paper_size, paper_size_data, scale, scale_data, blank_background,
 //            res_label1, res_label2, res_x, res_y,
          monochrome, invert;
+  Dimension width, height;
   Atom delw;
 
   // Get rid of the Print dialog
@@ -5066,19 +5067,24 @@ void Print_properties( Widget w, XtPointer UNUSED(clientData), XtPointer UNUSED(
                               XmNfontList, fontlist1,
                               NULL);
 
-
     pane = XtVaCreateWidget("Print_properties pane",xmPanedWindowWidgetClass, print_properties_dialog,
                             XmNbackground, colors[0xff],
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
 
-    form =  XtVaCreateWidget("Print_properties form",xmFormWidgetClass, pane,
+    form =  XtVaCreateWidget("Print_properties form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 2,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
                              XmNshadowThickness, 1,
                              NULL);
-
 
     /*
             paper_size = XtVaCreateManagedWidget(langcode("PRINT0002"),xmLabelWidgetClass, form,
@@ -5474,6 +5480,20 @@ void Print_properties( Widget w, XtPointer UNUSED(clientData), XtPointer UNUSED(
     XtManageChild(form);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(print_properties_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Print properties dialog size: X:%d\tY:%d\n", width, height);
+    }
+
 
     XtPopup(print_properties_dialog,XtGrabNone);
     //fix_dialog_size(print_properties_dialog);
@@ -5506,8 +5526,9 @@ void Print_properties( Widget w, XtPointer UNUSED(clientData), XtPointer UNUSED(
 //
 void Print_Postscript( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget pane, form, button_print, button_cancel,
+  static Widget pane, scrollwindow, form, button_print, button_cancel,
          sep, button_preview;
+  Dimension width, height;
   Atom delw;
 
   if (!print_postscript_dialog)
@@ -5524,19 +5545,24 @@ void Print_Postscript( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer
                               XmNfontList, fontlist1,
                               NULL);
 
-
     pane = XtVaCreateWidget("Print_postscript pane",xmPanedWindowWidgetClass, print_postscript_dialog,
                             XmNbackground, colors[0xff],
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
 
-    form =  XtVaCreateWidget("Print_postscript form",xmFormWidgetClass, pane,
+    form =  XtVaCreateWidget("Print_postscript form",
+                             xmFormWidgetClass,
+                             scrollwindow,
                              XmNfractionBase, 3,
                              XmNbackground, colors[0xff],
                              XmNautoUnmanage, FALSE,
                              XmNshadowThickness, 1,
                              NULL);
-
 
     // "Direct to:"
     button_print = XtVaCreateManagedWidget(langcode("PRINT1001"),xmPushButtonGadgetClass, form,
@@ -5667,6 +5693,19 @@ void Print_Postscript( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer
     XtManageChild(form);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(print_postscript_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Print postscript dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     XtPopup(print_postscript_dialog,XtGrabNone);
     //fix_dialog_size(print_postscript_dialog);

--- a/src/maps.c
+++ b/src/maps.c
@@ -76,15 +76,12 @@
   #undef PACKAGE_TARNAME
   #define XASTIR_PACKAGE_VERSION PACKAGE_VERSION
   #undef PACKAGE_VERSION
-  #ifdef HAVE_MAGICK
-    #ifdef HAVE_MAGICKCORE_MAGICKCORE_H
-      #include <MagickCore/MagickCore.h>
-    #else
-      #ifdef HAVE_MAGICK_API_H
-        #include <magick/api.h>
-      #endif // HAVE_MAGICK_API_H
-    #endif //HAVE_MAGICKCORE_MAGICKCORE_H
-  #endif //HAVE_MAGICK
+  #ifdef HAVE_GRAPHICSMAGICK
+    /*#include <GraphicsMagick/magick/api.h>*/
+    #include <magick/api.h>
+  #else   // HAVE_GRAPHICSMAGICK
+    #include <magick/api.h>
+  #endif  // HAVE_GRAPHICSMAGICK
   #undef PACKAGE_BUGREPORT
   #define PACKAGE_BUGREPORT XASTIR_PACKAGE_BUGREPORT
   #undef XASTIR_PACKAGE_BUGREPORT
@@ -5479,7 +5476,7 @@ void Print_properties( Widget w, XtPointer UNUSED(clientData), XtPointer UNUSED(
 
 
     XtPopup(print_properties_dialog,XtGrabNone);
-    fix_dialog_size(print_properties_dialog);
+    //fix_dialog_size(print_properties_dialog);
 
 
     // Move focus to the Cancel button.  This appears to highlight the
@@ -5672,7 +5669,7 @@ void Print_Postscript( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer
 
 
     XtPopup(print_postscript_dialog,XtGrabNone);
-    fix_dialog_size(print_postscript_dialog);
+    //fix_dialog_size(print_postscript_dialog);
 
 
     // Move focus to the Cancel button.  This appears to highlight the
@@ -6303,7 +6300,9 @@ extern void draw_shapefile_map (Widget w,
                                 u_char alert_color,
                                 int destination_pixmap,
                                 map_draw_flags *draw_flags);
+#ifdef WITH_DBFAWK
   extern void clear_dbfawk_sigs(void);
+#endif /* WITH_DBFAWK */
 #endif /* HAVE_LIBSHP */
 #ifdef HAVE_LIBGEOTIFF
 extern void draw_geotiff_image_map(Widget w,
@@ -9004,8 +9003,10 @@ void map_indexer(int parameter)
   fprintf(stderr,"Indexing maps...\n");
 
 #ifdef HAVE_LIBSHP
+#ifdef WITH_DBFAWK
   // get rid of stored dbfawk signatures and force reload.
   clear_dbfawk_sigs();
+#endif
 #endif
 
   // Find the timestamp on the index file first.  Save it away so

--- a/src/messages_gui.c
+++ b/src/messages_gui.c
@@ -2717,7 +2717,8 @@ void Auto_msg_set_now(Widget w, XtPointer clientData, XtPointer callData)
 
 void Auto_msg_set( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget  pane, my_form, button_ok, button_cancel, reply;
+  static Widget  pane, scrollwindow, my_form, button_ok, button_cancel, reply;
+  Dimension width, height;
   Atom delw;
 
   begin_critical_section(&auto_msg_dialog_lock, "messages_gui.c:Auto_msg_set" );
@@ -2740,9 +2741,15 @@ void Auto_msg_set( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNU
                             XmNfontList, fontlist1,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Auto_msg_set my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 5,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -2838,6 +2845,20 @@ void Auto_msg_set( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNU
 
     XtManageChild(my_form);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(auto_msg_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Auto msg dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     XtPopup(auto_msg_dialog,XtGrabNone);
     //fix_dialog_size(auto_msg_dialog);

--- a/src/messages_gui.c
+++ b/src/messages_gui.c
@@ -2861,7 +2861,6 @@ void Auto_msg_set( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNU
     }
 
     XtPopup(auto_msg_dialog,XtGrabNone);
-    //fix_dialog_size(auto_msg_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/messages_gui.c
+++ b/src/messages_gui.c
@@ -2840,7 +2840,7 @@ void Auto_msg_set( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNU
     XtManageChild(pane);
 
     XtPopup(auto_msg_dialog,XtGrabNone);
-    fix_dialog_size(auto_msg_dialog);
+    //fix_dialog_size(auto_msg_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/objects.c
+++ b/src/objects.c
@@ -11577,7 +11577,7 @@ void Set_Del_Object( Widget w, XtPointer clientData, XtPointer calldata)
     XtManageChild(ob_pane);
 
     XtPopup(object_dialog,XtGrabNone);
-    fix_dialog_size(object_dialog);         // don't allow a resize
+    //fix_dialog_size(object_dialog);         // don't allow a resize
 
     // Move focus to the Cancel button.  This appears to highlight t
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/objects.c
+++ b/src/objects.c
@@ -8092,10 +8092,11 @@ void Create_SAR_Object(Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED(
 void Set_Del_Object( Widget w, XtPointer clientData, XtPointer calldata)
 {
   Dimension width, height;
+  Dimension wd, ht;
   long lat,lon;
   char lat_str[MAX_LAT];
   char lon_str[MAX_LONG];
-  static Widget ob_pane, ob_form,
+  static Widget ob_pane, ob_scrollwindow, ob_form,
          ob_name,ob_latlon_frame,ob_latlon_form,
          ob_lat, ob_lat_deg, ob_lat_min,
          ob_lon, ob_lon_deg, ob_lon_min, ob_lon_ew,
@@ -8301,9 +8302,15 @@ void Set_Del_Object( Widget w, XtPointer clientData, XtPointer calldata)
                                XmNfontList, fontlist1,
                                NULL);
 
+    ob_scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                              xmScrolledWindowWidgetClass,
+                                              ob_pane,
+                                              XmNscrollingPolicy, XmAUTOMATIC,
+                                              NULL);
+
     ob_form =  XtVaCreateWidget("Set_Del_Object ob_form",
                                 xmFormWidgetClass,
-                                ob_pane,
+                                ob_scrollwindow,
                                 XmNfractionBase,            3,
                                 XmNautoUnmanage,            FALSE,
                                 XmNshadowThickness,         1,
@@ -11575,6 +11582,20 @@ void Set_Del_Object( Widget w, XtPointer clientData, XtPointer calldata)
     XtManageChild(ob_form1);
     XtManageChild(ob_form);
     XtManageChild(ob_pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(ob_form,
+                  XmNwidth, &wd,
+                  XmNheight, &ht,
+                  NULL);
+    XtVaSetValues(object_dialog,
+                  XmNwidth, wd+10,
+                  XmNheight, ht+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Object dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     XtPopup(object_dialog,XtGrabNone);
     //fix_dialog_size(object_dialog);         // don't allow a resize

--- a/src/objects.c
+++ b/src/objects.c
@@ -11598,9 +11598,8 @@ void Set_Del_Object( Widget w, XtPointer clientData, XtPointer calldata)
     }
 
     XtPopup(object_dialog,XtGrabNone);
-    //fix_dialog_size(object_dialog);         // don't allow a resize
 
-    // Move focus to the Cancel button.  This appears to highlight t
+    // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
     // have that default function happen.  Note:  We _can_ hit the
     // <SPACE> key, and that activates the option.

--- a/src/objects.c
+++ b/src/objects.c
@@ -8981,7 +8981,7 @@ void Set_Del_Object( Widget w, XtPointer clientData, XtPointer calldata)
                           XmNcursorPositionVisible,   TRUE,
                           XmNsensitive,               TRUE,
                           XmNshadowThickness,         1,
-                          XmNcolumns,                 43,     // max 43 without Data Extension
+                          XmNcolumns,                 37,     // max 43 without Data Extension
                           XmNmaxLength,               43,
                           XmNtopOffset,               6,
                           XmNbackground,              colors[0x0f],

--- a/src/popup.h
+++ b/src/popup.h
@@ -32,7 +32,7 @@ typedef struct
   char name[10];
   Widget popup_message_dialog;
   Widget popup_message_data;
-  Widget pane, form, button_close;
+  Widget pane, scrollwindow, form, button_close;
   time_t sec_opened;
 
 } Popup_Window;

--- a/src/popup_gui.c
+++ b/src/popup_gui.c
@@ -275,11 +275,6 @@ void popup_message_always(char *banner, char *message)
 
       XtPopup(pw[i].popup_message_dialog,XtGrabNone);
 
-// An half-hearted attempt at fixing the problem where a popup
-// comes up extremely small.  Commenting out the below so we can
-// change the size if necessary to read the message.
-//            fix_dialog_size(pw[i].popup_message_dialog);
-
       pw[i].sec_opened=sec_now();
     }
   }

--- a/src/popup_gui.c
+++ b/src/popup_gui.c
@@ -151,6 +151,7 @@ void popup_time_out_check(int curr_sec)
 void popup_message_always(char *banner, char *message)
 {
   XmString msg_str;
+  Dimension width, height;
   int j,i;
   Atom delw;
 
@@ -198,7 +199,15 @@ void popup_message_always(char *banner, char *message)
                                     XmNbackground, colors[0xff],
                                     NULL);
 
-      pw[i].form =  XtVaCreateWidget("popup_message form",xmFormWidgetClass, pw[i].pane,
+      pw[i].scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                                   xmScrolledWindowWidgetClass,
+                                                   pw[i].pane,
+                                                   XmNscrollingPolicy, XmAUTOMATIC,
+                                                   NULL);
+
+      pw[i].form =  XtVaCreateWidget("popup_message form",
+                                     xmFormWidgetClass,
+                                     pw[i].scrollwindow,
                                      XmNfractionBase, 5,
                                      XmNbackground, colors[0xff],
                                      XmNautoUnmanage, FALSE,
@@ -247,6 +256,20 @@ void popup_message_always(char *banner, char *message)
 
       XtManageChild(pw[i].form);
       XtManageChild(pw[i].pane);
+
+      // Resize dialog to exactly fit form w/o scrollbars
+      XtVaGetValues(pw[i].form,
+                    XmNwidth, &width,
+                    XmNheight, &height,
+                    NULL);
+      XtVaSetValues(pw[i].popup_message_dialog,
+                    XmNwidth, width+10,
+                    XmNheight, height+10,
+                    NULL);
+      if (debug_level & 1)
+      {
+        fprintf(stderr,"Popup message dialog size: X:%d\tY:%d\n", width, height);
+      }
 
       end_critical_section(&popup_message_dialog_lock, "popup_gui.c:popup_message" );
 

--- a/src/track_gui.c
+++ b/src/track_gui.c
@@ -408,7 +408,7 @@ void Track_station( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UN
     end_critical_section(&track_station_dialog_lock, "track_gui.c:Track_station" );
 
     XtPopup(track_station_dialog,XtGrabNone);
-    fix_dialog_size(track_station_dialog);
+    //fix_dialog_size(track_station_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -1052,7 +1052,7 @@ void Download_findu_trail( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPoi
     end_critical_section(&download_findu_dialog_lock, "track_gui.c:Download_trail" );
 
     XtPopup(download_findu_dialog,XtGrabNone);
-    fix_dialog_size(download_findu_dialog);
+    //fix_dialog_size(download_findu_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/track_gui.c
+++ b/src/track_gui.c
@@ -429,7 +429,6 @@ void Track_station( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UN
     end_critical_section(&track_station_dialog_lock, "track_gui.c:Track_station" );
 
     XtPopup(track_station_dialog,XtGrabNone);
-    //fix_dialog_size(track_station_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -1094,7 +1093,6 @@ void Download_findu_trail( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPoi
     end_critical_section(&download_findu_dialog_lock, "track_gui.c:Download_trail" );
 
     XtPopup(download_findu_dialog,XtGrabNone);
-    //fix_dialog_size(download_findu_dialog);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/track_gui.c
+++ b/src/track_gui.c
@@ -209,7 +209,8 @@ void Track_station_now(Widget w, XtPointer clientData, XtPointer callData)
 
 void Track_station( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget pane, my_form, button_ok, button_close, button_clear, call, sep;
+  static Widget pane, scrollwindow, my_form, button_ok, button_close, button_clear, call, sep;
+  Dimension width, height;
   Atom delw;
 
   if (!track_station_dialog)
@@ -231,9 +232,15 @@ void Track_station( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UN
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Track_station my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 3,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -404,6 +411,20 @@ void Track_station( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UN
 
     XtManageChild(my_form);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(track_station_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Track station dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     end_critical_section(&track_station_dialog_lock, "track_gui.c:Track_station" );
 
@@ -837,7 +858,8 @@ void Reset_posit_length_max(Widget UNUSED(w), XtPointer UNUSED(clientData), XtPo
 
 void Download_findu_trail( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget pane, my_form, button_ok, button_cancel, call, sep;
+  static Widget pane, scrollwindow, my_form, button_ok, button_cancel, call, sep;
+  Dimension width, height;
   Atom delw;
   XmString x_str;
 
@@ -861,9 +883,15 @@ void Download_findu_trail( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPoi
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("Download_findu_trail my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 2,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -1048,6 +1076,20 @@ void Download_findu_trail( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPoi
 
     XtManageChild(my_form);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(download_findu_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"Download findu dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     end_critical_section(&download_findu_dialog_lock, "track_gui.c:Download_trail" );
 

--- a/src/view_message_gui.c
+++ b/src/view_message_gui.c
@@ -493,9 +493,10 @@ void  Read_messages_mine_only_toggle( Widget UNUSED(widget), XtPointer clientDat
 
 void view_all_messages( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  Widget pane, my_form, button_close, dist, dist_units;
+  Widget pane, scrollwindow, my_form, button_close, dist, dist_units;
   Widget option_box, tnc_data, net_data, tnc_net_data,
          read_mine_only_button;
+  Dimension width, height;
   unsigned int n;
 #define NCNT 50
 #define IncN(n) if (n< NCNT) n++; else fprintf(stderr, "Oops, too many arguments for array!\a")
@@ -522,9 +523,15 @@ void view_all_messages( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointe
                             MY_BACKGROUND_COLOR,
                             NULL);
 
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
     my_form =  XtVaCreateWidget("view_all_messages my_form",
                                 xmFormWidgetClass,
-                                pane,
+                                scrollwindow,
                                 XmNfractionBase, 5,
                                 XmNautoUnmanage, FALSE,
                                 XmNshadowThickness, 1,
@@ -800,6 +807,20 @@ void view_all_messages( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointe
     XtVaSetValues(view_messages_text, XmNbackground, colors[0x0f], NULL);
     XtManageChild(my_form);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(All_messages_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"All messages dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     redraw_on_new_packet_data=1;
 

--- a/src/view_message_gui.c
+++ b/src/view_message_gui.c
@@ -830,7 +830,6 @@ void view_all_messages( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointe
     end_critical_section(&All_messages_dialog_lock, "view_message_gui.c:view_all_messages" );
 
     XtPopup(All_messages_dialog,XtGrabNone);
-//        fix_dialog_vsize(All_messages_dialog);
 
     // Move focus to the Close button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to

--- a/src/wx_gui.c
+++ b/src/wx_gui.c
@@ -110,7 +110,8 @@ void wx_detailed_alert_destroy_shell( Widget UNUSED(widget), XtPointer clientDat
 //
 void wx_alert_finger_output( Widget UNUSED(widget), char *handle)
 {
-  static Widget pane, my_form, mess, button_cancel,wx_detailed_alert_list;
+  static Widget pane, scrollwindow, my_form, mess, button_cancel,wx_detailed_alert_list;
+  Dimension width, height;
   Atom delw;
   Arg al[50];             // Arg List
   unsigned int ac = 0;    // Arg Count
@@ -145,7 +146,15 @@ void wx_alert_finger_output( Widget UNUSED(widget), char *handle)
                             XmNbackground, colors[0xff],
                             NULL);
 
-    my_form =  XtVaCreateWidget("wx_alert_double_click_action my_form", xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    my_form =  XtVaCreateWidget("wx_alert_double_click_action my_form",
+                                xmFormWidgetClass,
+                                scrollwindow,
                                 XmNtraversalOn, TRUE,
                                 XmNfractionBase, 5,
                                 XmNbackground, colors[0xff],
@@ -241,6 +250,20 @@ void wx_alert_finger_output( Widget UNUSED(widget), char *handle)
     XtManageChild(wx_detailed_alert_list);
     XtVaSetValues(wx_detailed_alert_list, XmNbackground, colors[0x0f], NULL);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(wx_detailed_alert_shell,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"WX detailed alert dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     XtPopup(wx_detailed_alert_shell, XtGrabNone);
 //        fix_dialog_vsize(wx_detailed_alert_shell);
@@ -663,7 +686,8 @@ void wx_alert_update_list(void)
 
 void Display_Wx_Alert( Widget UNUSED(wdgt), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget pane, my_form, mess, button_cancel;
+  static Widget pane, scrollwindow, my_form, mess, button_cancel;
+  Dimension width, height;
   Atom delw;
   Arg al[50];                    /* Arg List */
   unsigned int ac = 0;           /* Arg Count */
@@ -685,7 +709,15 @@ void Display_Wx_Alert( Widget UNUSED(wdgt), XtPointer UNUSED(clientData), XtPoin
                             XmNbackground, colors[0xff],
                             NULL);
 
-    my_form =  XtVaCreateWidget("Display_Wx_Alert my_form", xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    my_form =  XtVaCreateWidget("Display_Wx_Alert my_form",
+                                xmFormWidgetClass,
+                                scrollwindow,
                                 XmNtraversalOn, TRUE,
                                 XmNfractionBase, 5,
                                 XmNbackground, colors[0xff],
@@ -789,6 +821,20 @@ void Display_Wx_Alert( Widget UNUSED(wdgt), XtPointer UNUSED(clientData), XtPoin
     XtVaSetValues(wx_alert_list, XmNbackground, colors[0x0f], NULL);
     XtManageChild(pane);
 
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(wx_alert_shell,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"WX alert shell size: X:%d\tY:%d\n", width, height);
+    }
+
     XtPopup(wx_alert_shell, XtGrabNone);
 //        fix_dialog_vsize(wx_alert_shell);
 
@@ -890,14 +936,14 @@ void WX_station_change_data(Widget widget, XtPointer clientData, XtPointer callD
 //
 void WX_station( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED(callData) )
 {
-  static Widget  pane, my_form, form1, button_close, frame,
+  static Widget  pane, scrollwindow, my_form, form1, button_close, frame,
          WX_type, temp, wind_cse, wind_spd, wind_gst,
          my_rain, to_rain, rain_h, my_rain_24, baro,
          dew_point,
          high_wind, wind_chill,
          heat_index, three_hour_baro,
          hi_temp;
-
+  Dimension width, height;
   Atom delw;
 
   if(!wx_station_dialog)
@@ -916,7 +962,15 @@ void WX_station( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
                             XmNbackground, colors[0xff],
                             NULL);
 
-    my_form =  XtVaCreateWidget("WX_station my_form",xmFormWidgetClass, pane,
+    scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                           xmScrolledWindowWidgetClass,
+                                           pane,
+                                           XmNscrollingPolicy, XmAUTOMATIC,
+                                           NULL);
+
+    my_form =  XtVaCreateWidget("WX_station my_form",
+                                xmFormWidgetClass,
+                                scrollwindow,
                                 XmNfractionBase,7,
                                 XmNbackground, colors[0xff],
                                 XmNautoUnmanage, FALSE,
@@ -1815,6 +1869,20 @@ void WX_station( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
     XtManageChild(my_form);
     XtManageChild(form1);
     XtManageChild(pane);
+
+    // Resize dialog to exactly fit form w/o scrollbars
+    XtVaGetValues(my_form,
+                  XmNwidth, &width,
+                  XmNheight, &height,
+                  NULL);
+    XtVaSetValues(wx_station_dialog,
+                  XmNwidth, width+10,
+                  XmNheight, height+10,
+                  NULL);
+    if (debug_level & 1)
+    {
+      fprintf(stderr,"WX station dialog size: X:%d\tY:%d\n", width, height);
+    }
 
     end_critical_section(&wx_station_dialog_lock, "wx_gui.c:WX_station" );
 

--- a/src/wx_gui.c
+++ b/src/wx_gui.c
@@ -266,7 +266,6 @@ void wx_alert_finger_output( Widget UNUSED(widget), char *handle)
     }
 
     XtPopup(wx_detailed_alert_shell, XtGrabNone);
-//        fix_dialog_vsize(wx_detailed_alert_shell);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -836,7 +835,6 @@ void Display_Wx_Alert( Widget UNUSED(wdgt), XtPointer UNUSED(clientData), XtPoin
     }
 
     XtPopup(wx_alert_shell, XtGrabNone);
-//        fix_dialog_vsize(wx_alert_shell);
 
     // Move focus to the Cancel button.  This appears to highlight the
     // button fine, but we're not able to hit the <Enter> key to
@@ -1887,7 +1885,6 @@ void WX_station( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
     end_critical_section(&wx_station_dialog_lock, "wx_gui.c:WX_station" );
 
     XtPopup(wx_station_dialog,XtGrabNone);
-    //fix_dialog_size(wx_station_dialog);
     fill_wx_data();
   }
   else

--- a/src/wx_gui.c
+++ b/src/wx_gui.c
@@ -1819,7 +1819,7 @@ void WX_station( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
     end_critical_section(&wx_station_dialog_lock, "wx_gui.c:WX_station" );
 
     XtPopup(wx_station_dialog,XtGrabNone);
-    fix_dialog_size(wx_station_dialog);
+    //fix_dialog_size(wx_station_dialog);
     fill_wx_data();
   }
   else

--- a/src/xastir.h
+++ b/src/xastir.h
@@ -117,7 +117,7 @@ extern void create_gc(Widget w);
 
 extern void Station_info(Widget w, XtPointer clientData, XtPointer calldata);
 
-//extern void fix_dialog_size(Widget w);
+extern void fix_dialog_size(Widget w);
 extern void fix_dialog_vsize(Widget w);
 
 extern int debug_level;

--- a/src/xastir.h
+++ b/src/xastir.h
@@ -117,7 +117,7 @@ extern void create_gc(Widget w);
 
 extern void Station_info(Widget w, XtPointer clientData, XtPointer calldata);
 
-extern void fix_dialog_size(Widget w);
+//extern void fix_dialog_size(Widget w);
 extern void fix_dialog_vsize(Widget w);
 
 extern int debug_level;

--- a/src/xastir.h
+++ b/src/xastir.h
@@ -118,7 +118,6 @@ extern void create_gc(Widget w);
 extern void Station_info(Widget w, XtPointer clientData, XtPointer calldata);
 
 extern void fix_dialog_size(Widget w);
-extern void fix_dialog_vsize(Widget w);
 
 extern int debug_level;
 extern GC gc;


### PR DESCRIPTION
This is the first run-through of adding Scrolledwindow to dialogs. This allows computers with small-resolution screens to still run/configure Xastir. There's more yet to do but this fixes up many of the dialogs (around 40 of them). I added code so the scrollbars are not visible when the dialog first comes up: You must shrink the dialog to make them appear. The only downside I've seen so far is that the scrollbars in Scrolledwindow sometimes steal from scrollbars already in a dialog. Map Chooser and Map Chooser->Properties are examples of that: I'll have to redesign those dialogs (later) to fix that, but they're still quite usable as-is.
I pushed my branch to the main Xastir repo by mistake so I think the easiest cleanup is to merge these changes with master rather than deleting this branch. I'll continue the rest of the work on the we7u fork and do pull requests later from there. I'm not going to merge this one myself: I want you guys to take a look at it and ok it.
These changes are working on issue #138