### PR TITLE
Overlay chars 0 to 9 are encoded a to j #239

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -2157,7 +2157,7 @@ char *compress_posit(const char *input_lat, const char group, const char *input_
   xastir_snprintf(pos,
                   sizeof(pos),
                   "%c%s%s%c%c%c%c",
-                  group,
+                  group >= '0' && group <= '9' ? group - '0' + 'a' : group,
                   lat,
                   lon,
                   symbol,


### PR DESCRIPTION
This is a quick fix for #239 