### PR TITLE
Add calls to make curl follow redirects

### DIFF
--- a/src/dlm.c
+++ b/src/dlm.c
@@ -523,11 +523,11 @@ static CURL *DLM_curl_init(char *errBuf)
   {
     if (debug_level & 8192)
     {
-      curl_easy_setopt(mySession, CURLOPT_VERBOSE, 1);
+      curl_easy_setopt(mySession, CURLOPT_VERBOSE, 1L);
     }
     else
     {
-      curl_easy_setopt(mySession, CURLOPT_VERBOSE, 0);
+      curl_easy_setopt(mySession, CURLOPT_VERBOSE, 0L);
     }
 
     curl_easy_setopt(mySession, CURLOPT_ERRORBUFFER, errBuf);
@@ -567,8 +567,11 @@ static CURL *DLM_curl_init(char *errBuf)
     //
     //     http://curl.haxx.se/mail/lib-2002-12/0103.html
     //
-    curl_easy_setopt(mySession, CURLOPT_NOSIGNAL, 1);
+    curl_easy_setopt(mySession, CURLOPT_NOSIGNAL, 1L);
 #endif // LIBCURL_VERSION_NUM
+
+    // Respect and follow http redirects
+    curl_easy_setopt(mySession, CURLOPT_FOLLOWLOCATION, 1L);
   }
 
   return(mySession);

--- a/src/fetch_remote.c
+++ b/src/fetch_remote.c
@@ -99,11 +99,11 @@ CURL *xastir_curl_init(char *errBuf)
   {
     if (debug_level & 8192)
     {
-      curl_easy_setopt(mySession, CURLOPT_VERBOSE, 1);
+      curl_easy_setopt(mySession, CURLOPT_VERBOSE, 1L);
     }
     else
     {
-      curl_easy_setopt(mySession, CURLOPT_VERBOSE, 0);
+      curl_easy_setopt(mySession, CURLOPT_VERBOSE, 0L);
     }
 
 
@@ -143,9 +143,11 @@ CURL *xastir_curl_init(char *errBuf)
     //
     //     http://curl.haxx.se/mail/lib-2002-12/0103.html
     //
-    curl_easy_setopt(mySession, CURLOPT_NOSIGNAL, 1);
+    curl_easy_setopt(mySession, CURLOPT_NOSIGNAL, 1L);
 #endif // LIBCURL_VERSION_NUM
 
+    // Respect and follow http redirects
+    curl_easy_setopt(mySession, CURLOPT_FOLLOWLOCATION, 1L);
   }
 
   return(mySession);


### PR DESCRIPTION
Our cURL usage did not respect and follow redirects.  Some of the OSM tiled geo files we were creating used http: URLs, but the servers that handle those now redirect to https.  The end result was that users creating a brand new install of Xastir with no existing map tile cache would have failed to get their maps downloaded, where older installs with well-populated caches would never even try to download them and not notice the problem.

A quick fix was introduced to change some URLs to https and get things working again, but the *right* fix is to make our cURL usage follow http/https redirects.

This commit does that.  A single call to `curl_easy_setopt` that adds the `CURLOPT_FOLLOWLOCATION` option, in two places (dlm.c and fetch_remote.c) is needed.  With this change, I find that the OSM_tiled_mapnik.geo map loads properly with an empty cache, whether the http or https url is used.

I should note, though I didn't do so in the actual commit log, that in addition to adding the two calls to `curl_easy_setopt`, I made a few of the existing `curl_easy_setopt` calls pass explicit long int constants, because at least on my system these were throwing warnings that the function expected a long int and we were passing int constants.
