### PR TITLE
Add a new polygon label location selection method

### DIFF
--- a/src/map_shp_fwd.h
+++ b/src/map_shp_fwd.h
@@ -41,7 +41,10 @@ awk_symtab *initialize_dbfawk_symbol_table(char *dbffields, size_t dbffields_s,
                                            int *pattern, int *display_level,
                                            int *label_level,
                                            int *label_color,
-                                           int *font_size);
+                                           int *font_size,
+                                           int *label_method,
+                                           double *label_lon,
+                                           double *label_lat);
 int find_wx_alert_shape(alert_entry *alert, DBFHandle hDBF, int recordcount,
                         dbfawk_sig_info *sig_info, dbfawk_field_info *fld_info);
 void getViewportRect(struct Rect *viewportRect);

--- a/src/testdbfawk.c
+++ b/src/testdbfawk.c
@@ -153,6 +153,10 @@ int main(int argc, char *argv[])
   int fill_stipple;
   int label_color = 8;
   int font_size = 0;
+  int label_method = 0;
+  double label_lon = 0.0;
+  double label_lat = 0.0;
+
   char *dir = NULL,*file = NULL,*dfile = NULL;
   dbfawk_sig_info *si = NULL, *sigs = NULL;
 
@@ -213,6 +217,9 @@ int main(int argc, char *argv[])
   awk_declare_sym(symtbl,"label_level",INT,&label_level,sizeof(label_level));
   awk_declare_sym(symtbl,"label_color",INT,&label_color,sizeof(label_color));
   awk_declare_sym(symtbl,"font_size",INT,&font_size,sizeof(font_size));
+  awk_declare_sym(symtbl,"label_method",INT,&label_method,sizeof(label_method));
+  awk_declare_sym(symtbl,"label_lon",FLOAT,&label_lon,sizeof(label_lon));
+  awk_declare_sym(symtbl,"label_lat",FLOAT,&label_lat,sizeof(label_lat));
 
   if (dfile)          /* parse dbf file */
   {
@@ -275,8 +282,11 @@ int main(int argc, char *argv[])
       fprintf(stderr,"pattern=%d, ",pattern);
       fprintf(stderr,"display_level=%d, ",display_level);
       fprintf(stderr,"font_size=%d, ", font_size);
-      fprintf(stderr,"label_level=%d\n",label_level);
-      fprintf(stderr,"label_color=%d\n",label_color);
+      fprintf(stderr,"label_level=%d, ",label_level);
+      fprintf(stderr,"label_color=%d, ",label_color);
+      fprintf(stderr,"label_method=%d, ",label_method);
+      fprintf(stderr,"label_lon=%lf, ",label_lon);
+      fprintf(stderr,"label_lat=%lf\n",label_lat);
       //    print_symtbl(symtbl);
     }
     DBFClose(dbf);


### PR DESCRIPTION
This commit adds three new dbfawk variables:
  - label_method
  - label_lon
  - label_lat

If label_method is set in the dbfawk file to 1 and a shape has set label_lon and label_lat to something nonzero, Xastir will now use label_lat and label_lon as the point at which to draw a polygon's label.

If label_method is anything other than 1, or if  (lat,lon) is exactly (0.0,0.0) , we use the label location selection method we've always used, the center of the shape's bounding box as stored in the shapefile object.

Closes #291.