### PR TITLE
Get compressed posit overlays working right

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2427,7 +2427,7 @@ APRS_Symbol *id_callsign(char *call_sign, char * to_call)
         if (hold[2] >= 'a' && hold[2] <= 'j')
         {
           // Compressed mode numeric overlay
-          symbol.special_overlay = hold[2] - 'a';
+          symbol.special_overlay = hold[2] - 'a' + '0';
         }
         else if ( (hold[2] >= '0' && hold[2] <= '9')
                   || (hold[2] >= 'A' && hold[2] <= 'Z') )
@@ -11796,8 +11796,8 @@ void my_station_add(char *my_callsign, char my_group, char my_symbol, char *my_l
     }
     else
     {
-      // Found a bad overlay character
-      p_station->aprs_symbol.aprs_type = my_group;
+      // Found a bad overlay character, just use normal alternate character
+      p_station->aprs_symbol.aprs_type = '\\';
       p_station->aprs_symbol.special_overlay = '\0';
     }
   }

--- a/src/objects.c
+++ b/src/objects.c
@@ -621,13 +621,6 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
         char temp_group = object_group;
         long x_long, y_lat;
 
-        // If we have a numeric overlay, we need to convert
-        // it to 'a-j' for compressed objects.
-        if (temp_group >= '0' && temp_group <= '9')
-        {
-          temp_group = temp_group + 'a';
-        }
-
         if (speed == 0)
         {
           x_long = p_station->coord_lon;
@@ -692,13 +685,6 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
       {
         char temp_group = object_group;
         long x_long, y_lat;
-
-        // If we have a numeric overlay, we need to convert
-        // it to 'a-j' for compressed objects.
-        if (temp_group >= '0' && temp_group <= '9')
-        {
-          temp_group = temp_group + 'a';
-        }
 
         if (speed == 0)
         {
@@ -778,13 +764,6 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
         char temp_group = object_group;
         long x_long, y_lat;
 
-        // If we have a numeric overlay, we need to convert
-        // it to 'a-j' for compressed objects.
-        if (temp_group >= '0' && temp_group <= '9')
-        {
-          temp_group = temp_group + 'a';
-        }
-
         if (speed == 0)
         {
           x_long = p_station->coord_lon;
@@ -839,13 +818,6 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
       {
         char temp_group = object_group;
         long x_long, y_lat;
-
-        // If we have a numeric overlay, we need to convert
-        // it to 'a-j' for compressed objects.
-        if (temp_group >= '0' && temp_group <= '9')
-        {
-          temp_group = temp_group + 'a';
-        }
 
         if (speed == 0)
         {
@@ -905,13 +877,6 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
         char temp_group = object_group;
         long x_long, y_lat;
 
-        // If we have a numeric overlay, we need to convert
-        // it to 'a-j' for compressed objects.
-        if (temp_group >= '0' && temp_group <= '9')
-        {
-          temp_group = temp_group + 'a';
-        }
-
         if (speed == 0)
         {
           x_long = p_station->coord_lon;
@@ -967,13 +932,6 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
       {
         char temp_group = object_group;
         long x_long, y_lat;
-
-        // If we have a numeric overlay, we need to convert
-        // it to 'a-j' for compressed objects.
-        if (temp_group >= '0' && temp_group <= '9')
-        {
-          temp_group = temp_group + 'a';
-        }
 
         if (speed == 0)
         {
@@ -1044,13 +1002,6 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
         char temp_group = object_group;
         long x_long, y_lat;
 
-        // If we have a numeric overlay, we need to convert
-        // it to 'a-j' for compressed objects.
-        if (temp_group >= '0' && temp_group <= '9')
-        {
-          temp_group = temp_group + 'a';
-        }
-
         if (speed == 0)
         {
           x_long = p_station->coord_lon;
@@ -1107,13 +1058,6 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
       {
         char temp_group = object_group;
         long x_long, y_lat;
-
-        // If we have a numeric overlay, we need to convert
-        // it to 'a-j' for compressed objects.
-        if (temp_group >= '0' && temp_group <= '9')
-        {
-          temp_group = temp_group + 'a';
-        }
 
         if (speed == 0)
         {
@@ -1175,13 +1119,6 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
         char temp_group = object_group;
         long x_long, y_lat;
 
-        // If we have a numeric overlay, we need to convert
-        // it to 'a-j' for compressed objects.
-        if (temp_group >= '0' && temp_group <= '9')
-        {
-          temp_group = temp_group + 'a';
-        }
-
         if (speed == 0)
         {
           x_long = p_station->coord_lon;
@@ -1233,13 +1170,6 @@ int Create_object_item_tx_string(DataRow *p_station, char *line, int line_length
       {
         char temp_group = object_group;
         long x_long, y_lat;
-
-        // If we have a numeric overlay, we need to convert
-        // it to 'a-j' for compressed objects.
-        if (temp_group >= '0' && temp_group <= '9')
-        {
-          temp_group = temp_group + 'a';
-        }
 
         if (speed == 0)
         {
@@ -4979,13 +4909,6 @@ int Setup_object_data(char *line, int line_length, DataRow *p_station)
 // necessary.
 
 
-      // Need to handle the conversion of numeric overlay
-      // chars to "a-j" here.
-      if (last_obj_overlay >= '0' && last_obj_overlay <= '9')
-      {
-        temp_overlay = last_obj_overlay + 'a';
-      }
-
       xastir_snprintf(line, line_length, ";%-9s*%s%s%1d%02d%2s%02d%s%s%s",
                       last_object,
                       time,
@@ -5079,13 +5002,6 @@ int Setup_object_data(char *line, int line_length, DataRow *p_station)
 // necessary.
 
 
-      // Need to handle the conversion of numeric overlay
-      // chars to "a-j" here.
-      if (last_obj_overlay >= '0' && last_obj_overlay <= '9')
-      {
-        temp_overlay = last_obj_overlay + 'a';
-      }
-
       xastir_snprintf(line, line_length, ";%-9s*%s%s%s%s",
                       last_object,
                       time,
@@ -5146,13 +5062,6 @@ int Setup_object_data(char *line, int line_length, DataRow *p_station)
 // whether to add altitude as an uncompressed extension if
 // necessary.
 
-
-        // Need to handle the conversion of numeric overlay
-        // chars to "a-j" here.
-        if (last_obj_overlay >= '0' && last_obj_overlay <= '9')
-        {
-          temp_overlay = last_obj_overlay + 'a';
-        }
 
         xastir_snprintf(line, line_length, ";%-9s*%s%sDFS%s/%s%s",
                         last_object,
@@ -5226,13 +5135,6 @@ int Setup_object_data(char *line, int line_length, DataRow *p_station)
 // whether to add altitude as an uncompressed extension if
 // necessary.
 
-
-        // Need to handle the conversion of numeric overlay
-        // chars to "a-j" here.
-        if (last_obj_overlay >= '0' && last_obj_overlay <= '9')
-        {
-          temp_overlay = last_obj_overlay + 'a';
-        }
 
         xastir_snprintf(line, line_length, ";%-9s*%s%s/%03i/%s%s",
                         last_object,
@@ -5323,13 +5225,6 @@ int Setup_object_data(char *line, int line_length, DataRow *p_station)
 // whether to add altitude as an uncompressed extension if
 // necessary.
 
-
-      // Need to handle the conversion of numeric overlay
-      // chars to "a-j" here.
-      if (last_obj_overlay >= '0' && last_obj_overlay <= '9')
-      {
-        temp_overlay = last_obj_overlay + 'a';
-      }
 
       xastir_snprintf(line,
                       line_length,
@@ -5873,13 +5768,6 @@ int Setup_item_data(char *line, int line_length, DataRow *p_station)
 // necessary.
 
 
-      // Need to handle the conversion of numeric overlay
-      // chars to "a-j" here.
-      if (last_obj_overlay >= '0' && last_obj_overlay <= '9')
-      {
-        temp_overlay = last_obj_overlay + 'a';
-      }
-
       xastir_snprintf(line, line_length, ")%s!%s%1d%02d%2s%02d%s%s%s",
                       last_object,
                       compress_posit(ext_lat_str,
@@ -5968,13 +5856,6 @@ int Setup_item_data(char *line, int line_length, DataRow *p_station)
 // necessary.
 
 
-      // Need to handle the conversion of numeric overlay
-      // chars to "a-j" here.
-      if (last_obj_overlay >= '0' && last_obj_overlay <= '9')
-      {
-        temp_overlay = last_obj_overlay + 'a';
-      }
-
       xastir_snprintf(line, line_length, ")%s!%s%s%s",
                       last_object,
                       compress_posit(ext_lat_str,
@@ -6033,13 +5914,6 @@ int Setup_item_data(char *line, int line_length, DataRow *p_station)
 // whether to add altitude as an uncompressed extension if
 // necessary.
 
-
-        // Need to handle the conversion of numeric overlay
-        // chars to "a-j" here.
-        if (last_obj_overlay >= '0' && last_obj_overlay <= '9')
-        {
-          temp_overlay = last_obj_overlay + 'a';
-        }
 
         xastir_snprintf(line, line_length, ")%s!%sDFS%s/%s%s",
                         last_object,
@@ -6112,13 +5986,6 @@ int Setup_item_data(char *line, int line_length, DataRow *p_station)
 // whether to add altitude as an uncompressed extension if
 // necessary.
 
-
-        // Need to handle the conversion of numeric overlay
-        // chars to "a-j" here.
-        if (last_obj_overlay >= '0' && last_obj_overlay <= '9')
-        {
-          temp_overlay = last_obj_overlay + 'a';
-        }
 
         xastir_snprintf(line, line_length, ")%s!%s/%03i/%s%s",
                         last_object,
@@ -6209,13 +6076,6 @@ int Setup_item_data(char *line, int line_length, DataRow *p_station)
 // whether to add altitude as an uncompressed extension if
 // necessary.
 
-
-      // Need to handle the conversion of numeric overlay
-      // chars to "a-j" here.
-      if (last_obj_overlay >= '0' && last_obj_overlay <= '9')
-      {
-        temp_overlay = last_obj_overlay + 'a';
-      }
 
       xastir_snprintf(line,
                       line_length,

--- a/src/util.c
+++ b/src/util.c
@@ -2157,7 +2157,7 @@ char *compress_posit(const char *input_lat, const char group, const char *input_
   xastir_snprintf(pos,
                   sizeof(pos),
                   "%c%s%s%c%c%c%c",
-                  group,
+                  compress_group(group),
                   lat,
                   lon,
                   symbol,
@@ -2170,8 +2170,15 @@ char *compress_posit(const char *input_lat, const char group, const char *input_
 }
 
 
-
-
+char compress_group(char group_in)
+{
+  char group_out=group_in;
+  if (group_in >= '0' && group_in <= '9')
+  {
+    group_out=group_in - '0' + 'a';
+  }
+  return (group_out);
+}
 
 /*
  * See if position is defined

--- a/src/util.h
+++ b/src/util.h
@@ -100,7 +100,7 @@ extern char *get_line(FILE *f, char *linedata, int maxline);
 extern time_t time_from_aprsstring(char *timestamp);
 extern char *compress_posit(const char *lat, const char group, const char *lon, const char symbol,
                             const unsigned int course, const unsigned int speed, const char *phg);
-
+extern char compress_group(char group_in);
 extern int  position_defined(long lat, long lon, int strict);
 extern void convert_screen_to_xastir_coordinates(int x, int y, long *lat, long *lon);
 extern void convert_xastir_to_UTM_str(char *str, int str_len, long x, long y);


### PR DESCRIPTION
Compressed posits with numeric overlays should have their overlay characters sent as the letters a through j instead of the digits 0-9, per the APRS spec.

An attempt was being made to do this in a lot of special cases, mostly objects, but the code that did it was duplicated over 20 times in objects.c, and it was done incorrectly.

No attempt was made to do the same thing to regular station posits when compressed.

This commit removes all of the duplicated attempts to fix the overlay character being sent, all of which took place right before a call to compress_posit.  It places the code that does the fixing up into a new utility function "compress_group", which is then called inside compress_posit at the time the compressed posit string is constructed.

There was also broken code in db.c that sometimes incorrectly decoded compressed overlay characters (but only in the very ancient "NMEA Data" posit format).

Prior to this commit, Xastir would send station posits in compressed format without the correct digit-to-alphabetic conversion, which could not be decoded by any compliant APRS client.

Further, prior to this commit, attempts to send compressed object/item data with numeric overlays would cause Xastir to transmit invalid characters outside the normal printable ASCII range.

After this commit, station posits with numeric overlays are transmitted with the correct alphabetic overlay character and are correctly decoded by Xastir.

After this commit, all formats of objects or items that allow the user to select a symbol transmit correctly in compressed format and can be decoded properly.  While Xastir had code peppered throughout objects.c that supposedly handled overlay characters, only regular objects and probability circles actually allow you to change the symbol through the GUI, and so these are the only ones I was able to test.  They all worked.

If one wanted to verify that this commit works (since the code involved is not unit testable in its current state), one needs to enable both "transmit compressed posits" in the
File->Configure->Station dialog and the "transmit compressed objects/items" in the File->Configure->Defaults dialog, then set the station symbol to one in the alternate symbol table, and change the '\\' to a digit.  Upon transmit one should see the correct symbol with overlay in the map display.

Similarly, to test that all is well with objects, one needs to create an assortment of object types, all with alternate symbol table symbols and numeric overlays.

Closes #239