### PR TITLE
Remove bashism from acinclude.m4

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -201,10 +201,10 @@ if test "$gv" != "no"; then
   # Test gv version
   AC_MSG_CHECKING([gv version])
   gv_new="no";
-  gv_version=`gv --version 2>&1`
+  gv_version=`gv --version`
   gv_test=`echo $gv_version | cut -d ' ' -f 1`
   if test "$gv_test" != "gv"; then
-    gv_version=`gv -v 2>&1`
+    gv_version=`gv -v`
   fi
   gv_test=`echo $gv_version | cut -d ' ' -f 1`
   if test "$gv_test" != "gv"; then


### PR DESCRIPTION
Today, I was submitting a patch to the FreeBSD ports system to update
the port from 2.1.6 to 2.1.8, and found that it was easy to do so, but
that the port failed to detect "gv" even though it was installed.  This has 
apparently always been the case, and the port maintainer never bothered
us about it --- a version of Xastir built from the port system would simply
never use gv, and so a user couldn't print maps.  I guess nobody bothered
about it.  But seeing this problem made me want to fix it, and I have.

The reason for this is that Xastir's configure actually runs "\`gv
--version 2>&1\`" to get the gv version, and this is strictly Bourne
shell syntax.  The default shell for the root user on FreeBSD is csh,
not bash, and therefor the "2>&1" syntax is actually an error and
causing the probe to fail.

For the port, I simply do a post-tarball-extraction patch to remove
this syntax, which is *only* used in the probe for gv.  But that's a 
hack that simply undoes a mistake after the fact.  It shouldn't be
there to begin with.

I tried building my normal way (which is under a bash shell) and even
with this removed redirection it works fine.

I therefore propose that this bashism be removed from Xastir's
configure system.  Shell-specific syntax should not be used inside
backticks like that, because those commands are run with the default
shell of the user invoking configure, unlike configure itself, which
is always run with a version of the Bourne shell because it has a
"#!/bin/sh" at the top.

It is similarly incorrect to use bash extensions to the Bourne shell,
but we don't do that (anymore).