### PR TITLE
Stop removing duplicates from CFLAGS, CPPFLAGS, LDFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -673,31 +673,6 @@ fi
 # be caused by other problems with libraries.
 # 
 LIBS=" -lXm -lXt -lX11 $LIBS" 
-  
-# 
-# Remove duplicate entries.  Thanks to Paul Lutt, ke7xt, for this! 
-#
-# Don't get rid of dupes on the LIBS line.  We may need the same
-# "-Llibdir" called out several times, immediately prior to each
-# "-llibrary" that needs it.
-# 
-changequote(,) 
-CFLAGS=`echo  "$CFLAGS" | awk '{for(i=1;i<=NF;++i) {if (arg[$i]++ == 0) s = s " " $i} print s}'`
-CPPFLAGS=`echo  "$CPPFLAGS" | awk '{for(i=1;i<=NF;++i) {if (arg[$i]++ == 0) s = s " " $i} print s}'`
-LDFLAGS=`echo "$LDFLAGS" | awk '{for(i=1;i<=NF;++i) {if (arg[$i]++ == 0) s = s " " $i} print s}'`
-#LIBS=`echo "$LIBS" | awk '{for(i=1;i<=NF;++i) {if (arg[$i]++ == 0) s = s " " $i} print s}'`
-changequote([,]) 
-
-
-# 
-# Remove "-g" CFLAGS/CPPFLAGS entries.  Note:  This is a _bad_ idea
-# as debuggers won't have a symbol table to work from!
-#
-#changequote(,) 
-#CFLAGS=`echo  "$CFLAGS" | awk '{for(i=1;i<=NF;++i) {if ($i != "-g") s = s " " $i} print s}'`
-#CPPFLAGS=`echo  "$CPPFLAGS" | awk '{for(i=1;i<=NF;++i) {if ($i != "-g") s = s " " $i} print s}'`
-#changequote([,]) 
-
 
 #
 # Change the compiler optimization if using Windows/Cygwin in order


### PR DESCRIPTION
Xastir's configure.ac file had several lines of awk scripts that were designed to remove "duplicates" from CFLAGS, CPPFLAGS, and LDFLAGS (and some commented-out code to do the same to LIBS, which was determined to be a bad thing).

This has been present in some form since the initial import of Xastir into CVS in commit fa09e559, when it was in an M4 macro called "XASTIR_PRUNE_DUPLICATES" in the "acinclude.m4" file, and later moved into configure.ac itself when configure.in was replaced by configure.ac.

This has always been a bad idea, because it overrides the user's specified flags from the configure command line.

It was reported years ago in a Gentoo bug report by a user who was deliberately adding flags like "--param l1-cache-line-size=64 --param l2-cache-size=256" to CFLAGS for detailed system-specific optimization, and configure was inappropriately detecting the second "--param" as a "duplicate" and deleting it.  This led to a compile failure for the user because "l2-cache-size=256" was treated as a file name by the compiler and was not found.

Mucking with user's specified flags is ill-advised and frustrates knowledgeable users who are trying to do something specific.  This particular way of munging the flags is especially bad because it presumes that each field of the flags variable is independent, whereas many modern compilers (e.g. GCC) have flags of the form "--flag argument".

This commit removes this ill-advised block of configure.ac code.

Inspired by https://bugs.gentoo.org/411095
Closes #350