### PR TITLE
Replace hard-coded screen coordinates limits

### DIFF
--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -2667,7 +2667,7 @@ GC get_hole_clipping_context(Widget w, SHPObject *object,
   {
     // Here we check for really wacko points that will cause problems
     // with the X drawing routines, and fix them.
-    (void) clip_x_y_pair(&x, &y, 0l, 1700l, 0l, 1700l);
+    (void) clip_x_y_pair(&x, &y, 0l, screen_width, 0l, screen_height);
   }
 
   // Convert point to screen coordinates
@@ -2677,7 +2677,7 @@ GC get_hole_clipping_context(Widget w, SHPObject *object,
   {
     // Here we check for really wacko points that will cause problems
     // with the X drawing routines, and fix them.
-    (void) clip_x_y_pair(&width, &height, 1l, 1700l, 1l, 1700l);
+    (void) clip_x_y_pair(&width, &height, 1l, screen_width, 1l, screen_height);
   }
 
   //TODO
@@ -2754,7 +2754,7 @@ GC get_hole_clipping_context(Widget w, SHPObject *object,
           // cause problems with the X drawing routines, and
           // fix them.  Increment on_screen if any of the
           // points might be on screen.
-          on_screen += clip_x_y_pair(&x, &y, 0l, 1700l, 0l, 1700l);
+          on_screen += clip_x_y_pair(&x, &y, 0l, screen_width, 0l, screen_height);
 
           points[i].x = l16(x);
           points[i].y = l16(y);


### PR DESCRIPTION
draw_shapefile_map has, for a long time, had code that used hard-coded values of "1700l" to declare points in a shapefile as having "wacko" screen coordinates --- bigger than 1700l, they got reset to 1700l.

But the thing this code was trying to do was to make sure that coordinates were not so huge that they were way off screen.

On large screens (such as mine), this clipped things off well inside the screen boundaries.  Notably, when these limits were applied to the clipping region used to handle polygon shapefiles with holes and those polygons were much bigger than the screen, the clipping mask would clip them off inside the screen.

This commit fixes that.  Instead of using a hard-coded 1700l (which was probably appropriate back in 2003 when this code was written, and monitors of width greater than 1700 weren't common), it uses the global variables screen_width and screen_height.

closes #288