### PR TITLE
Extract code for wx alert handling from draw_shapefile_map

### DIFF
--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -916,7 +916,7 @@ void draw_shapefile_map (Widget w,
                                    adfBndsMax[0]))
   {
     // we keep a hash of all shapefiles encountered so far (and not purged
-    // due to inactivity.  Find the record of this shapefile in that
+    // due to inactivity).  Find the record of this shapefile in that
     // hash if it's there.
     si = get_shp_from_hash(file);
     if (!si)


### PR DESCRIPTION
As it turns out, the code for wx alert handling in `draw_shapefile_map` is actually pretty simple and straightforward, but that simplicity was a bit obscured by the code structure.

This PR pulls out several of the large blocks of code that handle wx alert processing into helper functions and then calls them.  I find this renders the code more readable, which will simplify my work on #268  and #274.

No unit tests here, because map_shp.c is not anywhere near to being in a state where its components can be unit tested, and some of these functions depend on larger chunks of the full Xastir code base than other things we've set up under unit testing.

Tested extensively by running Xastir while weather alerts are coming in through my internet feed and making sure that nothing changes and everything displays correctly.

Closes #278 
