### PR TITLE
Fix (possible) spaces in WMTS-URI

### DIFF
--- a/src/map_WMS.c
+++ b/src/map_WMS.c
@@ -356,7 +356,7 @@ void draw_WMS_map (Widget w,
 
 // This specifies a bounding box based on square pixels.
   xastir_snprintf(tmpstr, sizeof(tmpstr),
-                  "&BBOX=%8.5f,%7.5f,%8.5f,%7.5f",
+                  "&BBOX=%08.5f,%07.5f,%08.5f,%07.5f",
                   left,   // Lower left
                   bottom, // Lower left
                   right,  // Upper right


### PR DESCRIPTION
The formatting of the bounding box (`BBOX`) left spaced in the resulting URI, due to formatting with `%8.5f`, e.g., where a `5.2` will result in ` 5.20000` (mind the space in first place to gain 8 characters) and leading to cURL-errors due to malformed URIs.

This commit fixes the issue by using leading zeros (`%8.5f` --> `%08.5f`) in the format specifications.