### PR TITLE
Make xastir_udp_client work on FreeBSD

### DIFF
--- a/src/xastir_udp_client.c
+++ b/src/xastir_udp_client.c
@@ -109,10 +109,6 @@ int try_exchange(struct addrinfo *addr, char *buffer, int UNUSED(buflen) )
   return 1;
 }
 
-#ifndef AI_DEFAULT
-  #define AI_DEFAULT (AI_V4MAPPED|AI_ADDRCONFIG)
-#endif
-
 // Loop through the possible addresses for hostname (probably IPv6 and IPv4)
 // Tries until we are successful (get a response) or we run out of addresses
 int exchange_packet(char *hostname, char *port, char *buffer, int buflen)
@@ -124,13 +120,14 @@ int exchange_packet(char *hostname, char *port, char *buffer, int buflen)
   memset(&hints, 0, sizeof(hints));
   hints.ai_family = PF_UNSPEC;
   hints.ai_socktype = SOCK_DGRAM;
-  hints.ai_flags = AI_DEFAULT;
+  hints.ai_flags = (AI_V4MAPPED|AI_ADDRCONFIG);
 
   error = getaddrinfo(hostname, port, &hints, &res);
   if (error)
   {
     fprintf(stderr, "Error: Unable to lookup addresses for host %s port %s\n",
             hostname, port);
+    fprintf(stderr, "Getaddrinfo returned error: %s\n",gai_strerror(error));
     return 1;
   }
 


### PR DESCRIPTION
The xastir_udp_client program was throwing "Unable to lookup addresses for host localhost port 2023" when I tested it out on my BSD machine. I know I have used this program on this machine before, but not in a long time, so some OS update must have busted it.

I tracked it down to FreeBSD's getaddrinfo rejecting the "AI_DEFAULT" flag, which is defined differently on BSD than on some linux systems, apparently.  The code compiled fine, but doesn't work.

Replacing AI_DEFAULT with (AI_V4MAPPED|AI_ADDRCONFIG) fixed it on my system.  That is how we were defining AI_DEFAULT if the system didn't define it for us (a hack added in commit b929560 because at the time Ubuntu 14.04 didn't define AI_DEFAULT, and some other systems didn't either).

This commit also adds output of the actual error message from getaddrinfo using gai_strerror, which is a POSIX standard so should be available on all of our supported systems.

Closes #312