### PR TITLE
Issue 203 -- Add support for PCRE2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -394,15 +394,31 @@ fi
 # Shapelib requires pcre now
 use_pcre=no
 if test "${shapelib_desired}" = "yes" -a "${use_shapelib}" = "yes"; then
-  AC_CHECK_HEADERS([pcre.h pcre/pcre.h],
-                   [AC_CHECK_LIB([pcre], [pcre_compile],
-                                 [use_pcre="yes(legacy)"
-                                  LIBS="$LIBS -lpcre"
-                                  AC_DEFINE(HAVE_LIBPCRE, 1, Define to 1 if you have the `pcre' library (-lpcre). )
-                                  AC_DEFINE(XASTIR_LEGACY_PCRE, 1, Define to 1 if you have the legacy `pcre' library (-lpcre). )
-                                  ])
-                    break
-                    ])
+  AC_CHECK_HEADERS([pcre2.h],
+                   [AC_CHECK_LIB([pcre2-8],[pcre2_compile_8],
+                                 [use_pcre="yes(PCRE2)"
+                                  LIBS="$LIBS -lpcre2-8"
+                                  ],
+                                 [use_pcre=no
+                                  AC_MSG_WARN([Found pcre2 headers but not libraries])
+                                 ])
+                   ],
+                   [use_pcre=no],
+                   [
+                     #define PCRE2_CODE_UNIT_WIDTH 8
+                   ])
+   if test "${use_pcre}" = "no"
+   then
+     AC_MSG_WARN([Modern PCRE2 not found, checking for legacy version])
+     AC_CHECK_HEADERS([pcre.h pcre/pcre.h],
+                      [AC_CHECK_LIB([pcre], [pcre_compile],
+                                    [use_pcre="yes(legacy)"
+                                     LIBS="$LIBS -lpcre"
+                                     AC_DEFINE(XASTIR_LEGACY_PCRE, 1, Define to 1 if you have the legacy `pcre' library (-lpcre). )
+                                                   ])
+                       break
+                       ])
+    fi
  if test "${use_pcre}" = "no"
  then
     AC_MSG_ERROR([Shapelib support requires PCRE, and we could not find PCRE.  Either disable shapelib by specifying "--without-shapelib" or install PCRE libraries and headers])
@@ -762,7 +778,12 @@ else
   ILIBS="$ILIBS         "
 fi
 if test "${use_pcre}" != "no"; then
-  ILIBS="$ILIBS PCRE"
+  if test "${use_pcre}" = "yes(legacy)"
+  then
+    ILIBS="$ILIBS PCRE"
+  else
+    ILIBS="$ILIBS PCRE2"
+  fi
 else
   ILIBS="$ILIBS     "
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -396,9 +396,10 @@ use_pcre=no
 if test "${shapelib_desired}" = "yes" -a "${use_shapelib}" = "yes"; then
   AC_CHECK_HEADERS([pcre.h pcre/pcre.h],
                    [AC_CHECK_LIB([pcre], [pcre_compile],
-                                 [use_pcre=yes
+                                 [use_pcre="yes(legacy)"
                                   LIBS="$LIBS -lpcre"
                                   AC_DEFINE(HAVE_LIBPCRE, 1, Define to 1 if you have the `pcre' library (-lpcre). )
+                                  AC_DEFINE(XASTIR_LEGACY_PCRE, 1, Define to 1 if you have the legacy `pcre' library (-lpcre). )
                                   ])
                     break
                     ])
@@ -760,7 +761,7 @@ if test "${use_shapelib}" = "yes"; then
 else
   ILIBS="$ILIBS         "
 fi
-if test "${use_pcre}" = "yes"; then
+if test "${use_pcre}" != "no"; then
   ILIBS="$ILIBS PCRE"
 else
   ILIBS="$ILIBS     "

--- a/src/awk.c
+++ b/src/awk.c
@@ -807,16 +807,22 @@ void awk_free_rule(awk_rule *r)
       }
       if (r->tables)
       {
+#ifdef XASTIR_LEGACY_PCRE
         pcre_free((void *)r->tables);
+#endif
       }
       if (r->re)
       {
+#ifdef XASTIR_LEGACY_PCRE
         pcre_free(r->re);
+#endif
       }
+#ifdef XASTIR_LEGACY_PCRE
       if (r->pe)
       {
         pcre_free(r->pe);
       }
+#endif
     }
     if (r->code)
     {
@@ -1135,9 +1141,11 @@ loop:
  */
 int awk_compile_program(awk_symtab *symtab, awk_program *rs)
 {
-  const char *error;
   awk_rule *r;
+#ifdef XASTIR_LEGACY_PCRE
+  const char *error;
   int erroffset;
+#endif
 
   if (!rs)
   {
@@ -1151,16 +1159,22 @@ int awk_compile_program(awk_symtab *symtab, awk_program *rs)
     {
       if (r->tables)
       {
+#ifdef XASTIR_LEGACY_PCRE
         pcre_free((void *)r->tables);
+#endif
       }
+#ifdef XASTIR_LEGACY_PCRE
       r->tables = pcre_maketables(); /* NLS locale parse tables */
+#endif
       if (!r->re)
       {
+#ifdef XASTIR_LEGACY_PCRE
         r->re = pcre_compile(r->pattern, /* the pattern */
                              0, /* default options */
                              &error, /* for error message */
                              &erroffset, /* for error offset */
                              r->tables); /* NLS locale character tables */
+#endif
       }
       if (!r->re)
       {
@@ -1175,10 +1189,12 @@ int awk_compile_program(awk_symtab *symtab, awk_program *rs)
         fprintf(stderr,"^\n");
         return -1;
       }
+#ifdef XASTIR_LEGACY_PCRE
       if (!r->pe)
       {
         r->pe = pcre_study(r->re, 0, &error); /* optimize the regexp */
       }
+#endif
     }
     else if (r->ruletype == BEGIN)
     {
@@ -1228,19 +1244,25 @@ void awk_uncompile_program(awk_program *p)
     {
       if (r->tables)
       {
+#ifdef XASTIR_LEGACY_PCRE
         pcre_free((void *)r->tables);
+#endif
       }
       r->tables = NULL;
       if (r->re)
       {
+#ifdef XASTIR_LEGACY_PCRE
         pcre_free(r->re);
+#endif
       }
       r->re = NULL;
+#ifdef XASTIR_LEGACY_PCRE
       if (r->pe)
       {
         pcre_free(r->pe);
       }
       r->pe = NULL;
+#endif
     }
     if (r->code)
     {
@@ -1261,8 +1283,10 @@ int awk_exec_program(awk_program *this, char *buf, int len)
 {
   int i,rc,done = 0;
   awk_rule *r;
+#ifdef XASTIR_LEGACY_PCRE
   int ovector[3*MAXSUBS];
 #define OVECLEN (sizeof(ovector)/sizeof(ovector[0]))
+#endif
 
   if (!this || !buf || len <= 0)
   {
@@ -1273,7 +1297,9 @@ int awk_exec_program(awk_program *this, char *buf, int len)
   {
     if (r->ruletype == REGEXP)
     {
+#ifdef XASTIR_LEGACY_PCRE
       rc = pcre_exec(r->re,r->pe,buf,len,0,0,ovector,OVECLEN);
+#endif
       /* assign values to as many of $0 thru $9 as were set */
       /* XXX - avoid calling awk_find_sym for these known values */
       for (i = 0; rc > 0 && i < rc && i < MAXSUBS ; i++)

--- a/src/awk.c
+++ b/src/awk.c
@@ -64,7 +64,7 @@
   #include "config.h"
 #endif  // HAVE_CONFIG_H
 
-#ifdef HAVE_LIBPCRE
+#ifdef HAVE_LIBSHP
 #include <stdio.h>
 #include <string.h>
 
@@ -1384,6 +1384,6 @@ int awk_exec_end(awk_program *this)
 }
 
 
-#endif /* HAVE_LIBPCRE */
+#endif /* HAVE_LIBSHP */
 
 

--- a/src/awk.h
+++ b/src/awk.h
@@ -29,6 +29,9 @@
   #ifdef HAVE_PCRE_PCRE_H
     #include <pcre/pcre.h>
   #endif
+#else
+  #define PCRE2_CODE_UNIT_WIDTH 8
+  #include <pcre2.h>
 #endif
 
 enum awk_symtype
@@ -75,10 +78,14 @@ typedef struct awk_rule_
   struct awk_rule_ *next_rule;    /* linked list */
   enum {BEGIN,BEGIN_REC,END_REC,END,REGEXP} ruletype;
   const char *pattern;        /* pcre pattern string */
-  const u_char *tables;       /* pcre NLS tables */
   #ifdef XASTIR_LEGACY_PCRE
+    const u_char *tables;       /* pcre NLS tables */
     pcre *re;                   /* pcre compiled pattern */
     pcre_extra *pe;             /* pcre optimized pattern */
+  #else
+    const uint8_t *tables;       /* pcre2 NLS tables */
+    pcre2_code *re;             /* pcre2 compiled pattern */
+    void *pe;                   /* pcre2 doesn't use separate optimization */
   #endif
   const char *act;            /* the program string */
   awk_action *code;           /* compiled program */

--- a/src/awk.h
+++ b/src/awk.h
@@ -22,11 +22,13 @@
  */
 #ifndef AWK_H
 #define AWK_H
-#ifdef HAVE_PCRE_H
-  #include <pcre.h>
-#endif
-#ifdef HAVE_PCRE_PCRE_H
-  #include <pcre/pcre.h>
+#ifdef XASTIR_LEGACY_PCRE
+  #ifdef HAVE_PCRE_H
+    #include <pcre.h>
+  #endif
+  #ifdef HAVE_PCRE_PCRE_H
+    #include <pcre/pcre.h>
+  #endif
 #endif
 
 enum awk_symtype
@@ -74,8 +76,10 @@ typedef struct awk_rule_
   enum {BEGIN,BEGIN_REC,END_REC,END,REGEXP} ruletype;
   const char *pattern;        /* pcre pattern string */
   const u_char *tables;       /* pcre NLS tables */
-  pcre *re;                   /* pcre compiled pattern */
-  pcre_extra *pe;             /* pcre optimized pattern */
+  #ifdef XASTIR_LEGACY_PCRE
+    pcre *re;                   /* pcre compiled pattern */
+    pcre_extra *pe;             /* pcre optimized pattern */
+  #endif
   const char *act;            /* the program string */
   awk_action *code;           /* compiled program */
   int flags;                  /* some flags */

--- a/src/dbfawk.c
+++ b/src/dbfawk.c
@@ -258,6 +258,8 @@ dbfawk_sig_info *dbfawk_load_sigs(const char *dir, /* directory path */
       if (symtbl)
       {
         awk_free_symtab(symtbl);
+        free(symtbl);
+        symtbl=NULL;
       }
       fprintf(stderr,"failed to malloc in dbfawk.c!\n");
       closedir(d);
@@ -278,6 +280,8 @@ dbfawk_sig_info *dbfawk_load_sigs(const char *dir, /* directory path */
           if (symtbl)
           {
             awk_free_symtab(symtbl);
+            free(symtbl);
+            symtbl=NULL;
           }
           closedir(d);
           return NULL;
@@ -294,6 +298,8 @@ dbfawk_sig_info *dbfawk_load_sigs(const char *dir, /* directory path */
           if (symtbl)
           {
             awk_free_symtab(symtbl);
+            free(symtbl);
+            symtbl=NULL;
           }
           closedir(d);
           return head; // Return what we were able to gather.
@@ -332,6 +338,8 @@ dbfawk_sig_info *dbfawk_load_sigs(const char *dir, /* directory path */
   if (symtbl)
   {
     awk_free_symtab(symtbl);
+    free(symtbl);
+    symtbl=NULL;
   }
 
   return head;

--- a/src/dbfawk.c
+++ b/src/dbfawk.c
@@ -51,7 +51,7 @@
   #include "config.h"
 #endif  // HAVE_CONFIG_H
 
-#if defined(HAVE_LIBSHP) && defined(HAVE_LIBPCRE)
+#ifdef HAVE_LIBSHP
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
@@ -497,6 +497,6 @@ void dbfawk_parse_record(awk_program *rs,
   }
   awk_exec_end_record(rs); /* execute an END_RECORD rule if any */
 }
-#endif /* HAVE_LIBSHP && HAVE_LIBPCRE */
+#endif /* HAVE_LIBSHP */
 
 

--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -89,10 +89,8 @@
 #define CHECKREALLOC(m)  if (!m) { fprintf(stderr, "***** Realloc Failed *****\n"); exit(0); }
 
 #ifdef HAVE_LIBSHP
-#ifdef HAVE_LIBPCRE
   #include "awk.h"
   #include "dbfawk.h"
-#endif /* HAVE_LIBPCRE */
 #ifdef HAVE_SHAPEFIL_H
   #include <shapefil.h>
 #else   // HAVE_SHAPEFIL_H

--- a/src/testdbfawk.c
+++ b/src/testdbfawk.c
@@ -301,6 +301,7 @@ int main(int argc, char *argv[])
     awk_free_program(rs);
   }
   awk_free_symtab(symtbl);
+  free(symtbl);
   exit(0);
 }
 #else /* HAVE_LIBSHP */

--- a/src/testdbfawk.c
+++ b/src/testdbfawk.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-#if defined(HAVE_LIBSHP) && defined(HAVE_LIBPCRE)
+#ifdef HAVE_LIBSHP 
 
 #ifdef HAVE_SHAPEFIL_H
   #include <shapefil.h>
@@ -303,7 +303,7 @@ int main(int argc, char *argv[])
   awk_free_symtab(symtbl);
   exit(0);
 }
-#else /* defined(HAVE_LIBSHP) && defined(HAVE_LIBPCRE) */
+#else /* HAVE_LIBSHP */
 
 
 
@@ -314,6 +314,6 @@ int main(int argc, char *argv[])
   fprintf(stderr,"DBFAWK support not compiled.\n");
   exit(1);
 }
-#endif /* defined(HAVE_LIBSHP) && defined(HAVE_LIBPCRE) */
+#endif /* HAVE_LIBSHP */
 
 


### PR DESCRIPTION
This pull request adds PCRE2 support to Xastir, while maintaining support for legacy PCRE.

If PCRE2 is found (first by finding "pcre2.h" and then by finding "libpcre2-8"), we use it.  Only if it is NOT found (or doesn't work because of pathing or other issues) then we probe for legacy PCRE as we always have.  If neither works, we puke saying we can't support shapelib without a version of PCRE and tell the user to install it or disable shapefile support.

I have tested this primarily by using the "testdbfawk" program over a handful of complex shapefiles I have.  I have confirmed that testdbfawk produces identical parsing and handling of shapefiles with either version of PCRE, and have tested the fallback mechanism multiple times --- Xastir compiles and links with either version of PCRE and works correctly.

I would like to merge this ASAP, as this issue (#203) is blocking some Linux distros from including Xastir in new releases (PCRE is deprecated and has been unsupported for years, whereas PCRE2 is still an active project).

Once merged, it will be a high priority to release a new version of Xastir, as the same distros that won't keep Xastir without PCRE2 support will not include anything but release versions.
