### PR TITLE
Use prefix path consistently for dbfawk test as well as download

### DIFF
--- a/scripts/get-NWSdata.in
+++ b/scripts/get-NWSdata.in
@@ -123,10 +123,11 @@ for d in $FILE1 $FILE2 $FILE3 $FILE4 $FILE5 $FILE6 $FILE7; do
     echo
     echo $e.dbf
     # Run in a separate shell so we don't mess up the current directory for the -e test above
-    (cd /usr/local/share/xastir; /usr/local/bin/testdbfawk -D config -d Counties/$e.dbf 2>&1 | head -3 | tail -1)
+    (cd ${prefix}/share/xastir; ${prefix}/bin/testdbfawk -D config -d Counties/$e.dbf 2>&1 | head -3 | tail -1)
  
   fi
 done
 echo
+
 
 


### PR DESCRIPTION
Fixes an issue where the dbfawk test fails on non /usr/local prefix paths by making the usage at the test step consistent with the download step based on the defined prefix path.