### PR TITLE
Add GitHub Actions to test build for linux MacOS

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,4 +1,4 @@
-name: Basic Ubuntu Build
+name: Test Builds
 
 on:
   push:
@@ -7,8 +7,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build:
-
+  basic-ubuntu-build:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,6 +16,39 @@ jobs:
       run: sudo apt-get update
     - name: Install Packages
       run: sudo apt-get install -y graphicsmagick libgraphicsmagick1-dev libmotif-dev libcurl4-openssl-dev libpcre3-dev libdb-dev shapelib libshp-dev libxpm-dev
+    - name: Bootstrap
+      run: ./bootstrap.sh
+    - name: configure
+      run: ./configure CPPFLAGS="-I/usr/include/geotiff"
+    - name: make
+      run: make
+    - name: make install
+      run: sudo make install
+
+  full-ubuntu-build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Update Packages
+      run: sudo apt-get update
+    - name: Install Packages
+      run: sudo apt-get install -y graphicsmagick libgraphicsmagick1-dev libmotif-dev libcurl4-openssl-dev libpcre3-dev libdb-dev shapelib libshp-dev libxpm-dev libproj-dev festival festival-dev libgeotiff-dev gpsman gpsmanshp 
+    - name: Bootstrap
+      run: ./bootstrap.sh
+    - name: configure
+      run: ./configure CPPFLAGS="-I/usr/include/geotiff"
+    - name: make
+      run: make
+    - name: make install
+      run: sudo make install
+
+  macos-build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Packages
+      run: brew install berkeley-db graphicsmagick libgeotiff openmotif pcre proj shapelib wget
     - name: Bootstrap
       run: ./bootstrap.sh
     - name: configure

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Packages
-      run: brew install berkeley-db graphicsmagick libgeotiff openmotif pcre proj shapelib wget
+      run: brew install autoconf automake libtool berkeley-db graphicsmagick libgeotiff openmotif pcre proj shapelib wget
     - name: Bootstrap
       run: ./bootstrap.sh
     - name: configure

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Update Packages
-      run: apt-get update
+      run: sudo apt-get update
     - name: Install Packages
       run: sudo apt-get install -y imagemagick libmagickcore-dev libmotif-dev libcurl4-openssl-dev libpcre3-dev libdb-dev shapelib libshp-dev libxpm-dev
     - name: Bootstrap
@@ -24,4 +24,4 @@ jobs:
     - name: make
       run: make
     - name: make install
-      run: make install
+      run: sudo make install

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: Basic Ubuntu Build
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
     - name: Update Packages
       run: sudo apt-get update
     - name: Install Packages
-      run: sudo apt-get install -y imagemagick libmagickcore-dev libmotif-dev libcurl4-openssl-dev libpcre3-dev libdb-dev shapelib libshp-dev libxpm-dev
+      run: sudo apt-get install -y graphicsmagick libgraphicsmagick1-dev libmotif-dev libcurl4-openssl-dev libpcre3-dev libdb-dev shapelib libshp-dev libxpm-dev
     - name: Bootstrap
       run: ./bootstrap.sh
     - name: configure

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,27 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Update Packages
+      run: apt-get update
+    - name: Install Packages
+      run: sudo apt-get install -y imagemagick libmagickcore-dev libmotif-dev libcurl4-openssl-dev libpcre3-dev libdb-dev shapelib libshp-dev libxpm-dev
+    - name: Bootstrap
+      run: ./bootstrap.sh
+    - name: configure
+      run: ./configure CPPFLAGS="-I/usr/include/geotiff"
+    - name: make
+      run: make
+    - name: make install
+      run: make install

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Bootstrap
       run: ./bootstrap.sh
     - name: configure
-      run: ./configure CPPFLAGS="-I/usr/include/geotiff -I/opt/homebrew/include -I/opt/homebrew/opt/berkeley-db@4/include" "LDFLAGS=-L/opt/homebrew/lib -L/opt/homebrew/opt/berkeley-db@4/lib"
+      run: ./configure CPPFLAGS="-I/usr/include/geotiff -I/opt/homebrew/include -I/opt/homebrew/opt/berkeley-db/include" "LDFLAGS=-L/opt/homebrew/lib -L/opt/homebrew/opt/berkeley-db/lib"
     - name: make
       run: make
     - name: make install

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -47,6 +47,8 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Install XQuartz
+      run: brew install xquartz --cask
     - name: Install Packages
       run: brew install autoconf automake libtool berkeley-db graphicsmagick libgeotiff openmotif pcre proj shapelib wget
     - name: Bootstrap

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -50,11 +50,11 @@ jobs:
     - name: Install XQuartz
       run: brew install xquartz --cask
     - name: Install Packages
-      run: brew install autoconf automake libtool berkeley-db graphicsmagick libgeotiff openmotif pcre proj shapelib wget
+      run: brew install autoconf automake libtool berkeley-db graphicsmagick libgeotiff openmotif pcre proj shapelib
     - name: Bootstrap
       run: ./bootstrap.sh
     - name: configure
-      run: ./configure CPPFLAGS="-I/usr/include/geotiff"
+      run: ./configure CPPFLAGS="-I/usr/include/geotiff -I/opt/homebrew/include -I/opt/homebrew/opt/berkeley-db@4/include" "LDFLAGS=-L/opt/homebrew/lib -L/opt/homebrew/opt/berkeley-db@4/lib"
     - name: make
       run: make
     - name: make install

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -34,8 +34,8 @@ jobs:
       run: sudo apt-get update
     - name: Install Packages
       run: sudo apt-get install -y graphicsmagick libgraphicsmagick1-dev libmotif-dev libcurl4-openssl-dev libpcre3-dev libdb-dev shapelib libshp-dev libxpm-dev libproj-dev festival festival-dev libgeotiff-dev gpsman gpsmanshp 
-    - name: Bootstrap
-      run: ./bootstrap.sh
+    - name: Bootstrap (with autoreconf)
+      run: autoreconf -i
     - name: configure
       run: ./configure CPPFLAGS="-I/usr/include/geotiff"
     - name: make


### PR DESCRIPTION
Use GitHub actions to do a test build on ubuntu (both a smaller scale and full-featured version, minus kernel AX25) and on macOS. 