### PR TITLE
Extract code for shortened filename

### DIFF
--- a/src/map_OSM.c
+++ b/src/map_OSM.c
@@ -1158,26 +1158,8 @@ void draw_OSM_tiles (Widget w,
     serverURL[strlen(serverURL) - 1] = '\0';
   }
 
-  // Create a shorter filename for display (one that fits the
-  // status line more closely).  Allow space for the
-  // "Indexing " or "Loading " strings.
-  if (strlen(filenm) > (41 - 9))
-  {
-    int avail = 41 - 11;
-    int new_len = strlen(filenm) - avail;
-
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "..%s",
-                    &filenm[new_len]);
-  }
-  else
-  {
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "%s",
-                    filenm);
-  }
+  // Create a shorter filename for display
+  short_filename_for_status(filenm, short_filenm, sizeof(short_filenm));
 
   GetExceptionInfo(&exception);
 
@@ -1515,26 +1497,8 @@ void draw_OSM_map (Widget w,
   // initialize this
   local_filename[0]='\0';
 
-  // Create a shorter filename for display (one that fits the
-  // status line more closely).  Subtract the length of the
-  // "Indexing " and/or "Loading " strings as well.
-  if (strlen(filenm) > (41 - 9))
-  {
-    int avail = 41 - 11;
-    int new_len = strlen(filenm) - avail;
-
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "..%s",
-                    &filenm[new_len]);
-  }
-  else
-  {
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "%s",
-                    filenm);
-  }
+  // Create a shorter filename for display
+  short_filename_for_status(filenm, short_filenm, sizeof(short_filenm));
 
   xastir_snprintf(map_it,
                   sizeof(map_it),

--- a/src/map_WMS.c
+++ b/src/map_WMS.c
@@ -220,26 +220,8 @@ void draw_WMS_map (Widget w,
     }
   }
 
-  // Create a shorter filename for display (one that fits the
-  // status line more closely).  Subtract the length of the
-  // "Indexing " and/or "Loading " strings as well.
-  if (strlen(filenm) > (41 - 9))
-  {
-    int avail = 41 - 11;
-    int new_len = strlen(filenm) - avail;
-
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "..%s",
-                    &filenm[new_len]);
-  }
-  else
-  {
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "%s",
-                    filenm);
-  }
+  // Create a shorter filename for display
+  short_filename_for_status(filenm, short_filenm, sizeof(short_filenm));
 
   xastir_snprintf(map_it,
                   sizeof(map_it),

--- a/src/map_dos.c
+++ b/src/map_dos.c
@@ -474,26 +474,8 @@ void draw_dos_map(Widget w,
 
   xastir_snprintf(file, sizeof(file), "%s/%s", dir, filenm);
 
-  // Create a shorter filename for display (one that fits the
-  // status line more closely).  Subtract the length of the
-  // "Indexing " and/or "Loading " strings as well.
-  if (strlen(filenm) > (41 - 9))
-  {
-    int avail = 41 - 11;
-    int new_len = strlen(filenm) - avail;
-
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "..%s",
-                    &filenm[new_len]);
-  }
-  else
-  {
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "%s",
-                    filenm);
-  }
+  // Create a shorter filename for display
+  short_filename_for_status(filenm, short_filenm, sizeof(short_filenm));
 
   f = fopen (file, "r");
   if (f == NULL)

--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -334,29 +334,9 @@ void draw_toporama_map (Widget w,
   float my_zoom = 1.0;
   char temp_file_path[MAX_VALUE];
 
-  // Create a shorter filename for display (one that fits the
-  // status line more closely).  Subtract the length of the
-  // "Indexing " and/or "Loading " strings as well.
-  if (strlen(filenm) > (41 - 9))
-  {
-    int avail = 41 - 11;
-    int new_len = strlen(filenm) - avail;
-
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "..%s",
-                    &filenm[new_len]);
-  }
-  else
-  {
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "%s",
-                    filenm);
-  }
-
-
-  //fprintf(stderr, "Found TOPORAMA in a .geo file, %dk scale\n", toporama_flag);
+  // Create a shorter filename for display
+  short_filename_for_status(filenm, short_filenm, sizeof(short_filenm));
+;
 
   // Check whether we're indexing or drawing the map
   if ( (destination_pixmap == INDEX_CHECK_TIMESTAMPS)
@@ -718,27 +698,8 @@ void draw_geo_image_map (Widget w,
 
   xastir_snprintf(file, sizeof(file), "%s/%s", dir, filenm);
 
-  // Create a shorter filename for display (one that fits the
-  // status line more closely).  Subtract the length of the
-  // "Indexing " and/or "Loading " strings as well.
-  if (strlen(filenm) > (41 - 9))
-  {
-    int avail = 41 - 11;
-    int new_len = strlen(filenm) - avail;
-
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "..%s",
-                    &filenm[new_len]);
-  }
-  else
-  {
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "%s",
-                    filenm);
-  }
-
+  // Create a shorter filename for display
+  short_filename_for_status(filenm, short_filenm, sizeof(short_filenm));
 
   // Read the .geo file to find out map filename and tiepoint info
 

