### PR TITLE
Add minimum automake version to AM_INIT_AUTOMAKE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ AC_PREREQ(2.60)
 AC_CONFIG_SRCDIR([src/xastir.h])
 #AM_CONFIG_HEADER(config.h)
 AC_CONFIG_HEADERS(config.h)
-AM_INIT_AUTOMAKE([subdir-objects])
+AM_INIT_AUTOMAKE([subdir-objects 1.16])
 AM_SILENT_RULES(yes)
 
 echo ""


### PR DESCRIPTION
Using "$(var)" in a "_SOURCES" variable was broken in versions of Automake prior to 1.16.  We do that in the test suite.

1.16 came out in 2018, and is probably present in all modern OS distros, but some old, still operational machines are running older OSen with old automake, and trying to build Xastir on these machines will have startling failure when the build hits the test suite.

Putting a minimum version into AM_INIT_AUTOMAKE identifies the problem at the bootstrap/autoreconf stage and lets the user get a newer version of automake.

Prior to this commit, the build pukes when it hits the tests directory, with errors about missing .dep files.

After this commit, the user is informed at the time of doing autoreconf that it can't proceed:
```
> autoreconf -i
configure.ac:34: error: require Automake 1.16, but have 1.15 
autoreconf: automake failed with exit status: 1
```

Closes #314