### PR TITLE
Fix issue 121 for real

### DIFF
--- a/src/gps.c
+++ b/src/gps.c
@@ -986,16 +986,17 @@ void create_garmin_waypoint(long latitude,long longitude,char *call_sign)
   //fprintf(stderr,"%s\n",out_string2);
 }
 
-// Test if this is a GGA string, irrespective of what constellation it
-// might be for.  This should allow us to support GPS, GLONASS, Gallileo,
-// Beidou, or GNSS receivers, and multi-constellation receivers.
+// Test if this is a GGA string, irrespective of what talker produced
+// it.  This should allow us to support GPS, GLONASS, Gallileo,
+// Beidou, or GNSS receivers, and multi-constellation receivers ($GP,
+// $GN, etc.), but also other talkers like Integrated Instrumentation
+// ($II).
 int isGGA(char *gps_line_data)
 {
   int retval;
   retval = (strncmp(gps_line_data,"$",1)==0);
   retval = retval && ((strlen(gps_line_data)>7)
                       && strncmp(&(gps_line_data[3]),"GGA,",4)==0);
-  retval = retval && (strchr("PNALB",gps_line_data[2])!=0);
   return (retval);
 }
 
@@ -1006,6 +1007,5 @@ int isRMC(char *gps_line_data)
   retval = (strncmp(gps_line_data,"$",1)==0);
   retval = retval && ((strlen(gps_line_data)>7)
                       && strncmp(&(gps_line_data[3]),"RMC,",4)==0);
-  retval = retval && (strchr("PNALB",gps_line_data[2])!=0);
   return (retval);
 }


### PR DESCRIPTION
Issue #121 asked us to support more GPS RMC and GGA strings than just
those that start with '$Gx" (where x is P, N, A, L, or B).  The user
specifically wanted us to recognize "$II" strings.

Pull request #122 got this almost there by taking out the probe for
the initial "$G" and looking only for "$", but left in place the check
for the P,N, A, L or B in the third character.

This commit removes that final check, which should actually fix #121
instead of just leaving it half fixed.

Sadly, the original requester never got back to us to tell us that the
fix didn't work, and so it went unnoticed until today when I was
reviewing the old PR and this glaring error jumped out at me.

Xastir#121
Xastir#122
Xastir#53
Xastir#58