### PR TITLE
Fix C99 compatibility issue

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -647,7 +647,7 @@ LDFLAGS="-Wl,--no-keep-memory $LDFLAGS"
 AC_LINK_IFELSE(
  [AC_LANG_PROGRAM([[#include <sys/types.h>]],
                   [[/* Stupid useless test for linker flags */
-                     exit(0);]])],
+                     return(0);]])],
  [xa_cv_no_keep_memory=yes],
  [xa_cv_no_keep_memory=no])
 


### PR DESCRIPTION
Related to:

  <https://fedoraproject.org/wiki/Changes/PortingToModernC>
  <https://fedoraproject.org/wiki/Toolchain/PortingToModernC>

Using return(0) instead of exit(0) means we don't need a prototype for exit() from stdlib.h.

Alternately, we could change sys/types.h to stdlib.h, and/or keep the return and remove sys/types.h.  Or just add stdlib.h.  It all depends on what, exactly, the original test was testing besides the obvious.