--- a/src/map_gnis.c
+++ b/src/map_gnis.c
@@ -139,26 +139,8 @@ void draw_gnis_map (Widget w,
 
   xastir_snprintf(file, sizeof(file), "%s/%s", dir, filenm);
 
-  // Create a shorter filename for display (one that fits the
-  // status line more closely).  Subtract the length of the
-  // "Indexing " and/or "Loading " strings as well.
-  if (strlen(filenm) > (41 - 9))
-  {
-    int avail = 41 - 11;
-    int new_len = strlen(filenm) - avail;
-
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "..%s",
-                    &filenm[new_len]);
-  }
-  else
-  {
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "%s",
-                    filenm);
-  }
+  // Create a shorter filename for display
+  short_filename_for_status(filenm, short_filenm, sizeof(short_filenm));
 
   // Screen view
   min_lat = SE_corner_latitude;

--- a/src/map_pop.c
+++ b/src/map_pop.c
@@ -143,26 +143,8 @@ void draw_pop_map (Widget w,
 
   xastir_snprintf(file, sizeof(file), "%s/%s", dir, filenm);
 
-  // Create a shorter filename for display (one that fits the
-  // status line more closely).  Subtract the length of the
-  // "Indexing " and/or "Loading " strings as well.
-  if (strlen(filenm) > (41 - 9))
-  {
-    int avail = 41 - 11;
-    int new_len = strlen(filenm) - avail;
-
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "..%s",
-                    &filenm[new_len]);
-  }
-  else
-  {
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "%s",
-                    filenm);
-  }
+  // Create a shorter filename for display
+  short_filename_for_status(filenm, short_filenm, sizeof(short_filenm));
 
   // Screen view
   min_lat = SE_corner_latitude;

--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -717,28 +717,8 @@ void draw_shapefile_map (Widget w,
 
   xastir_snprintf(file, sizeof(file), "%s/%s", dir, filenm);
 
-  // Create a shorter filename for display (one that fits the
-  // status line more closely).  Subtract the length of the
-  // "Indexing " and/or "Loading " strings as well.
-  if (strlen(filenm) > (41 - 9))
-  {
-    int avail = 41 - 11;
-    int new_len = strlen(filenm) - avail;
-
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "..%s",
-                    &filenm[new_len]);
-  }
-  else
-  {
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "%s",
-                    filenm);
-  }
-
-  //fprintf(stderr,"draw_shapefile_map:start:%s\n",file);
+  // Create a shorter filename for display
+  short_filename_for_status(filenm, short_filenm, sizeof(short_filenm));
 
   filename = filenm;
   i = strlen(filenm);
