### PR TITLE
Add detection and use of db18

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -999,7 +999,7 @@ AC_DEFUN([XASTIR_BERKELEY_DB_CHK_LIB],
 # to specify the function call with the full prototype for it to be found.
         BDB_LIB_FOUND="none"
         AC_MSG_CHECKING([for a library containing db_create])
-        for dbname in db-5.3 db5.3 db53 db-5.2 db5.2 db52 db-5.1 db5.1 db51 db-5.0 db5.0 db50 db-4.9 db4.9 db49 db-4.8 db4.8 db48 db-4.7 db4.7 db47 db-4.6 db4.6 db46 db-4.5 db4.5 db45 db-4.4 db4.4 db44 db-4.3 db4.3 db43 db-4.2 db4.2 db42 db-4.1 db4.1 db41 db-4.0 db4.0 db-4 db40 db4 db
+        for dbname in db-18.1 db-18 db-5.3 db5.3 db53 db-5.2 db5.2 db52 db-5.1 db5.1 db51 db-5.0 db5.0 db50 db-4.9 db4.9 db49 db-4.8 db4.8 db48 db-4.7 db4.7 db47 db-4.6 db4.6 db46 db-4.5 db4.5 db45 db-4.4 db4.4 db44 db-4.3 db4.3 db43 db-4.2 db4.2 db42 db-4.1 db4.1 db41 db-4.0 db4.0 db-4 db40 db4 db
           do
 	    LIBS="$saved_LIBS -l$dbname"
       AC_LINK_IFELSE(


### PR DESCRIPTION
As a very, very early attempt at addressing Xastir/Xastir#217, I have tweaked the very, very simplistic autoconf check for DB libraries to look for libdb-18.1 or libdb-18 in addition to all the libdb-5 checks we already do, placing the newer version earlier in the detection loop.

I have confirmed that libdb18 has changed absolutely nothing in the API that breaks Xastir's use, and in fact by simplyt telling my build to look for db-18 headers in /usr/local/include/db18 and libraries in /usr/local/lib, the DB18 libraries are successfully linked in and work correctly.

However this is not ideal, as if one tells Xastir to look for db5 headers and both db-18 and db-5 libraries are installed in /usr/local/lib, then Xastir uses the headers from db5 and the library from db18, with consequent failure at run time (with a warning and disabling of DB use:

***** WARNING *****
Berkeley DB header files/shared library file do NOT match! Disabling use of the map cache.
 Header file: Berkeley DB 5.3.28: (September  9, 2013)
Library file: Berkeley DB 18.1.40: (May 29, 2020)
***** WARNING *****

So the configure detection really ought to be beefed up to make sure that headers and libraries match just as the code does.  But because we only *compile* a configure check and don't run it (which is the right way to do it lest one break cross compilation), we *can't* do that check, which involves calling db_version and checking its result.

In fact, the entire reason we *have* that warning is that users have this problem all the time and this is the only way to tell them that they must fix their configure arguments.

It is entirely possible that this is the best we can do at the moment, just as it was the best we could do for other BDB version issues.

I have ONLY added checks for libdb-18.1 and libdb-18, I have not tried to add other versions in between version 5 and 18.

This at least partially addresses Xastir/Xastir#217