### PR TITLE
Issue 156 -- Fix default display_level to be consistent and huge

### DIFF
--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -49,6 +49,7 @@
 #include <sys/types.h>
 #include <pwd.h>
 #include <errno.h>
+#include <limits.h>
 
 #include <dirent.h>
 #include <netinet/in.h>
@@ -693,7 +694,7 @@ static awk_rule dbfawk_default_rules[] =
     NULL,
     0,
     0,
-    "dbfinfo=\"\"; key=\"\"; lanes=1; color=8; fill_color=13; fill_stipple=0; name=\"\"; filled=0; fill_style=0; pattern=0; display_level=65536; label_level=0",
+    "dbfinfo=\"\"; key=\"\"; lanes=1; color=8; fill_color=13; fill_stipple=0; name=\"\"; filled=0; fill_style=0; pattern=0; display_level=2147483647; label_level=0",
     0,
     0
   },
@@ -801,7 +802,7 @@ void draw_shapefile_map (Widget w,
   fill_color=13;
   fill_stipple=0;
   pattern=0;
-  display_level=8192;
+  display_level=INT_MAX;
   label_level=0;
   label_color=8;
   font_size=FONT_DEFAULT;


### PR DESCRIPTION
In issue #156 it was reported that Xastir's defaults make it so that a shapefile that has no associated dbfawk file does not correctly get displayed at all zoom levels.  There are two reasons for this.

One, the default_dbfawk_rules defines a display level of 65536 which is very small compared to the possible world-level zoom.  This rule is used when no dbfawk file is found.

The second problem is that elsewhere in the code we set display_level to 8192.  This much, much older value used to be the same in default_dbfawk_rules, but the default rules were updated in commit 56b7e30 to the higher value.  This value is only used when there *is* an associated dbfawk file, but that file fails to initialize display_level in the BEGIN record.

This commit makes the default in default_dbfawk_rules to be 2147483647 (the highest allowable value in a signed 16 bit int) and to MAX_INT (the actual highest allowable value in a variable declared as "int").

This is because the value in default_dbfawk_rules is embedded in a STRING, and expanding the INT_MAX macro (from limits.h) is not possible there.  So I just had to pick a hard-coded number.

This should make it so that we always display a shapefile with no dbfawk associated at all zoom levels, and always display a shape for a shapefile that *does* have a dbfawk but which fails to initialize display_level in the BEGIN record.

Addresses issue #156
