### PR TITLE
Issue 202 -- remove obsolete autoconf macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -289,10 +289,10 @@ AC_SUBST(LIBS)
 #
 AC_FUNC_ALLOCA 
 AC_HEADER_DIRENT 
-AC_HEADER_STDC 
 AC_HEADER_SYS_WAIT 
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h locale.h malloc.h math.h netdb.h]) 
-AC_CHECK_HEADERS([netinet/in.h nl_types.h stdarg.h stddef.h stdlib.h string.h strings.h])
+# We still check for stdarg.h even though it's standard, because a legacy
+# file (snprintf.c) still uses its symbol.
+AC_CHECK_HEADERS([stdarg.h])
 AC_CHECK_HEADERS([sys/file.h sys/ioctl.h sys/param.h sys/socket.h sys/time.h signal.h])
 AC_CHECK_HEADERS([termios.h unistd.h]) 
 

--- a/configure.ac
+++ b/configure.ac
@@ -296,16 +296,14 @@ AC_CHECK_HEADERS([stdarg.h])
 AC_CHECK_HEADERS([sys/file.h sys/ioctl.h sys/param.h sys/socket.h sys/time.h signal.h])
 AC_CHECK_HEADERS([termios.h unistd.h]) 
 
-# Checks for typedefs, structures, and compiler characteristics. 
-# 
-AC_C_CONST 
-AC_TYPE_UID_T 
-AC_C_INLINE 
-AC_TYPE_PID_T 
-AC_TYPE_SIZE_T 
-AC_HEADER_TIME 
-#AC_STRUCT_TM 
-AC_TYPE_SIGNAL 
+# Checks for typedefs, structures, and compiler characteristics.
+#
+AC_C_CONST
+AC_TYPE_UID_T
+AC_C_INLINE
+AC_TYPE_PID_T
+AC_TYPE_SIZE_T
+AC_HEADER_TIME
 AC_STRUCT_TIMEZONE
 
 #Some (Mac?) systems don't define this where it should be, so we kludge

--- a/configure.ac
+++ b/configure.ac
@@ -303,7 +303,6 @@ AC_TYPE_UID_T
 AC_C_INLINE
 AC_TYPE_PID_T
 AC_TYPE_SIZE_T
-AC_HEADER_TIME
 AC_STRUCT_TIMEZONE
 
 #Some (Mac?) systems don't define this where it should be, so we kludge

--- a/src/alert.c
+++ b/src/alert.c
@@ -293,9 +293,7 @@
 #include <assert.h>
 #include <ctype.h>
 
-#ifdef  HAVE_LOCALE_H
-  #include <locale.h>
-#endif  // HAVE_LOCALE_H
+#include <locale.h>
 
 #include <Xm/XmAll.h>
 

--- a/src/alert.h
+++ b/src/alert.h
@@ -25,17 +25,10 @@
 #define __XASTIR_ALERT_H
 
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else
-    #include <time.h>
-  #endif
-#endif
-
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include "database.h"
 //#include "maps.h"

--- a/src/awk.c
+++ b/src/awk.c
@@ -68,11 +68,6 @@
 #include <stdio.h>
 #include <string.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <ctype.h>
 #include <sys/types.h>
 #include "awk.h"

--- a/src/bulletin_gui.c
+++ b/src/bulletin_gui.c
@@ -34,11 +34,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <ctype.h>
 #include <sys/types.h>
 

--- a/src/bulletin_gui.c
+++ b/src/bulletin_gui.c
@@ -37,16 +37,10 @@
 #include <ctype.h>
 #include <sys/types.h>
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include <Xm/XmAll.h>
 

--- a/src/db.c
+++ b/src/db.c
@@ -50,11 +50,6 @@
 #include <ctype.h>
 #include <string.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <math.h>
 
 #include <Xm/XmAll.h>

--- a/src/dlm.c
+++ b/src/dlm.c
@@ -39,11 +39,6 @@
 #include <sys/types.h>
 #include <errno.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #ifdef HAVE_LIBCURL
   #include <curl/curl.h>
 #endif

--- a/src/fcc_data.c
+++ b/src/fcc_data.c
@@ -32,16 +32,10 @@
 #include <string.h>
 #include <ctype.h>
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include <Xm/XmAll.h>
 

--- a/src/fetch_remote.c
+++ b/src/fetch_remote.c
@@ -28,16 +28,10 @@
 
 #include "snprintf.h"
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include <unistd.h>
 #include <signal.h>

--- a/src/fetch_remote.c
+++ b/src/fetch_remote.c
@@ -43,11 +43,6 @@
 #include <signal.h>
 #include <string.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>