@@ -746,7 +726,6 @@ void draw_shapefile_map (Widget w,
   {
     filename = &filenm[i--];
   }
-  //fprintf(stderr,"draw_shapefile_map:filename:%s\ttitle:%s\n",filename,alert->title);
 
   if (alert)
   {
@@ -755,7 +734,6 @@ void draw_shapefile_map (Widget w,
 
   // Check for ~/.xastir/tracklogs directory.  We set up the
   // labels and colors differently for these types of files.
-//    if (strstr(filenm,".xastir/tracklogs")) { // We're in the ~/.xastir/tracklogs directory
   if (strstr(filenm,"GPS"))   // We're in the maps/GPS directory
   {
     gps_flag++;

--- a/src/map_tif.c
+++ b/src/map_tif.c
@@ -547,26 +547,8 @@ void draw_geotiff_image_map (Widget w,
 
   xastir_snprintf(file, sizeof(file), "%s/%s", dir, filenm);
 
-  // Create a shorter filename for display (one that fits the
-  // status line more closely).  Subtract the length of the
-  // "Indexing " and/or "Loading " strings as well.
-  if (strlen(filenm) > (41 - 9))
-  {
-    int avail = 41 - 11;
-    int new_len = strlen(filenm) - avail;
-
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "..%s",
-                    &filenm[new_len]);
-  }
-  else
-  {
-    xastir_snprintf(short_filenm,
-                    sizeof(short_filenm),
-                    "%s",
-                    filenm);
-  }
+  // Create a shorter filename for display
+  short_filename_for_status(filenm, short_filenm, sizeof(short_filenm));
 
   /* Check whether we have an associated *.fgd file.  This
    * file contains the neat-line corner points for USGS DRG

--- a/src/util.c
+++ b/src/util.c
@@ -4600,3 +4600,33 @@ char * makeMultiline(int numPairs, double *lon, double *lat, char colorStyle,
 }
 
 
+// This function is used by the map drawing functions to set a shorter
+// filename for use in the status line display.  If the file name is short
+// enough, just set the "short" filename to be a copy of the full name.
+// If it's too long, use only the final characters and preface with ".."
+//
+// The intent is that "Indexing " or "Loading " will appear before it,
+// so we leave enough space for that and the short filename in the status
+// line.
+
+void short_filename_for_status(char *filename, char *short_filename,
+                               size_t short_filename_size)
+{
+  if (strlen(filename) > (41 - 9))
+  {
+    int avail = 41 - 11;
+    int new_len = strlen(filename) - avail;
+
+    xastir_snprintf(short_filename,
+                    short_filename_size,
+                    "..%s",
+                    &filename[new_len]);
+  }
+  else
+  {
+    xastir_snprintf(short_filename,
+                    short_filename_size,
+                    "%s",
+                    filename);
+  }
+}

--- a/src/util.h
+++ b/src/util.h
@@ -154,6 +154,8 @@ char * makeMultiline(int numPairs, double *lon, double *lat, char colorStyle,
                      int lineType, char* sqnc,
                      double *lonCentr, double *latCentr );
 
+void short_filename_for_status(char *filename, char *short_filename, size_t short_filename_size);
+
 #endif // __XASTIR_UTIL_H
 
 

--- a/tests/test_util.c
+++ b/tests/test_util.c
@@ -366,6 +366,27 @@ int test_convert_xastir_to_screen_coordinates(void)
   TEST_PASS("convert_xastir_to_screen_coordinates: works as expected");
 }
 
+int test_short_filename_for_status_notrunc(void)
+{
+  char filename[MAX_FILENAME]="this_is_short.shp";
+  char short_filename[MAX_FILENAME];
+
+  short_filename_for_status(filename, short_filename, sizeof(short_filename));
+
+  TEST_ASSERT_STR_EQ("this_is_short.shp", short_filename, "Name not truncated if already short enough");
+  TEST_PASS("short_filename_for_status");
+}
+int test_short_filename_for_status_trunc(void)
+{
+  char filename[MAX_FILENAME]="/a/long/path/with/lots/of/components/basename.shp";
+  char short_filename[MAX_FILENAME];
+
+  short_filename_for_status(filename, short_filename, sizeof(short_filename));
+
+  TEST_ASSERT_STR_EQ("..ots/of/components/basename.shp", short_filename, "Name truncated if long");
+  TEST_PASS("short_filename_for_status");
+}
+
 /* Test runner */
 typedef struct {
     const char *name;
@@ -389,6 +410,8 @@ int main(int argc, char *argv[])
     {"l2s_s2l_consistency",test_l2s_s2l_consistency},
     {"convert_screen_to_xastir_coordinates", test_convert_screen_to_xastir_coordinates},
     {"convert_xastir_to_screen_coordinates", test_convert_xastir_to_screen_coordinates},
+    {"short_filename_for_status_notrunc",test_short_filename_for_status_notrunc},
+    {"short_filename_for_status_trunc",test_short_filename_for_status_trunc},
     {NULL,NULL}
   };
 

--- a/tests/util_tests.at
+++ b/tests/util_tests.at
@@ -91,3 +91,16 @@ AT_KEYWORDS([util convert_screen_to_xastir_coordinates])
 AT_CHECK(["$abs_top_builddir/tests/test_util" convert_xastir_to_screen_coordinates], [0], [PASS: convert_xastir_to_screen_coordinates: works as expected
 ])
 AT_CLEANUP
+
+AT_BANNER([tests of filename shortener for status line])
+AT_SETUP([short_filename_for_status: short name not truncated])
+AT_KEYWORDS([util short_filename_for_status])
+AT_CHECK(["$abs_top_builddir/tests/test_util" short_filename_for_status_notrunc], [0], [PASS: short_filename_for_status
+])
+AT_CLEANUP
+
+AT_SETUP([short_filename_for_status: long name truncated])
+AT_KEYWORDS([util short_filename_for_status])
+AT_CHECK(["$abs_top_builddir/tests/test_util" short_filename_for_status_trunc], [0], [PASS: short_filename_for_status
+])
+AT_CLEANUP


### PR DESCRIPTION
All of the map types do a little dance to get a shortened filename to use in the status line.  If the map file name is too long, it's truncated on the left and ".." is prepended.

All of these files had cut/pasted code to do exactly the same thing. Some files even had the code cut and pasted twice, complete with the full four line comment.

This commit refactors that code into a single function in util.c, and replaces all instances of that duplicated code with a function call.

There are also two unit tests of the function, to assure it doesn't truncate a short filename and does truncate a long one correctly.

Closes #275