### PR TITLE
Remove workarounds for ancient versions of ImageMagick

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -30018,15 +30018,7 @@ int main(int argc, char *argv[], char *envp[])
   InitializeMagick(*argv);
 #else   // HAVE_GRAPHICSMAGICK
 #ifdef HAVE_IMAGEMAGICK
-#if (MagickLibVersion < 0x0538)
-  MagickIncarnate(*argv);
-#else   // 0x0538 < MagickLibVersion < 0x0669
-  #if (MagickLibVersion < 0x0669)
-    InitializeMagick(*argv);
-  #else // > 0x669
-    MagickCoreGenesis(*argv, MagickTrue);
-  #endif
-#endif  // MagickLibVersion < 0x0538
+  MagickCoreGenesis(*argv, MagickTrue);
 #endif  // HAVE_IMAGEMAGICK
 #endif  //HAVE_GRAPHICSMAGICK
 

--- a/src/map_OSM.c
+++ b/src/map_OSM.c
@@ -543,28 +543,18 @@ static void draw_image(
   // try to reduce the number of colors in an image.
   // This may take some time, so it would be best to do ahead of
   // time if it is a static image.
-#if (MagickLibVersion < 0x0540)
-  if (visual_type == NOT_TRUE_NOR_DIRECT && GetNumberColors(image, NULL) > 128)
-  {
-#else   // MagickLib >= 540
   if (visual_type == NOT_TRUE_NOR_DIRECT && GetNumberColors(image, NULL, except_ptr) > 128)
   {
-#endif  // MagickLib Version
-
     if (image->storage_class == PseudoClass)
     {
-#if (MagickLibVersion < 0x0549)
-      CompressColormap(image); // Remove duplicate colors
-#else // MagickLib >= 0x0549
       CompressImageColormap(image); // Remove duplicate colors
-#endif  // MagickLibVersion < 0x0549
     }
 
     // Quantize down to 128 will go here...
   }
 
 
-#if defined(HAVE_GRAPHICSMAGICK) || (MagickLibVersion < 0x0669)
+#if defined(HAVE_GRAPHICSMAGICK)
   pixel_pack = GetImagePixels(image, 0, 0, image->columns, image->rows);
 #else
   pixel_pack = GetAuthenticPixels(image, 0, 0, image->columns, image->rows, except_ptr);
@@ -582,11 +572,7 @@ static void draw_image(
   index_pack = AccessMutableIndexes(image);
 #endif
 #else
-#if (MagickLibVersion < 0x0669)
-  index_pack = GetIndexes(image);
-#else
   index_pack = GetAuthenticIndexQueue(image);
-#endif
 #endif
   if (image->storage_class == PseudoClass && !index_pack)
   {
@@ -776,28 +762,18 @@ static void draw_OSM_image(
   // try to reduce the number of colors in an image.
   // This may take some time, so it would be best to do ahead of
   // time if it is a static image.
-#if (MagickLibVersion < 0x0540)
-  if (visual_type == NOT_TRUE_NOR_DIRECT && GetNumberColors(image, NULL) > 128)
-  {
-#else   // MagickLib >= 540
   if (visual_type == NOT_TRUE_NOR_DIRECT && GetNumberColors(image, NULL, except_ptr) > 128)
   {
-#endif  // MagickLib Version
-
     if (image->storage_class == PseudoClass)
     {
-#if (MagickLibVersion < 0x0549)
-      CompressColormap(image); // Remove duplicate colors
-#else // MagickLib >= 0x0549
       CompressImageColormap(image); // Remove duplicate colors
-#endif  // MagickLibVersion < 0x0549
     }
 
     // Quantize down to 128 will go here...
   }
 
 
-#if defined(HAVE_GRAPHICSMAGICK) || (MagickLibVersion < 0x669)
+#if defined(HAVE_GRAPHICSMAGICK)
   pixel_pack = GetImagePixels(image, 0, 0, image->columns, image->rows);
 #else
   pixel_pack = GetAuthenticPixels(image, 0, 0, image->columns, image->rows, except_ptr);
@@ -815,11 +791,7 @@ static void draw_OSM_image(
   index_pack = AccessMutableIndexes(image);
 #endif
 #else
-#if (MagickLibVersion < 0x0669)
-  index_pack = GetIndexes(image);
-#else
   index_pack = GetAuthenticIndexQueue(image);
-#endif
 #endif
   if (image->storage_class == PseudoClass && !index_pack)
   {
@@ -1360,7 +1332,7 @@ void draw_OSM_tiles (Widget w,
     canvas->background_color.green = MATTE_GREEN;
     canvas->background_color.blue = MATTE_BLUE;
     canvas->background_color.opacity = MATTE_OPACITY;
-#if defined(HAVE_GRAPHICSMAGICK) || (MagickLibVersion < 0x0669)
+#if defined(HAVE_GRAPHICSMAGICK)
     SetImage(canvas, MATTE_OPACITY);
 #else
     SetImageBackgroundColor(canvas);
@@ -1397,7 +1369,7 @@ void draw_OSM_tiles (Widget w,
           if (exception.severity==FileOpenError)
           {
             //fprintf(stderr, "%s NOT available\n", tile_info->filename);
-#if !defined(HAVE_GRAPHICSMAGICK) && (MagickLibVersion > 0x0669)
+#if !defined(HAVE_GRAPHICSMAGICK)
             ClearMagickException(&exception);
 #endif
           }
@@ -1440,7 +1412,7 @@ void draw_OSM_tiles (Widget w,
 
     if (debug_level & 512)
     {
-#if defined(HAVE_GRAPHICSMAGICK) || (MagickLibVersion < 0x0669)
+#if defined(HAVE_GRAPHICSMAGICK)
       DescribeImage(canvas, stderr, 0);
 #else
       IdentifyImage(canvas, stderr, 0);
@@ -1839,11 +1811,7 @@ void draw_OSM_map (Widget w,
   {
     fprintf(stderr,"Image: %s\n", file);
     fprintf(stderr,"Image size %d %d\n", map_image_width, map_image_height);
-#if (MagickLibVersion < 0x0540)
-    fprintf(stderr,"Unique colors = %d\n", GetNumberColors(image, NULL));
-#else // MagickLib < 540
     fprintf(stderr,"Unique colors = %ld\n", GetNumberColors(image, NULL, &exception));
-#endif // MagickLib < 540
     fprintf(stderr,"image matte is %i\n", image->matte);
   } // debug_level & 512
 

--- a/src/map_WMS.c
+++ b/src/map_WMS.c
@@ -650,28 +650,19 @@ void draw_WMS_map (Widget w,
   // try to reduce the number of colors in an image.
   // This may take some time, so it would be best to do ahead of
   // time if it is a static image.
-#if (MagickLibVersion < 0x0540)
-  if (visual_type == NOT_TRUE_NOR_DIRECT && GetNumberColors(image, NULL) > 128)
-  {
-#else   // MagickLib >= 540
   if (visual_type == NOT_TRUE_NOR_DIRECT && GetNumberColors(image, NULL, &exception) > 128)
   {
-#endif  // MagickLib Version
 
     if (image->storage_class == PseudoClass)
     {
-#if (MagickLibVersion < 0x0549)
-      CompressColormap(image); // Remove duplicate colors
-#else // MagickLib >= 0x0549
       CompressImageColormap(image); // Remove duplicate colors
-#endif  // MagickLibVersion < 0x0549
     }
 
     // Quantize down to 128 will go here...
   }
 
 
-#if defined(HAVE_GRAPHICSMAGICK) || (MagickLibVersion < 0x0669)
+#if defined(HAVE_GRAPHICSMAGICK)
   pixel_pack = GetImagePixels(image, 0, 0, image->columns, image->rows);
 #else
   pixel_pack = GetAuthenticPixels(image, 0, 0, image->columns, image->rows, &exception);
@@ -699,11 +690,7 @@ void draw_WMS_map (Widget w,
     index_pack = AccessMutableIndexes(image);
   #endif
 #else
-  #if (MagickLibVersion < 0x0669)
-    index_pack = GetIndexes(image);
-  #else
     index_pack = GetAuthenticIndexQueue(image);
-  #endif
 #endif
   if (image->storage_class == PseudoClass && !index_pack)
   {
@@ -874,11 +861,7 @@ void draw_WMS_map (Widget w,
     fprintf(stderr,"XX: %ld YY:%ld Sx %f %d Sy %f %d\n",
             map_c_L, map_c_T, map_c_dx,(int) (map_c_dx / scale_x), map_c_dy, (int) (map_c_dy / scale_y));
     fprintf(stderr,"Image size %d %d\n", width, height);
-#if (MagickLibVersion < 0x0540)
-    fprintf(stderr,"Unique colors = %d\n", GetNumberColors(image, NULL));
-#else // MagickLib < 540
     fprintf(stderr,"Unique colors = %ld\n", GetNumberColors(image, NULL, &exception));
-#endif // MagickLib < 540
     fprintf(stderr,"XX: %ld YY:%ld Sx %f %d Sy %f %d\n", map_c_L, map_c_T,
             map_c_dx,(int) (map_c_dx / scale_x), map_c_dy, (int) (map_c_dy / scale_y));
     fprintf(stderr,"image matte is %i\n", image->matte);

--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -1164,7 +1164,6 @@ void draw_geo_image_map (Widget w,
       {
         imagemagick_options.normalize = 1;
       }
-#if (MagickLibVersion >= 0x0539)
       if (strncasecmp(line, "LEVEL", 5) == 0)
       {
         xastir_snprintf(imagemagick_options.level,
@@ -1172,7 +1171,6 @@ void draw_geo_image_map (Widget w,
                         "%s",
                         line+6);
       }
-#endif  // MagickLibVersion >= 0x0539
       if (strncasecmp(line, "MODULATE", 8) == 0)
       {
         xastir_snprintf(imagemagick_options.modulate,
@@ -2237,7 +2235,6 @@ void draw_geo_image_map (Widget w,
     return;
   }
 
-#if (MagickLibVersion >= 0x0539)
   if (imagemagick_options.level[0] != '\0')
   {
     if (debug_level & 16)
@@ -2246,7 +2243,6 @@ void draw_geo_image_map (Widget w,
     }
     LevelImage(image, imagemagick_options.level);
   }
-#endif  // MagickLibVersion >= 0x0539
 
   if (check_interrupt(image, image_info,
                       &exception, &da, &pixmap, &gc, screen_width, screen_height))
@@ -2300,7 +2296,7 @@ void draw_geo_image_map (Widget w,
     //        target=GetOnePixel(image,0,0);
     for (y=0; y < (long) image->rows; y++)
     {
-#if defined(HAVE_GRAPHICSMAGICK) || (MagickLibVersion < 0x0669)
+#if defined(HAVE_GRAPHICSMAGICK)
       q=GetImagePixels(image,0,y,image->columns,1);
 #else
       q=GetAuthenticPixels(image,0,y,image->columns,1,&exception);
@@ -2318,7 +2314,7 @@ void draw_geo_image_map (Widget w,
         }
         q++;
       }
-#if defined(HAVE_GRAPHICSMAGICK) || (MagickLibVersion < 0x0669)
+#if defined(HAVE_GRAPHICSMAGICK)
       if (!SyncImagePixels(image))
       {
         fprintf(stderr, "SyncImagePixels Failed....\n");
@@ -2336,21 +2332,12 @@ void draw_geo_image_map (Widget w,
   // try to reduce the number of colors in an image.
   // This may take some time, so it would be best to do ahead of
   // time if it is a static image.
-#if (MagickLibVersion < 0x0540)
-  if (visual_type == NOT_TRUE_NOR_DIRECT && GetNumberColors(image, NULL) > 128)
-  {
-#else   // MagickLib >= 540
   if (visual_type == NOT_TRUE_NOR_DIRECT && GetNumberColors(image, NULL, &exception) > 128)
   {
-#endif  // MagickLib Version
 
     if (image->storage_class == PseudoClass)
     {
-#if (MagickLibVersion < 0x0549)
-      CompressColormap(image); // Remove duplicate colors
-#else // MagickLib >= 0x0549
       CompressImageColormap(image); // Remove duplicate colors
-#endif  // MagickLibVersion < 0x0549
     }
 
     // Quantize down to 128 will go here...
@@ -2362,7 +2349,7 @@ void draw_geo_image_map (Widget w,
     return;
   }
 
-#if defined(HAVE_GRAPHICSMAGICK) || (MagickLibVersion < 0x0669)
+#if defined(HAVE_GRAPHICSMAGICK)
   pixel_pack = GetImagePixels(image, 0, 0, image->columns, image->rows);
 #else
   pixel_pack = GetAuthenticPixels(image, 0, 0, image->columns, image->rows,&exception);
@@ -2395,11 +2382,7 @@ void draw_geo_image_map (Widget w,
     index_pack = AccessMutableIndexes(image);
   #endif
 #else
-  #if (MagickLibVersion < 0x0669)
-    index_pack = GetIndexes(image);
-  #else
     index_pack = GetAuthenticIndexQueue(image);
-  #endif
 #endif
   if (image->storage_class == PseudoClass && !index_pack)
   {
@@ -2541,25 +2524,14 @@ void draw_geo_image_map (Widget w,
   if (debug_level & 16)
   {
     fprintf(stderr,"Image size %d %d\n", width, height);
-#if (MagickLibVersion < 0x0540)
-    fprintf(stderr,"Unique colors = %d\n", GetNumberColors(image, NULL));
-#else   // MagickLibVersion < 0x0540
     fprintf(stderr,"Unique colors = %ld\n", GetNumberColors(image, NULL, &exception));
-#endif  // MagickLibVersion < 0x0540
     fprintf(stderr,"XX: %ld YY:%ld Sx %f %d Sy %f %d\n", map_c_L, map_c_T,
             map_c_dx,(int) (map_c_dx / scale_x), map_c_dy, (int) (map_c_dy / scale_y));
 
-#if (MagickLibVersion < 0x0540)
-    fprintf(stderr,"is Gray Image = %i\n", IsGrayImage(image));
-    fprintf(stderr,"is Monochrome Image = %i\n", IsMonochromeImage(image));
-    //fprintf(stderr,"is Opaque Image = %i\n", IsOpaqueImage(image));
-    //fprintf(stderr,"is PseudoClass = %i\n", image->storage_class == PseudoClass);
-#else    // MagickLibVersion < 0x0540
     fprintf(stderr,"is Gray Image = %i\n", IsGrayImage( image, &exception ));
     fprintf(stderr,"is Monochrome Image = %i\n", IsMonochromeImage( image, &exception ));
     //fprintf(stderr,"is Opaque Image = %i\n", IsOpaqueImage( image, &exception ));
     //fprintf(stderr,"is PseudoClass = %i\n", image->storage_class == PseudoClass);
-#endif   // MagickLibVersion < 0x0540
 
     fprintf(stderr,"image matte is %i\n", image->matte);
     fprintf(stderr,"Colorspace = %i\n", image->colorspace);


### PR DESCRIPTION
In olden times, the ImageMagick API was quite unstable and kept changing out from underneath us.  Because it had not yet made it into package management systems, most users of Xastir that needed ImageMagick at the time *also* needed to compile it themselves from source.  As a result, many of them would not want to recompile the very latest version of ImageMagick every time an API got broken, but neither would new users want to have to stick to an old version. Xastir code was therefore peppered with all manner of ifdefs to handle every old version of ImageMagick one might have installed.

The first of these ifdefs was already present in 2002 when Xastir was first imported into CVS.  New ifdefs were added in 2002, 2003, and a final set in 2018.  There have been no more new versions of ImageMagick with broken APIs since then that we can use.

ImageMagick 6 is already ancient, and Xastir can't work at all with ImageMagick 7.

Maintaining ifdefs to support 20 year old versions of ImageMagick just bloats the code and makes it unreadable.  It isn't even necessary to continue to support those that were already old in 2018.

I have removed all the ifdefs that deal with any version of ImageMagick older than the one that reports its MagickLibVersion as 0x0669.  There have been no API breakages since then, and we can safely assume now that all users of ImageMagick 6 have a version at least as new as that.

ImageMagick support in Xastir is not long for this world, since ImageMagick's focus seems to be pushing harder into HDRI, which is completely incompatible with our image usage and would require a complete rewrite of the Magick code.  GraphicsMagick, however, continues to pursue stability of API rather than cutting edge image processing, and even if ImageMagick6 disappears from every single Linux package management system, we can still work so long as GraphicsMagick exists.

GraphicsMagick is already our recommended tool and we always use it if it is found and the user hasn't explicitly requested ImageMagick. We don't even look for ImageMagick unless the user has explicitly disabled graphicsmagick *or* graphicsmagick isn't found.

There are still a few ifdefs to deal with ONE GraphicsMagick API breakage, and someday we should probably remove that, too.  But issue #25 was strictly about removing "old ImageMagick API breakage
workarounds", so that's all I'm doing here.

Addresses #25