### PR TITLE
Clean up and refactor SHPT_ARC portion of draw_shapefile_map

### DIFF
--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -1462,11 +1462,7 @@ void draw_shapefile_map (Widget w,
           }
 
 
-// Figure out and draw the labels for PolyLines.  Note that we later
-// determine whether we want to draw the label at all.  Move all
-// code possible below that decision point to keep everything fast.
-// Don't do unnecessary calculations if we're not going to draw the
-// label.
+          // Figure out and draw the labels for SHPT_ARC
 
           temp = (gps_flag)?gps_label:name;
           if ( (temp != NULL)
@@ -1484,14 +1480,12 @@ void draw_shapefile_map (Widget w,
               int new_label = 1;
               int mod_number;
 
-              // Set up the mod_number, which is used
-              // below to determine how many of each
-              // identical label are skipped at each
-              // zoom level.
+              // Set up the mod_number, which is used below to
+              // determine how many of each identical label are
+              // skipped at each zoom level.
               mod_number = select_arc_label_mod();
 
-              // Check whether we've written out this string
-              // already.
+              // Check whether we've written out this string already.
 
               // The problem with this method is that we might get
               // strings "written" at the extreme top or right edge of


### PR DESCRIPTION
This commit simply rips out pieces of the SHPT_ARC/SHPT_ARCZ case of the big switch statement in draw_shapefile_map (#274) and puts the pieces into small functions that are just called.  In some cases I've removed comments, but mostly I've migrated them to the function rather than keeping them inlined in draw_shapefile_map where they make the code less readable.

I believe that this section of the case statement is clean enough to make an easy job of another issue, that of improper rendering of SHPT_ARC objects that have more than one part (#154).

Closes #282