### PR TITLE
Fix typing errors

### DIFF
--- a/Davis/README
+++ b/Davis/README
@@ -184,8 +184,8 @@ $ make
 $ su -c 'make install'
 
 
-ACKNOWLEGEMENTS & AUTHORS
--------------------------
+ACKNOWLEDGEMENTS & AUTHORS
+--------------------------
 
 db2APRS is the product of Bruce Bennett, callsign KB8ROP 
 <bruts@adelphia.net> It is freely available at no charge 

--- a/Davis/src/db2APRS.c
+++ b/Davis/src/db2APRS.c
@@ -30,7 +30,7 @@
         Output is to the ip hostname:port required in the
         command line.
 
-    ACKNOWLEGEMENTS:
+    ACKNOWLEDGEMENTS:
 
         Elements of this software are taken from wx200d ver 1.2
         by Tim Witham <twitham@quiknet.com>, and it is modeled

--- a/LaCrosse/README
+++ b/LaCrosse/README
@@ -87,7 +87,7 @@ SETTINGS & STARTUP
 
 
 open2300db2APRS RUN OPTIONS
--------------------
+---------------------------
 
 The open2300db2APRS utility takes standard short & long command line 
 options, which can be displayed by "open2300db2APRS -?". Here's the list:
@@ -164,7 +164,7 @@ transmitting.
 
 
 BUILD open2300db2APRS
--------------
+---------------------
 
 It's the usual:
 
@@ -175,8 +175,8 @@ $ make
 $ su -c 'make install'
 
 
-ACKNOWLEGEMENTS & AUTHORS
--------------------------
+ACKNOWLEDGEMENTS & AUTHORS
+--------------------------
 
 A large portion of this work taken from db2APRS (thanks Bruce!!)
 

--- a/LaCrosse/src/open2300db2APRS.c
+++ b/LaCrosse/src/open2300db2APRS.c
@@ -29,7 +29,7 @@
         Output is to the ip hostname:port required in the
         command line.
 
-    ACKNOWLEGEMENTS:
+    ACKNOWLEDGEMENTS:
 
         Elements of this software are taken from wx200d ver 1.2
         by Tim Witham <twitham@quiknet.com>, and it is modeled

--- a/src/dlm.c
+++ b/src/dlm.c
@@ -67,7 +67,7 @@
 
    We could have used the curl_multi list as the queue, but that would end up
    with us either waiting until the last few tiles were downloading before returning,
-   or just adding all the tiles and letting curl go fot it - which could end up
+   or just adding all the tiles and letting curl go for it - which could end up
    with hundreds of simultaneous transfers, although curl is supposed to have a
    limiter of some kind, it delivers no control over what order to process the queue.
 

--- a/src/main.c
+++ b/src/main.c
@@ -17152,7 +17152,7 @@ void  GPS_operations_color_toggle( Widget UNUSED(widget), XtPointer clientData, 
 
 // This routine should be called while the transfer is progressing,
 // or perhaps just after it ends.  If we can do it while the
-// transfer is ocurring we can save time overall.  Here we'll select
+// transfer is occurring we can save time overall.  Here we'll select
 // the color and name for the resulting file, then cause it to be
 // selected and displayed on the map screen.
 //
@@ -22374,7 +22374,7 @@ void map_index_update_temp_select(char *filename, map_index_record **current)
       // Found a match.  Update the field.
       (*current)->temp_select = 1;
     }
-    else if (result > 0)    // We passsed the relevant area.
+    else if (result > 0)    // We passed the relevant area.
     {
       // All done for now.
       return;


### PR DESCRIPTION
Found using codespell:
codespell --skip *.dat,LICENSE,./src/snprintf.c,./scripts/langOldeEnglish.pl,./scripts/langPirateEnglish.pl --ignore-words-list 3st,bu,cancl,clen,herat,ists,lond,ro,templat,writen