### PR TITLE
Quad overlay flag removal

### DIFF
--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -2950,9 +2950,6 @@ void draw_shapefile_map (Widget w,
                 }
 
                 (void)XSetForeground(XtDisplay(w), gc, colors[color]); // border color
-
-                // Draw a thicker border for city boundaries
-                (void)XSetForeground(XtDisplay(w), gc, colors[color]); // border
                 (void)XSetFillStyle(XtDisplay(w), gc, FillSolid);
 
                 (void)XDrawLines(XtDisplay(w),


### PR DESCRIPTION
Remove vestiges of old hard-coded handling of rendering for the old "24kgrid.shp" shapefile of USGS quad outlines.

These should have been removed in commit 3a9b6e1, but that commit was the result of a use of the "unifdef" utility that stripped out code inside an ifdef, and neglected to remove code that wasn't ifdeffed and just wouldn't get executed once the ifdef was removed.  The blocks removed here are all conditionals that will never have their condition met because the code that set `quad_overlay_flag` to anything but zero was inside the ifdefs that got removed.

Anyhow, this cleans up `draw_shapefile_map` a little and completes work that should have been done in #128.

Closes #271 