--- a/src/forked_getaddrinfo.c
+++ b/src/forked_getaddrinfo.c
@@ -105,14 +105,13 @@ static void host_time_out( int UNUSED(sig) )
 /* TIMEOUT for time exceeded                                             */
 /*************************************************************************/
 
+#define RETSIGTYPE void
+
 int forked_getaddrinfo(const char *hostname, const char *servname, const struct addrinfo *hints, struct addrinfo **resout, int time)
 {
 
-#ifdef RETSIGTYPE
   RETSIGTYPE * previous_loc;
-#else
-#error RETSIGTYPE not defined
-#endif
+
 
   pid_t host_pid;
   int status;
@@ -190,11 +189,7 @@ int forked_getaddrinfo(const char *hostname, const char *servname, const struct 
         fprintf(stderr,"Set alarm \n");
       }
 
-#ifdef RETSIGTYPE
       previous_loc = (RETSIGTYPE *)signal(SIGALRM, host_time_out);
-#else
-      previous_loc = signal(SIGALRM, host_time_out);
-#endif
 
       // Set up to jump here if we time out on SIGALRM
       if (sigsetjmp(ret_place,-1)!=0)

--- a/src/gps.c
+++ b/src/gps.c
@@ -31,22 +31,10 @@
 #include <ctype.h>
 #include <Xm/XmAll.h>
 
-// The following files support setting the system time from the GPS
-#if TIME_WITH_SYS_TIME
-  // Define needed by some versions of Linux in order to define
-  // strptime()
-  #ifndef __USE_XOPEN
-    #define __USE_XOPEN
-  #endif
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/interface.c
+++ b/src/interface.c
@@ -59,16 +59,10 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include <errno.h>
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -54,9 +54,7 @@
 #include <arpa/inet.h>
 #include <netinet/tcp.h>    // Needed for TCP_NODELAY setsockopt() (disabling Nagle algorithm)
 
-#ifdef HAVE_NETDB_H
-  #include <netdb.h>
-#endif  // HAVE_NETDB_H
+#include <netdb.h>
 
 #include <sys/types.h>
 #include <sys/ioctl.h>
@@ -74,9 +72,7 @@
 
 #include <errno.h>
 
-#ifdef  HAVE_LOCALE_H
-  #include <locale.h>
-#endif  // HAVE_LOCALE_H
+#include <locale.h>
 
 #include <Xm/XmAll.h>
 

--- a/src/lang.c
+++ b/src/lang.c
@@ -37,16 +37,10 @@
 #include <ctype.h>
 #include <sys/types.h>
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include <Xm/XmAll.h>
 

--- a/src/list_gui.c
+++ b/src/list_gui.c
@@ -32,9 +32,7 @@
 #include <assert.h>
 #include <ctype.h>
 
-#ifdef  HAVE_LOCALE_H
-  #include <locale.h>
-#endif  // HAVE_LOCALE_H
+#include <locale.h>
 
 #include <Xm/XmAll.h>
 

--- a/src/main.c
+++ b/src/main.c
@@ -51,11 +51,6 @@ static int DISPLAY_XASTIR_COORDINATES = 0;
 #include <pwd.h>
 #include <locale.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <sys/wait.h>
 #include <errno.h>
 

--- a/src/main.c
+++ b/src/main.c
@@ -73,7 +73,6 @@ char *xastir_version=VERSION;
 
 #ifdef HAVE_MAGICK
   #include <sys/types.h>
-  #undef RETSIGTYPE
   /* JMT - stupid ImageMagick */
   #define XASTIR_PACKAGE_BUGREPORT PACKAGE_BUGREPORT
   #undef PACKAGE_BUGREPORT

--- a/src/main.c
+++ b/src/main.c
@@ -54,16 +54,10 @@ static int DISPLAY_XASTIR_COORDINATES = 0;
 #include <sys/wait.h>
 #include <errno.h>
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 // TVR -- stupid, stupid ImageMagick
 char *xastir_package=PACKAGE;

--- a/src/map_OSM.c
+++ b/src/map_OSM.c
@@ -88,7 +88,6 @@
       #include <time.h>
     #endif // HAVE_SYS_TIME_H
   #endif  // TIME_WITH_SYS_TIME
-  #undef RETSIGTYPE
   // TVR: "stupid ImageMagick"
   // The problem is that magick/api.h includes Magick's config.h file, and that
   // pulls in all the same autoconf-generated defines that we use.

--- a/src/map_OSM.c
+++ b/src/map_OSM.c
@@ -42,11 +42,6 @@
 #include <pwd.h>
 #include <errno.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <dirent.h>
 #include <netinet/in.h>
 #include <Xm/XmAll.h>

--- a/src/map_OSM.c
+++ b/src/map_OSM.c
@@ -78,16 +78,10 @@
 #define CHECKMALLOC(m)  if (!m) { fprintf(stderr, "***** Malloc Failed *****\n"); exit(0); }
 
 #ifdef HAVE_MAGICK
-  #if TIME_WITH_SYS_TIME
+  #if HAVE_SYS_TIME_H
     #include <sys/time.h>
-    #include <time.h>
-  #else   // TIME_WITH_SYS_TIME
-    #if HAVE_SYS_TIME_H
-      #include <sys/time.h>
-    #else  // HAVE_SYS_TIME_H
-      #include <time.h>
-    #endif // HAVE_SYS_TIME_H
-  #endif  // TIME_WITH_SYS_TIME
+  #endif // HAVE_SYS_TIME_H
+  #include <time.h>
   // TVR: "stupid ImageMagick"
   // The problem is that magick/api.h includes Magick's config.h file, and that
   // pulls in all the same autoconf-generated defines that we use.

--- a/src/map_WMS.c
+++ b/src/map_WMS.c
@@ -73,16 +73,10 @@
 #define CHECKMALLOC(m)  if (!m) { fprintf(stderr, "***** Malloc Failed *****\n"); exit(0); }
 
 #ifdef HAVE_MAGICK
-  #if TIME_WITH_SYS_TIME
+  #if HAVE_SYS_TIME_H
     #include <sys/time.h>
-    #include <time.h>
-  #else   // TIME_WITH_SYS_TIME
-    #if HAVE_SYS_TIME_H
-      #include <sys/time.h>
-    #else  // HAVE_SYS_TIME_H
-      #include <time.h>
-    #endif // HAVE_SYS_TIME_H
-  #endif  // TIME_WITH_SYS_TIME
+  #endif // HAVE_SYS_TIME_H
+  #include <time.h>
   // TVR: "stupid ImageMagick"
   // The problem is that magick/api.h includes Magick's config.h file, and that
   // pulls in all the same autoconf-generated defines that we use.

--- a/src/map_WMS.c
+++ b/src/map_WMS.c
@@ -83,7 +83,6 @@
       #include <time.h>
     #endif // HAVE_SYS_TIME_H
   #endif  // TIME_WITH_SYS_TIME
-  #undef RETSIGTYPE
   // TVR: "stupid ImageMagick"
   // The problem is that magick/api.h includes Magick's config.h file, and that
   // pulls in all the same autoconf-generated defines that we use.

--- a/src/map_WMS.c
+++ b/src/map_WMS.c
@@ -37,11 +37,6 @@
 #include <pwd.h>
 #include <errno.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <dirent.h>
 #include <netinet/in.h>
 #include <Xm/XmAll.h>

--- a/src/map_dos.c
+++ b/src/map_dos.c
@@ -36,11 +36,6 @@
 #include <pwd.h>
 #include <errno.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <dirent.h>
 #include <netinet/in.h>
 #include <Xm/XmAll.h>

--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -88,16 +88,10 @@
 
 
 #ifdef HAVE_MAGICK
-  #if TIME_WITH_SYS_TIME
+  #if HAVE_SYS_TIME_H
     #include <sys/time.h>
-    #include <time.h>
-  #else   // TIME_WITH_SYS_TIME
-    #if HAVE_SYS_TIME_H
-      #include <sys/time.h>
-    #else  // HAVE_SYS_TIME_H
-      #include <time.h>
-    #endif // HAVE_SYS_TIME_H
-  #endif  // TIME_WITH_SYS_TIME
+  #endif // HAVE_SYS_TIME_H
+  #include <time.h>
   // TVR: "stupid ImageMagick"
   // The problem is that magick/api.h includes Magick's config.h file, and that
   // pulls in all the same autoconf-generated defines that we use.

--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -98,7 +98,6 @@
       #include <time.h>
     #endif // HAVE_SYS_TIME_H
   #endif  // TIME_WITH_SYS_TIME
-  #undef RETSIGTYPE
   // TVR: "stupid ImageMagick"
   // The problem is that magick/api.h includes Magick's config.h file, and that
   // pulls in all the same autoconf-generated defines that we use.

--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -38,11 +38,6 @@
 #include <pwd.h>
 #include <errno.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <dirent.h>
 #include <netinet/in.h>
 #include <Xm/XmAll.h>

--- a/src/map_gnis.c
+++ b/src/map_gnis.c
@@ -37,11 +37,6 @@
 #include <pwd.h>
 #include <errno.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <dirent.h>
 #include <netinet/in.h>
 #include <Xm/XmAll.h>

--- a/src/map_pop.c
+++ b/src/map_pop.c
@@ -37,11 +37,6 @@
 #include <pwd.h>
 #include <errno.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <dirent.h>
 #include <netinet/in.h>
 #include <Xm/XmAll.h>

--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -50,11 +50,6 @@
 #include <pwd.h>
 #include <errno.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <dirent.h>
 #include <netinet/in.h>
 #include <Xm/XmAll.h>

--- a/src/map_tif.c
+++ b/src/map_tif.c
@@ -38,11 +38,6 @@
 #include <pwd.h>
 #include <errno.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <dirent.h>
 #include <netinet/in.h>
 #include <Xm/XmAll.h>

--- a/src/maps.c
+++ b/src/maps.c
@@ -50,7 +50,6 @@
       #include <time.h>
     #endif // HAVE_SYS_TIME_H
   #endif  // TIME_WITH_SYS_TIME
-  #undef RETSIGTYPE
   // TVR: "stupid ImageMagick"
   // The problem is that magick/api.h includes Magick's config.h file, and that
   // pulls in all the same autoconf-generated defines that we use.

--- a/src/maps.c
+++ b/src/maps.c
@@ -39,11 +39,6 @@
 #include <pwd.h>
 #include <errno.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #ifdef HAVE_MAGICK
   #if TIME_WITH_SYS_TIME
     #include <sys/time.h>

--- a/src/maps.c
+++ b/src/maps.c
@@ -40,16 +40,10 @@
 #include <errno.h>
 
 #ifdef HAVE_MAGICK
-  #if TIME_WITH_SYS_TIME
+  #if HAVE_SYS_TIME_H
     #include <sys/time.h>
-    #include <time.h>
-  #else   // TIME_WITH_SYS_TIME
-    #if HAVE_SYS_TIME_H
-      #include <sys/time.h>
-    #else  // HAVE_SYS_TIME_H
-      #include <time.h>
-    #endif // HAVE_SYS_TIME_H
-  #endif  // TIME_WITH_SYS_TIME
+  #endif // HAVE_SYS_TIME_H
+  #include <time.h>
   // TVR: "stupid ImageMagick"
   // The problem is that magick/api.h includes Magick's config.h file, and that
   // pulls in all the same autoconf-generated defines that we use.

--- a/src/messages.c
+++ b/src/messages.c
@@ -37,11 +37,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#ifdef HAVE_STRING_H
-  #include <string.h>
-#else
-  #include <strings.h>
-#endif
+#include <string.h>
 #include <ctype.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/src/messages.c
+++ b/src/messages.c
@@ -42,16 +42,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include "xastir.h"
 #include "main.h"

--- a/src/objects.c
+++ b/src/objects.c
@@ -32,16 +32,10 @@
 #include <ctype.h>
 #include <math.h>
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include "xastir.h"
 #include "draw_symbols.h"

--- a/src/rac_data.c
+++ b/src/rac_data.c
@@ -44,16 +44,10 @@
 #include <ctype.h>
 #include <sys/types.h>
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include <Xm/XmAll.h>
 

--- a/src/shp_hash.c
+++ b/src/shp_hash.c
@@ -31,16 +31,10 @@
 #include <stdio.h>
 #include <stdint.h>
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #ifdef HAVE_SHAPEFIL_H
   #include <shapefil.h>

--- a/src/util.c
+++ b/src/util.c
@@ -28,16 +28,10 @@
 
 #include "snprintf.h"
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include <unistd.h>
 #include <signal.h>

--- a/src/util.c
+++ b/src/util.c
@@ -43,11 +43,6 @@
 #include <signal.h>
 #include <string.h>
 
-// Needed for Solaris
-#ifdef HAVE_STRINGS_H
-  #include <strings.h>
-#endif  // HAVE_STRINGS_H
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>

--- a/src/view_message_gui.c
+++ b/src/view_message_gui.c
@@ -37,11 +37,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#ifdef HAVE_STRING_H
-  #include <string.h>
-#else
-  #include <strings.h>
-#endif
+#include <string.h>
 #include <ctype.h>
 #include <sys/types.h>
 

--- a/src/view_message_gui.c
+++ b/src/view_message_gui.c
@@ -41,16 +41,10 @@
 #include <ctype.h>
 #include <sys/types.h>
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include "xastir.h"
 #include "main.h"

--- a/src/wx.c
+++ b/src/wx.c
@@ -60,16 +60,10 @@
 #include <stdio.h>
 #include <math.h>
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include <string.h>
 

--- a/src/wx_gui.c
+++ b/src/wx_gui.c
@@ -35,13 +35,9 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-#ifdef  HAVE_LOCALE_H
-  #include <locale.h>
-#endif  // HAVE_LOCALE_H
+#include <locale.h>
 
-#ifdef HAVE_MATH_H
-  #include <math.h>
-#endif  // HAVE_MATH_H
+#include <math.h>
 
 #include "xastir.h"
 #include "wx.h"

--- a/src/x_spider.c
+++ b/src/x_spider.c
@@ -132,9 +132,7 @@
 #include <arpa/inet.h>
 #include <netinet/tcp.h>    // Needed for TCP_NODELAY setsockopt() (disabling Nagle algorithm)
 
-#ifdef HAVE_NETDB_H
-  #include <netdb.h>
-#endif  // HAVE_NETDB_H
+#include <netdb.h>
 
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -153,9 +151,7 @@
 
 #include <errno.h>
 
-#ifdef  HAVE_LOCALE_H
-  #include <locale.h>
-#endif  // HAVE_LOCALE_H
+#include <locale.h>
 
 #ifndef SIGRET
   #define SIGRET  void

--- a/src/x_spider.c
+++ b/src/x_spider.c
@@ -138,16 +138,10 @@
 #include <sys/wait.h>
 #include <sys/ioctl.h>
 
-#if TIME_WITH_SYS_TIME
+#if HAVE_SYS_TIME_H
   #include <sys/time.h>
-  #include <time.h>
-#else   // TIME_WITH_SYS_TIME
-  #if HAVE_SYS_TIME_H
-    #include <sys/time.h>
-  #else  // HAVE_SYS_TIME_H
-    #include <time.h>
-  #endif // HAVE_SYS_TIME_H
-#endif  // TIME_WITH_SYS_TIME
+#endif // HAVE_SYS_TIME_H
+#include <time.h>
 
 #include <errno.h>
 

--- a/src/xastir_udp_client.c
+++ b/src/xastir_udp_client.c
@@ -38,9 +38,7 @@
 #include <arpa/inet.h>
 //#include <netinet/tcp.h>    // Needed for TCP_NODELAY setsockopt() (disabling Nagle algorithm)
 
-#ifdef HAVE_NETDB_H
-  #include <netdb.h>
-#endif  // HAVE_NETDB_H
+#include <netdb.h>
 
 #include <sys/types.h>
 #include <sys/wait.h>


### PR DESCRIPTION
This branch removes three autoconf macros from our configure.ac file, all of which cause autoconf  to scream loudly that they're obsolete and implore the user to run "autoupdate" (which would be the WRONG fix, as we were still using the defined macros that these things set).

AC_HEADER_STDC:  checks for existence of several files that have been part of the standard since around C89, and should no longer need probing.  In many cases we were simply including those files unconditionally anyway, so it was pointless to be asking configure if they exist --- if they didn't the user base would have complained loudly that Xastir bombs during compilation.  This is exactly how autoconf is NOT supposed to be used anyway.  At any rate, I have cleaned out the use of this macro and any cases where the things it defined were being inconsistently applied.

AC_HEADER_TIME:  this checks if sys/time.h and time.h may both be included if they exist.  It, too, is considered an obsolete macro and autoconf screams if you use it.  Very old systems tended to have a sys/time.h that included time.h itself, but a time.h that didn't protect against multiple includes.  That is no longer a problem and the macro is obsolete.  Now, we just probe for sys/time.h and include it if it exists, and also include time.h which is assumed to exist (it's part of the standard).  In ONE case (gps.c) I removed some extra hackage intended to allow strptime to work "on some linux systems" but a separate file (db.c) used strptime and *DIDN'T* have that hackage.  That means the hackage was obsolete, too, and I removed it.  

AC_TYPE_SIGNAL:  tests if "signal()" returns a void or not.  The standard says it's always void, and in almost every case in Xastir we were already *assuming* it returns void.  In exactly ONE case we were actually respecting the case where it didn't return void, but clearly since we were assuming it everywhere else it was pointless to be running the autoconf macro to check.

I also removed a number of AC_CHECK_HEADERS arguments for headers that we either are unconditionally assuming exist anyway, or not even including anywhere.  Every argument in an AC_CHECK_HEADERS call means that configure is creating and compiling a little test program, and every unnecessary probe wastes time as configure runs.  

