### PR TITLE
Make CWOP detection case-insensitive

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2943,8 +2943,9 @@ int ok_to_draw_station(DataRow *p_station)
       // CW through GW and then four digits.  There will undoubtedly be
       // more added in future years, so let's not be *too* restrictive,
       // but let's not be too aggressive, either.
-      if ((p_station->call_sign[0] >= 'C' && p_station->call_sign[0] <= 'G')
-          && p_station->call_sign[1] == 'W' )
+      if (((p_station->call_sign[0] >= 'C' && p_station->call_sign[0] <= 'G')
+           || (p_station->call_sign[0] >= 'c' && p_station->call_sign[0] <= 'g'))
+          && (p_station->call_sign[1] == 'W' || p_station->call_sign[1] == 'w'))
       {
         if ( is_num_chr(p_station->call_sign[2])
              && is_num_chr(p_station->call_sign[3])


### PR DESCRIPTION
Firenet is started including CWOP stations in its feed back around October 2025.  Xastir has a filter to hide CWOP stations.

In #280 I made this filter more aggressive, because there are now so many CWOP stations you have to filter CWxxxx through GWxxxx to get them all.

Well, not all.  CWOP doesn't require these non-APRS stations to use upper case names, and I'm seeing lower- and mixed-case in the feed, which don't get filtered out by Xastir for display even when the CWOP filter is set to hide them.

This commit makes our check look for any station that starts with C through G or c through g, whose second letter is W or w, and that has four digits after that.

That should nail 'em all.

Closes #320