### PR TITLE
configure.ac: drop duplicate AM_INIT_AUTOMAKE call

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,6 @@
 # It should look something like this:  ([xastir], [2.0.8], [xastir@xastir.org])
 # The revision number must contain at least one '.' and two digits.
 AC_INIT([xastir], [2.1.7], [xastir@xastir.org])
-AM_INIT_AUTOMAKE
 #########################################################################
 
 


### PR DESCRIPTION
This fixes autoreconf with >= automake 1.16.5 which
made two calls fatal.

See https://www.gnu.org/software/automake/manual/html_node/Public-Macros.html
and https://git.savannah.gnu.org/cgit/automake.git/commit/?id=f4a3a70f69e1dbccb6578f39ef47835098a04624.

Bug: https://bugs.gentoo.org/816615
Signed-off-by: Sam James <sam@gentoo.org>