### PR TITLE
Convert language files to UTF-8, decode to Latin-1 at load time

### DIFF
--- a/config/language-Dutch.sys
+++ b/config/language-Dutch.sys
@@ -758,7 +758,7 @@ WPUPSTI012|laatste via onbekend||
 WPUPSTI013|, en is van positie veranderd||
 WPUPSTI014|Huidig Vermogen en Winst:||
 WPUPSTI016|Hoogte: %.0f%s ||
-WPUPSTI017|Richting: %sø ||
+WPUPSTI017|Richting: %sÃ¸ ||
 WPUPSTI018|Snelheid: %.1fkm/h||
 WPUPSTI019|Snelheid: %.1fmph||
 WPUPSTI020|%0.1f Mijl||
@@ -770,10 +770,10 @@ WPUPSTI025|Wind Richting: %s Snelheid: %03d km/h||
 WPUPSTI026|Wind Richting: %s Snelheid: %s mph||
 WPUPSTI027| Piek: %03d km/h||
 WPUPSTI028| Piek: %s mph||
-WPUPSTI029|Temperatuur: %02.1føC   ||
-WPUPSTI030|Temperatuur: %søF   ||
+WPUPSTI029|Temperatuur: %02.1fÃ¸C   ||
+WPUPSTI030|Temperatuur: %sÃ¸F   ||
 WPUPSTI031|Vochigheid: %s%%   ||
-WPUPSTI032|Gevoels temperatuur: %02.1føC  ||
+WPUPSTI032|Gevoels temperatuur: %02.1fÃ¸C  ||
 WPUPSTI033|Baro: %s hPa||
 WPUPSTI034|Sneeuw: %0.1f (cm/24h)||
 WPUPSTI035|Sneeuw: %0.0f (inch/24h)||
@@ -801,8 +801,8 @@ WPUPSTI056|Zet automatisch bijwerken aan||
 WPUPSTI057|Omni-DF: %s||
 WPUPSTI058|DF richting: %s||
 WPUPSTI059|Status %02d/%02d %02d:%02d : %s||
-WPUPSTI060|Ontbrandings temp: %02.1føC  ||
-WPUPSTI061|Ontbrandings temp: %søF   ||
+WPUPSTI060|Ontbrandings temp: %02.1fÃ¸C  ||
+WPUPSTI061|Ontbrandings temp: %sÃ¸F   ||
 WPUPSTI062|Vochtigheids gehalte in brandstof: %s%%   ||
 WPUPSTI063|Baro: %0.2f in Hg||
 WPUPSTI064|Vraag NWS waarschuwing||

--- a/config/language-English.sys
+++ b/config/language-English.sys
@@ -751,7 +751,7 @@ WPUPSTI012|last via Unknown||
 WPUPSTI013|, and has moved||
 WPUPSTI014|Current Power Gain:||
 WPUPSTI016|Altitude: %.0f%s ||
-WPUPSTI017|Course: %s° ||
+WPUPSTI017|Course: %sÂ° ||
 WPUPSTI018|Speed: %.1f km/h||
 WPUPSTI019|Speed: %.1f mph||
 WPUPSTI020|%0.1f miles||
@@ -759,14 +759,14 @@ WPUPSTI021|%0.1f km||
 WPUPSTI022|Distance from my station: %s  Bearing from my station: %s||
 WPUPSTI023|Last Position: ||
 WPUPSTI024|Weather Data %c:%s||
-WPUPSTI025|Wind Course: %s°    Speed: %03d km/h||
-WPUPSTI026|Wind Course: %s°    Speed: %s mph||
+WPUPSTI025|Wind Course: %sÂ°    Speed: %03d km/h||
+WPUPSTI026|Wind Course: %sÂ°    Speed: %s mph||
 WPUPSTI027|   Gust: %03d km/h||
 WPUPSTI028|   Gust: %s mph||
-WPUPSTI029|Temperature: %02.1f°C  ||
-WPUPSTI030|Temperature: %s°F   ||
+WPUPSTI029|Temperature: %02.1fÂ°C  ||
+WPUPSTI030|Temperature: %sÂ°F   ||
 WPUPSTI031|Humidity: %s%%   ||
-WPUPSTI032| Humidex: %02.1f°C  ||
+WPUPSTI032| Humidex: %02.1fÂ°C  ||
 WPUPSTI033|Baro: %s hPa||
 WPUPSTI034|Snow: %0.1f (cm/24h)||
 WPUPSTI035|Snow: %0.0f (inch/24h)||
@@ -794,8 +794,8 @@ WPUPSTI056|Enable Automatic Updates||
 WPUPSTI057|Omni-DF: %s||
 WPUPSTI058|DF Bearing: %s||
 WPUPSTI059|Status  %02d/%02d %02d:%02d : %s||
-WPUPSTI060|Fuel Temp: %02.1f°C  ||
-WPUPSTI061|Fuel Temp: %s°F   ||
+WPUPSTI060|Fuel Temp: %02.1fÂ°C  ||
+WPUPSTI061|Fuel Temp: %sÂ°F   ||
 WPUPSTI062|Fuel Moisture: %s%%   ||
 WPUPSTI063|Baro: %0.2f in Hg||
 WPUPSTI064|Fetch NWS Alert||
@@ -880,8 +880,8 @@ UNIOP00010|Allow Transmitting?||
 UNIOP00011|Activate on Startup?||
 UNIOP00012|km/h||
 UNIOP00013|mph||
-UNIOP00014|°C||
-UNIOP00015|°F||
+UNIOP00014|Â°C||
+UNIOP00015|Â°F||
 UNIOP00016|mm||
 UNIOP00017|inch||
 UNIOP00018|mm/day||
@@ -1136,7 +1136,7 @@ SYMSEL0003|Secondary Symbol Table||
 PRINT0001|Print Properties||
 PRINT0002|Paper Size||
 PRINT0003|Auto-Rotate Image||
-PRINT0004|Rotate Image 90° CCW||
+PRINT0004|Rotate Image 90Â° CCW||
 PRINT0005|Auto-Scale Image||
 PRINT0006|Scale:||
 PRINT0007|Force default background color to white||

--- a/config/language-French.sys
+++ b/config/language-French.sys
@@ -4,8 +4,8 @@
 #
 # Creator        : Richard VE2DJE ve2dje@amsat.org
 # Maintained by  : The Xastir Group <xastir@xastir.org>
-# Merci à        : Jacques Chion, F6CWO, qui a contribué une grande part des
-#                  traductions récentes. (N7TAP)
+# Merci Ã         : Jacques Chion, F6CWO, qui a contribuÃ© une grande part des
+#                  traductions rÃ©centes. (N7TAP)
 #
 # comment lines with pound signs in front are ignored
 # File format as follows:
@@ -30,36 +30,36 @@ PULDNFI001|Configurer|C|
 PULDNFI002|Ouvrir le journal|O|
 PULDNFI003|Test|e|
 PULDNFI004|Quitter|Q|
-PULDNFI007|Changer niveau de débogage|d|
+PULDNFI007|Changer niveau de dÃ©bogage|d|
 PULDNFI010|Activer archivage TNC|T|
-PULDNFI011|Activer archivage réseau|r|
+PULDNFI011|Activer archivage rÃ©seau|r|
 PULDNFI012|Activer archivage IGate|I|
-PULDNFI013|Activer archivage météo|m|
-PULDNFI014|Activer copie d'écran PNG||
+PULDNFI013|Activer archivage mÃ©tÃ©o|m|
+PULDNFI014|Activer copie d'Ã©cran PNG||
 PULDNFI015|Imprimer carte|p|
-PULDNFI016|Instantané KML||
+PULDNFI016|InstantanÃ© KML||
 #
 # Menu "View"
 PULDNVI001|Bulletins|B|
-PULDNVI002|Données entrantes|D|
+PULDNVI002|DonnÃ©es entrantes|D|
 PULDNVI003|Stations mobiles|m|
 PULDNVI004|Toutes stations|T|
 PULDNVI009|Stations locales|l|
-PULDNVI012|Stations récentes|r|
-PULDNVI005|Stations météo|m|
-PULDNVI008|Mes données météo|o|
-PULDNVI007|Alertes météo|A|
+PULDNVI012|Stations rÃ©centes|r|
+PULDNVI005|Stations mÃ©tÃ©o|m|
+PULDNVI008|Mes donnÃ©es mÃ©tÃ©o|o|
+PULDNVI007|Alertes mÃ©tÃ©o|A|
 PULDNVI011|Trafic des messages|i|
-PULDNVI013|Durée de fonctionnement|f|
-PULDNVI014|Durée de fonctionnement du logiciel||
+PULDNVI013|DurÃ©e de fonctionnement|f|
+PULDNVI014|DurÃ©e de fonctionnement du logiciel||
 PULDNVI015|Etat du GPS||
 PULDNVI016|Statistiques ALOHA||
 #
 # Menu "Configure"
 PULDNCF004|Station|S|
-PULDNCF001|Défauts|D|
+PULDNCF001|DÃ©fauts|D|
 PULDNCF003|Temporisations|T|
-PULDNCF002|Système des coordonnées|C|
+PULDNCF002|SystÃ¨me des coordonnÃ©es|C|
 PULDNCF006|Alertes sonores|A|
 PULDNCF007|Parole|P|
 PULDNCF008|Sauvegarder la configuration maintenant !|a|
@@ -67,38 +67,38 @@ PULDNCF008|Sauvegarder la configuration maintenant !|a|
 #
 # Menu "Maps"
 PULDNMP001|Choix des cartes|C|
-PULDNMP012|Aller à|l|
-PULDNMP014|Localiser élément cartographique|F|
-PULDNMP016|Désactiver Zoom/Pan/Accueil rapide||
-PULDNMP013|Désactiver toutes cartes|D|
+PULDNMP012|Aller Ã |l|
+PULDNMP014|Localiser Ã©lÃ©ment cartographique|F|
+PULDNMP016|DÃ©sactiver Zoom/Pan/Accueil rapide||
+PULDNMP013|DÃ©sactiver toutes cartes|D|
 PULDNMP002|Activer cartographie automatique|A|
 PULDNMP003|Activer quadrillage|q|
 PULDNMP004|Activer niveaux de cartes|n|
 PULDNMP010|Activer annotation des cartes|n|
 PULDNMP009|Activer remplissage de zones|r|
-PULDNMP007|Activer alertes météo|M|
+PULDNMP007|Activer alertes mÃ©tÃ©o|M|
 PULDNMP005|Couleur de fond|f|
 PULDNMP006|Style du texte de station|S|
-PULDNMP026|Style du contour d'icône|O|
+PULDNMP026|Style du contour d'icÃ´ne|O|
 PULDNMP011|Menu souris|e|
-PULDNMP008|Intensité des cartes|I|
-PULDNMP021|Cartographie automatique - désactiver cartes tramées||
-PULDNMP022|Indexer nouvelles cartes au démarrage||
+PULDNMP008|IntensitÃ© des cartes|I|
+PULDNMP021|Cartographie automatique - dÃ©sactiver cartes tramÃ©es||
+PULDNMP022|Indexer nouvelles cartes au dÃ©marrage||
 PULDNMP023|Index: Ajouter nouvelles cartes|R|
 PULDNMP024|Index: Re-indexer toutes cartes|A|
 PULDNMP025|Fonts||
 PULDNMP015|Xfontsel||
-PULDNMP027|Re-télécharger les cartes (pas à partir du cache)||
+PULDNMP027|Re-tÃ©lÃ©charger les cartes (pas Ã  partir du cache)||
 PULDNMP028|Vider le cache des cartes||
 PULDNMP029|Rechercher un lieu||
 PULDNMP030|Configurer USGS DRG||
 PULDNMP031|Activer bordure des cartes||
-PULDNMP032|Paramètres de géocodage||
+PULDNMP032|ParamÃ¨tres de gÃ©ocodage||
 MPUPTGR017|Temporisation de carte Internet (sec)||
 #
 # PopUp "Configure USGS DRG"
-MPUPDRG001|Sélectionner ce qui doit être affiché :||
-MPUPDRG002|Colorer la carte sous-jaçante (XOR)||
+MPUPDRG001|SÃ©lectionner ce qui doit Ãªtre affichÃ© :||
+MPUPDRG002|Colorer la carte sous-jaÃ§ante (XOR)||
 MPUPDRG003|Noir||
 MPUPDRG004|Blanc||
 MPUPDRG005|Bleu||
@@ -120,9 +120,9 @@ PULDNMMC02|Vectorielles|V|
 PULDNMMC03|Topogr. 250k|2|
 PULDNMMC04|Topogr. 100k|1|
 PULDNMMC05|Topogr. 24k|4|
-PULDNMMC06|Agrandir répertoires|||
-PULDNMMC07|Réps/cartes choisies:||
-PULDNMMC08|Déselct. réps|C|
+PULDNMMC06|Agrandir rÃ©pertoires|||
+PULDNMMC07|RÃ©ps/cartes choisies:||
+PULDNMMC08|DÃ©selct. rÃ©ps|C|
 PULDNMMC09|Choisir tout|S|
 #
 # PullDown "Map Background Color"
@@ -131,17 +131,17 @@ PULDNMBC02|Rose||
 PULDNMBC03|Bleu marine||
 PULDNMBC04|Bleu acier ||
 PULDNMBC05|Vert moyen||
-PULDNMBC06|Vert pâle||
-PULDNMBC07|Jaune pâle||
-PULDNMBC08|Blanc crème||
-PULDNMBC09|Brun rosé||
+PULDNMBC06|Vert pÃ¢le||
+PULDNMBC07|Jaune pÃ¢le||
+PULDNMBC08|Blanc crÃ¨me||
+PULDNMBC09|Brun rosÃ©||
 PULDNMBC10|Rouge brique||
 PULDNMBC11|Blanc||
 PULDNMBC12|Noir||
 #
 # PullDown "Station text Style"
 PULDNMSL01|Bordure noire|n|
-PULDNMSL02|Ombré avec toile de fond|O|
+PULDNMSL02|OmbrÃ© avec toile de fond|O|
 PULDNMSL03|Blanc sur noir|B|
 PULDNMSL04|DropShadow||
 #
@@ -159,26 +159,26 @@ PULDNOT003|Court||
 # Menu "Stations"
 PULDNDP014|Localiser une station|L|
 PULDNDP001|Suivre une station|S|
-PULDNDP022|Récupérer piste Findu||
-PULDNDP032|Filtrer données||
+PULDNDP022|RÃ©cupÃ©rer piste Findu||
+PULDNDP032|Filtrer donnÃ©es||
 PULDNDP040|Ne rien afficher||
 PULDNDP041|Ma station||
 PULDNDP042|Choisir TNC||
 PULDNDP027|- Stations en direct||
 PULDNDP043|- Stations via digi||
 PULDNDP034|Stations via le net||
-PULDNDP019|Inclure données périmées||
+PULDNDP019|Inclure donnÃ©es pÃ©rimÃ©es||
 PULDNDP044|Afficher les stations||
 PULDNDP028|- Stations fixes||
 PULDNDP029|- Stations mobiles||
-PULDNDP030|- Stations météo||
-PULDNDP053|  - Stations météo CWOP||
+PULDNDP030|- Stations mÃ©tÃ©o||
+PULDNDP053|  - Stations mÃ©tÃ©o CWOP||
 PULDNDP045|Objets/articles||
-PULDNDP026|- Objets/articles météo||
+PULDNDP026|- Objets/articles mÃ©tÃ©o||
 PULDNDP039|- Objets/articles indicateurs d'eau||#'
 PULDNDP031|- Autres objets/articles||
 PULDNDP057|- Selecte Aircraft objets/articles||
-PULDNDP058|- Sélectionnez l'objet du navire/Articles||
+PULDNDP058|- SÃ©lectionnez l'objet du navire/Articles||
 PULDNDP033|Filtrer affichage||
 PULDNDP010|Afficher indicatif|n|
 PULDNDP012|Afficher symbole|c|
@@ -186,26 +186,26 @@ PULDNDP011|- Pivoter symbole|o|
 PULDNDP007|Afficher piste|p|
 PULDNDP003|Afficher cap|r|
 PULDNDP004|Afficher vitesse|v|
-PULDNDP017|- Afficher vitesse abrégée||
+PULDNDP017|- Afficher vitesse abrÃ©gÃ©e||
 PULDNDP002|Afficher altitude|A|
-PULDNDP009|Afficher info météo|I|
-PULDNDP046|- Afficher texte météo||
-PULDNDP018|-- Seulement la température||
+PULDNDP009|Afficher info mÃ©tÃ©o|I|
+PULDNDP046|- Afficher texte mÃ©tÃ©o||
+PULDNDP018|-- Seulement la tempÃ©rature||
 PULDNDP047|- Indicateur de vent||
 PULDNDP054|Afficher cercle Aloha||
-PULDNDP013|Afficher ambiguïté de position|b|
+PULDNDP013|Afficher ambiguÃ¯tÃ© de position|b|
 PULDNDP008|Afficher puissance/gain|g|
-PULDNDP021|- Activer puissance/gain défaut||
+PULDNDP021|- Activer puissance/gain dÃ©faut||
 PULDNDP020|- Activer puissance/gain mobile||
 PULDNDP023|Afficher attributs DF||
 PULDNDP123|Afficher largeur faiseau recherche auto (DF)||
-PULDNDP223|Afficher relevé recherche auto (DF)||
-PULDNDP035|Activer point estimé||
+PULDNDP223|Afficher relevÃ© recherche auto (DF)||
+PULDNDP035|Activer point estimÃ©||
 PULDNDP036|- Afficher arc||
 PULDNDP037|- Afficher cap||
 PULDNDP038|- Afficher symbole||
-PULDNDP005|Afficher distance/relèvement|d|
-PULDNDP024|Afficher âge du dernier rapport||
+PULDNDP005|Afficher distance/relÃ¨vement|d|
+PULDNDP024|Afficher Ã¢ge du dernier rapport||
 PULDNDP015|Effacer toutes stations !!!|E|
 PULDNDP016|Effacer toutes pistes !!!|f|
 PULDNDP025|Effacer histoire des objets/articles||
@@ -219,25 +219,25 @@ PULDNDP056|Exporter vers fichier KML||
 #
 # Units
 PULDNUT001|Activer mesures anglaises||
-PULDNUT002|Mètres||
+PULDNUT002|MÃ¨tres||
 #
 # Menu "Messages"
-PULDNMG001|Composer un message à|C|
+PULDNMG001|Composer un message Ã |C|
 PULDNMG002|Ouvrir les messages de groupe|g|
-PULDNMG003|Effacer tout message à expédier|E|
-PULDQUS001|Intérroger toutes les stations|I|
-PULDQUS002|Intérroger les stations IGate|n|
-PULDQUS003|Intérroger les stations météo|m|
-PULDNMG004|Configurer la réponse automatique|o|
-PULDNMG005|Activer la réponse automatique|R|
+PULDNMG003|Effacer tout message Ã  expÃ©dier|E|
+PULDQUS001|IntÃ©rroger toutes les stations|I|
+PULDQUS002|IntÃ©rroger les stations IGate|n|
+PULDQUS003|IntÃ©rroger les stations mÃ©tÃ©o|m|
+PULDNMG004|Configurer la rÃ©ponse automatique|o|
+PULDNMG005|Activer la rÃ©ponse automatique|R|
 PULDNMG006|Mode "Satellite Ack"|M|
 PULDNMG007|Voir les messages en attente|V|
 #
 # Menu "Interfaces"
-PULDNTNT04|Contrôle de l'interface|C|
-PULDNTNT03|Désactiver transmission: Tout||
-PULDNTNT05|Désactiver transmission: Ma position||
-PULDNTNT06|Désactiver transmission: Objets/Articles||
+PULDNTNT04|ContrÃ´le de l'interface|C|
+PULDNTNT03|DÃ©sactiver transmission: Tout||
+PULDNTNT05|DÃ©sactiver transmission: Ma position||
+PULDNTNT06|DÃ©sactiver transmission: Objets/Articles||
 PULDNTNT11|Activer serveur sur port 2023||
 PULDNTNT01|Transmettre maintenant !|T|
 PULDNTNT07|Extraire piste GPS|F|
@@ -250,7 +250,7 @@ PULDNHEL01|Information|I|
 PULDNHEL02|Index de l'Aide|A|#'
 PULDNHEL03|ACTIVER MODE BALISE DE DETRESSE|E|
 PULDNHEL04|!!! MODE BALISE DE DETRESSE !!!||
-PULDNHEL05|À propos de Xastir||
+PULDNHEL05|Ã€ propos de Xastir||
 #
 #
 # Mouse Menu Popup
@@ -267,19 +267,19 @@ POPUPMA008|Niveau 256|2|
 POPUPMA009|Niveau 1024|0|
 POPUPMA010|Niveau 8192|8|
 POPUPMA017|Monde entier|M|
-POPUPMA016|Pos/zoom précédent||
-POPUPMA018|Objet/Article->Créer||
+POPUPMA016|Pos/zoom prÃ©cÃ©dent||
+POPUPMA018|Objet/Article->CrÃ©er||
 POPUPMA019|Objet/Article->Modifier||
-POPUPMA025|Déplacer ma station ici|H|
+POPUPMA025|DÃ©placer ma station ici|H|
 POPUPMA011|Nord||
 POPUPMA012|Sud||
 POPUPMA013|Ouest||
 POPUPMA014|Est||
 POPUPMA020|Mesurer||
-POPUPMA021|Déplacer||
+POPUPMA021|DÃ©placer||
 POPUPMA022|Me suivre||
-POPUPMA023|Modificateurs trouvés !||
-POPUPMA024|SVP désactiver CapsLock/NumLock/ScrollLock/autres||
+POPUPMA023|Modificateurs trouvÃ©s !||
+POPUPMA024|SVP dÃ©sactiver CapsLock/NumLock/ScrollLock/autres||
 POPUPMA026|Centre & zoom||
 POPUPMA027|  Latitude||
 POPUPMA028| Longitude||
@@ -289,26 +289,26 @@ POPUPMA031|Fermer polygone||
 POPUPMA032|Effacer polygones CAD||
 POPUPMA033|**NOT USED**||
 POPUPMA034|Changer niveau de zoom||
-POPUPMA035|10% arrière||
+POPUPMA035|10% arriÃ¨re||
 POPUPMA036|10% avant||
 POPUPMA037|Aire||
-POPUPMA038|carré||
-POPUPMA039|pieds carrés||
-POPUPMA040|mètres carrés||
-POPUPMA041|Relèvement||
-POPUPMA042|degrés||
-POPUPMA043|Modifier ambiguïté de position||
-POPUPMA044|Ambiguïté de position est active, votre nouvelle position pourra sauter.||
-POPUPMA045|Objets prédéfinis||
+POPUPMA038|carrÃ©||
+POPUPMA039|pieds carrÃ©s||
+POPUPMA040|mÃ¨tres carrÃ©s||
+POPUPMA041|RelÃ¨vement||
+POPUPMA042|degrÃ©s||
+POPUPMA043|Modifier ambiguÃ¯tÃ© de position||
+POPUPMA044|AmbiguÃ¯tÃ© de position est active, votre nouvelle position pourra sauter.||
+POPUPMA045|Objets prÃ©dÃ©finis||
 POPUPMA046|Polygones CAD||
 POPUPMA047|Activer les objets CAD||
-POPUPMA048|Activer les étiquettes CAD||
+POPUPMA048|Activer les Ã©tiquettes CAD||
 POPUPMA049|Activer les commentaires CAD||
-POPUPMA050|Activer la probabilité CAD||
+POPUPMA050|Activer la probabilitÃ© CAD||
 POPUPMA051|Activer la taille de la surface CAD||
 POPUPMA052|sq||
 POPUPMA053|ft||
-POPUPMA054|mètres||
+POPUPMA054|mÃ¨tres||
 POPUPMA055|mi|
 #
 #
@@ -320,64 +320,64 @@ BBARSTA000|%-9s Nouvel objet !||
 BBARSTA001|%-9s Nouvelle station !||
 BBARSTA002|%-9s||
 BBARSTA003|Chargement de cartes...||
-BBARSTA004|Cartes chargées||
-BBARSTA005|Quadrillage de carte Lat/Long activé||
-BBARSTA006|Quadrillage de carte Lat/Long désactivé||
-BBARSTA007|Carte automatique activée||
-BBARSTA008|Carte automatique désactivée||
-BBARSTA009|Niveau de cartes activé||
-BBARSTA010|Niveau de cartes désactivé||
-BBARSTA011|Réponse automatique désactivée||
-BBARSTA012|Fichier terminé...||
+BBARSTA004|Cartes chargÃ©es||
+BBARSTA005|Quadrillage de carte Lat/Long activÃ©||
+BBARSTA006|Quadrillage de carte Lat/Long dÃ©sactivÃ©||
+BBARSTA007|Carte automatique activÃ©e||
+BBARSTA008|Carte automatique dÃ©sactivÃ©e||
+BBARSTA009|Niveau de cartes activÃ©||
+BBARSTA010|Niveau de cartes dÃ©sactivÃ©||
+BBARSTA011|RÃ©ponse automatique dÃ©sactivÃ©e||
+BBARSTA012|Fichier terminÃ©...||
 BBARSTA013|Ouverture du port GPS||
 BBARSTA014|Fermeture du port GPS||
-BBARSTA015|Réception de message GPS RMC||
-BBARSTA016|Réception de message GPS GGA||
-BBARSTA017|Réseau déconnecté de l'hôte||
-BBARSTA018|Connexion réseau dépassement de temps !||
-BBARSTA019|Recherche de l'hôte %s||#'
-BBARSTA020|Connecté à %s||
-BBARSTA021|Échec de la connexion !||
+BBARSTA015|RÃ©ception de message GPS RMC||
+BBARSTA016|RÃ©ception de message GPS GGA||
+BBARSTA017|RÃ©seau dÃ©connectÃ© de l'hÃ´te||
+BBARSTA018|Connexion rÃ©seau dÃ©passement de temps !||
+BBARSTA019|Recherche de l'hÃ´te %s||#'
+BBARSTA020|ConnectÃ© Ã  %s||
+BBARSTA021|Ã‰chec de la connexion !||
 BBARSTA022|Incapable de relier le socket !||
-BBARSTA023|Hôte inconnu !||
-BBARSTA024|Serveur non spécifié||#'
-BBARSTA025|Hôte trouvé, connexion en cours %d||
-BBARSTA026|Attente de données du GPS par HSP||
-BBARSTA027|Fermeture port HSP réception donnée TNC..||
+BBARSTA023|HÃ´te inconnu !||
+BBARSTA024|Serveur non spÃ©cifiÃ©||#'
+BBARSTA025|HÃ´te trouvÃ©, connexion en cours %d||
+BBARSTA026|Attente de donnÃ©es du GPS par HSP||
+BBARSTA027|Fermeture port HSP rÃ©ception donnÃ©e TNC..||
 BBARSTA028|Chargement de %s||
-BBARSTA029|Ouverture port météo||
-BBARSTA030|Fermeture port météo||
-BBARSTA031|Recherche d'hôte %d||#'
-BBARSTA032|Données météo décodées||
-BBARSTA033|Écho de digipeater||
-BBARSTA034|Chargement de cartes alertes météo||
-BBARSTA035|Attente de donées du GPS par AUX||
-BBARSTA036|Fermeture port GPS réception donnée TNC..||
-BBARSTA037|GPS météo décodées||
+BBARSTA029|Ouverture port mÃ©tÃ©o||
+BBARSTA030|Fermeture port mÃ©tÃ©o||
+BBARSTA031|Recherche d'hÃ´te %d||#'
+BBARSTA032|DonnÃ©es mÃ©tÃ©o dÃ©codÃ©es||
+BBARSTA033|Ã‰cho de digipeater||
+BBARSTA034|Chargement de cartes alertes mÃ©tÃ©o||
+BBARSTA035|Attente de donÃ©es du GPS par AUX||
+BBARSTA036|Fermeture port GPS rÃ©ception donnÃ©e TNC..||
+BBARSTA037|GPS mÃ©tÃ©o dÃ©codÃ©es||
 BBARSTA038|Placez le changement sur ma station||
-BBARSTA039|Création de l'index de %s||
+BBARSTA039|CrÃ©ation de l'index de %s||
 BBARSTA040|Station d'amateur APRS(tm) %s||#'
-BBARSTA041|Attente de données GPS..||
+BBARSTA041|Attente de donnÃ©es GPS..||
 BBARSTA042|Transmission objets/articles||
 BBARSTA043|Journalisation||
 BBARSTA044|Le rayon ALOHA est de %d%s||
 BBARSTA045|Chargement de symboles...||
 BBARSTA046|Rechargement des symboles...||
 BBARSTA047|Initialisation de ma station...||
-BBARSTA048|Démarrer interfaces...||
+BBARSTA048|DÃ©marrer interfaces...||
 BBARSTA049|Lit les dalles...||
-BBARSTA050|Télécharge les dalles...||
-BBARSTA051|Télécharge dalle %li de %li||
+BBARSTA050|TÃ©lÃ©charge les dalles...||
+BBARSTA051|TÃ©lÃ©charge dalle %li de %li||
 #
 #
 # PopUp "View - Incoming Packet Data"
-WPUPDPD001|Affichage de données paquet||
-WPUPDPD002|Données du TNC seulement||
-WPUPDPD003|Données du réseau seulement||
-WPUPDPD004|Données du TNC et du réseau||
+WPUPDPD001|Affichage de donnÃ©es paquet||
+WPUPDPD002|DonnÃ©es du TNC seulement||
+WPUPDPD003|DonnÃ©es du rÃ©seau seulement||
+WPUPDPD004|DonnÃ©es du TNC et du rÃ©seau||
 WPUPDPD005|TNC||
-WPUPDPD006|Réseau||
-WPUPDPD007|Capacité Station||
+WPUPDPD006|RÃ©seau||
+WPUPDPD007|CapacitÃ© Station||
 WPUPDPD008|Seulement les miens||
 #
 # PopUp "View - Find Station"
@@ -386,19 +386,19 @@ WPUPLSP002|Localiser l'indicatif||#'
 WPUPLSP003|Casse exacte|C|
 WPUPLSP004|Correspondance exacte|E|
 WPUPLSP005|Localiser maintenant !|L|
-WPUPLSP006|Localiser détresse !||
+WPUPLSP006|Localiser dÃ©tresse !||
 WPUPLSP007|Recherche indicatif FCC/RAC||
 #
 # PopUp "Configure - Defaults"
-WPUPCFD001|Configurer défauts||
-WPUPCFD002|Au bout de combien de temps une station sera-t-elle considérée âgée ?||
+WPUPCFD001|Configurer dÃ©fauts||
+WPUPCFD002|Au bout de combien de temps une station sera-t-elle considÃ©rÃ©e Ã¢gÃ©e ?||
 WPUPCFD003|15 min|1|
 WPUPCFD004|30 min|3|
 WPUPCFD005|45 min|4|
 WPUPCFD006|1 heure|h|
 WPUPCFD007|90 min|9|
 WPUPCFD008|2 heures|2|
-WPUPCFD009|Au bout de combien de temps une station ne sera-t-elle plus affichée ?||
+WPUPCFD009|Au bout de combien de temps une station ne sera-t-elle plus affichÃ©e ?||
 WPUPCFD010|6 heures|6|
 WPUPCFD011|12 heures|e|
 WPUPCFD012|1 jour|j|
@@ -409,45 +409,45 @@ WPUPCFD016|Station fixe||
 WPUPCFD017|Station mobile + heure locale||
 WPUPCFD018|Station mobile + date/heure Zulu||
 WPUPCFD019|Station mobile + heure/secondes Zulu||
-WPUPCFD021|Position de station + météo||
-WPUPCFD022|Position de station + date/heure Zulu + météo||
-WPUPCFD023|Transmettre les données météo non traitées ?||
-WPUPCFD024|Transmettre les objets/articles sous forme compréssés ?||
-WPUPCFD025|Activer réseau alterne ?|A|
-WPUPCFD026|Transmettre position à quel intervalle ?||
+WPUPCFD021|Position de station + mÃ©tÃ©o||
+WPUPCFD022|Position de station + date/heure Zulu + mÃ©tÃ©o||
+WPUPCFD023|Transmettre les donnÃ©es mÃ©tÃ©o non traitÃ©es ?||
+WPUPCFD024|Transmettre les objets/articles sous forme comprÃ©ssÃ©s ?||
+WPUPCFD025|Activer rÃ©seau alterne ?|A|
+WPUPCFD026|Transmettre position Ã  quel intervalle ?||
 WPUPCFD027|Afficher bulletins nouveaux||
-WPUPCFD028|Alerter si clés modificatrices (Verr.Num.)||
-WPUPCFD029|Voir bulletins avec distance zéro||
-WPUPCFD030|Désactiver identif. de duplic. posit.||
-WPUPCFD031|Charger des objets prédéfinis à partir d'un fichier||
+WPUPCFD028|Alerter si clÃ©s modificatrices (Verr.Num.)||
+WPUPCFD029|Voir bulletins avec distance zÃ©ro||
+WPUPCFD030|DÃ©sactiver identif. de duplic. posit.||
+WPUPCFD031|Charger des objets prÃ©dÃ©finis Ã  partir d'un fichier||
 WPUPCFD032|Mon parcour en une seule couleur||
 WPUPCFD033|ALTNET:||
 #
 # PopUp "Configure - Timing"
 WPUPCFTM01|Configurer temporisation||
 WPUPCFTM02|Intervalle transmission de position (min)||
-WPUPCFTM03|Délai d'affichage faible d'une station (min)||
+WPUPCFTM03|DÃ©lai d'affichage faible d'une station (min)||
 WPUPCFTM04|Intervalle maximum de transmission des objets/articles (min)||#'
-WPUPCFTM05|Délai de suppression d'affichage d'une station (heures)||
+WPUPCFTM05|DÃ©lai de suppression d'affichage d'une station (heures)||
 WPUPCFTM06|Intervalle de lecture GPS (sec)||
-WPUPCFTM07|Délai de suppression d'une station (jours)||
-WPUPCFTM08|Expiration de point estimé (min)||
-WPUPCFTM09|Délai inter-char port série (ms)||
-WPUPCFTM10|Délai nouvelle piste (min)||
-WPUPCFTM11|Espace nouvelle piste (degrés)||
-WPUPCFTM12|RINO -> Intervalle d'objets (min), 0 = Désactivé||
-WPUPCFTM13|Intervalle de capture instantané (min)||
+WPUPCFTM07|DÃ©lai de suppression d'une station (jours)||
+WPUPCFTM08|Expiration de point estimÃ© (min)||
+WPUPCFTM09|DÃ©lai inter-char port sÃ©rie (ms)||
+WPUPCFTM10|DÃ©lai nouvelle piste (min)||
+WPUPCFTM11|Espace nouvelle piste (degrÃ©s)||
+WPUPCFTM12|RINO -> Intervalle d'objets (min), 0 = DÃ©sactivÃ©||
+WPUPCFTM13|Intervalle de capture instantanÃ© (min)||
 WPUPCFTM14|Aircraft Ghost/Clear Time (min), 0 = Disabled||
 #
 # PopUp "Configure Coordinate System"
-WPUPCFC001|Configurer système de coordonnées||
-WPUPCFC002|Choisir système de coordonnées||
+WPUPCFC001|Configurer systÃ¨me de coordonnÃ©es||
+WPUPCFC002|Choisir systÃ¨me de coordonnÃ©es||
 WPUPCFC003|dd.ddddd|d|
 WPUPCFC004|dd mm.mmm|m|
 WPUPCFC005|dd mm ss.s|s|
 WPUPCFC006|UTM|U|
 WPUPCFC007|USNG/MGRS2||
-WPUPCFC008|UTM avec zones spéciales||
+WPUPCFC008|UTM avec zones spÃ©ciales||
 #
 # PopUp "Configure GPS"
 WPUPCFG001|Configurer GPS||
@@ -455,8 +455,8 @@ WPUPCFG003|Port GPS seulement||
 WPUPCFG002|Utiliser la position GPS ?||
 WPUPCFG004|Options du GPS||
 WPUPCFG005|GPS seul||
-WPUPCFG006|TNC branché au GPS (Câble HSP)||
-WPUPCFG007|TNC branché au GPS avec CTL-E||
+WPUPCFG006|TNC branchÃ© au GPS (CÃ¢ble HSP)||
+WPUPCFG007|TNC branchÃ© au GPS avec CTL-E||
 WPUPCFG008|Intervalle de temps GPS||
 WPUPCFG009|5 sec||
 WPUPCFG010|15 sec||
@@ -465,14 +465,14 @@ WPUPCFG012|1 min||
 WPUPCFG013|2 min||
 WPUPCFG014|5 min||
 WPUPCFG015|10 min||
-WPUPCFG016|GPS branché réseau||
-WPUPCFG017|Hôte GPSD||
+WPUPCFG016|GPS branchÃ© rÃ©seau||
+WPUPCFG017|HÃ´te GPSD||
 WPUPCFG018|Port GPSD||
-WPUPCFG019|GPS réseau via GPSD||
-WPUPCFG020|Reconnexion sur échec ?||
-WPUPCFG021|Connexion météo réseau||
-WPUPCFG022|Hôte météo||
-WPUPCFG023|Port météo||
+WPUPCFG019|GPS rÃ©seau via GPSD||
+WPUPCFG020|Reconnexion sur Ã©chec ?||
+WPUPCFG021|Connexion mÃ©tÃ©o rÃ©seau||
+WPUPCFG022|HÃ´te mÃ©tÃ©o||
+WPUPCFG023|Port mÃ©tÃ©o||
 #
 # Configure TNC (baud/style are also for WX)
 WPUPCFT001|Configurer le TNC||
@@ -498,7 +498,7 @@ WPUPCFT020|57600 bps||
 WPUPCFT021|115200 bps||
 WPUPCFT022|230400 bps||
 WPUPCFT023|Configurer TNC +HSP GPS||
-WPUPCFT024|Type de données||
+WPUPCFT024|Type de donnÃ©es||
 WPUPCFT025|Auto detection||
 WPUPCFT026|Type binaire||
 WPUPCFT027|Type ASCII||
@@ -506,28 +506,28 @@ WPUPCFT028|Configurer TNC +AUX GPS||
 WPUPCFT029|COnfigurer TNC +INVALID ENUM: %d||
 WPUPCFT030|Configurer TNC KISS||
 WPUPCFT031|Fichiers de configuration du TNC||
-WPUPCFT032|Nom du fichier de démarrage du TNC||
-WPUPCFT033|Nom du fichier d'arrêt du TNC||#'
-WPUPCFT034|Paramètres KISS||
-WPUPCFT035|TXDelay (unité 10 ms)||
-WPUPCFT036|Persistance (0 à 255)||
-WPUPCFT037|SlotTime (unité 10 ms)||
-WPUPCFT038|TxTail (unité 10 ms)||
+WPUPCFT032|Nom du fichier de dÃ©marrage du TNC||
+WPUPCFT033|Nom du fichier d'arrÃªt du TNC||#'
+WPUPCFT034|ParamÃ¨tres KISS||
+WPUPCFT035|TXDelay (unitÃ© 10 ms)||
+WPUPCFT036|Persistance (0 Ã  255)||
+WPUPCFT037|SlotTime (unitÃ© 10 ms)||
+WPUPCFT038|TxTail (unitÃ© 10 ms)||
 WPUPCFT039|Full duplex||
 WPUPCFT040|Configurer TNC Multi-Port KISS||
 WPUPCFT041|Port radio||
-WPUPCFT042|Propriétés d'interface: Chemin UNPROTO douteux !||
+WPUPCFT042|PropriÃ©tÃ©s d'interface: Chemin UNPROTO douteux !||
 WPUPCFT043|SVP choisissez un chemin plus court tel que WIDE2-2 or WIDE1-1,WIDE2-2||
-WPUPCFT044|Propriétés d'interface: Chemin IGATE douteux !||
+WPUPCFT044|PropriÃ©tÃ©s d'interface: Chemin IGATE douteux !||
 WPUPCFT045|Transmission avec chemin UNPROTO douteux !||
 WPUPCFT046|Transmission avec chemin IGATE douteux !||
-WPUPCFT047|Initialiser mode KISS au démarrage||
+WPUPCFT047|Initialiser mode KISS au dÃ©marrage||
 #
 #
 # PopUp "Configure WX Port"
-WPUPCFWX01|Configurer port météo||
-WPUPCFWX02|Port météo||
-WPUPCFWX03|Correction globale de pluviomètre||
+WPUPCFWX01|Configurer port mÃ©tÃ©o||
+WPUPCFWX02|Port mÃ©tÃ©o||
+WPUPCFWX03|Correction globale de pluviomÃ¨tre||
 WPUPCFWX04|.1 pouce/2.5mm||
 WPUPCFWX05|.01 pouce/.25mm||
 WPUPCFWX06|.1mm||
@@ -546,31 +546,31 @@ WPUPCFS009|Symbole de station||
 WPUPCFS010|Groupe/superposition||
 WPUPCFS011|Symbole||
 WPUPCFS028|Choisir||
-WPUPCFS012|Puissance - Hauteur (HAAT) - Gain - Directivité||
-WPUPCFS013|Désactiver PHG||
+WPUPCFS012|Puissance - Hauteur (HAAT) - Gain - DirectivitÃ©||
+WPUPCFS013|DÃ©sactiver PHG||
 WPUPCFS014|Hauteur de l'antenne||#'
 WPUPCFS015|Gain de l'antenne||#'
 WPUPCFS016|Omni||
 WPUPCFS017|Commentaire:||
-WPUPCFS018|Ambiguïté de position||
+WPUPCFS018|AmbiguÃ¯tÃ© de position||
 WPUPCFS019|Rien||
 WPUPCFS020|.11 milles||
 WPUPCFS021|1.15 milles||
 WPUPCFS022|11.51 milles||
 WPUPCFS023|69.09 milles||
-WPUPCFS024|.18 kilomètres||
-WPUPCFS025|1.85 kilomètres||
-WPUPCFS026|18.53 kilomètres||
-WPUPCFS027|111.19 kilomètres||
-WPUPCFS029|Transmettre positions compressées|C|
+WPUPCFS024|.18 kilomÃ¨tres||
+WPUPCFS025|1.85 kilomÃ¨tres||
+WPUPCFS026|18.53 kilomÃ¨tres||
+WPUPCFS027|111.19 kilomÃ¨tres||
+WPUPCFS029|Transmettre positions compressÃ©es|C|
 #
 # PopUp "Object/Item"
 POPUPOB001|Objet/Article||
 POPUPOB002|Nom||
-POPUPOB003|Créer nouvel objet||
+POPUPOB003|CrÃ©er nouvel objet||
 POPUPOB004|Supprimer objet||
 POPUPOB005|Modifier objet||
-POPUPOB006|Créer nouvel article||
+POPUPOB006|CrÃ©er nouvel article||
 POPUPOB007|Objet polygonal||
 POPUPOB008|Objet polygonal||
 POPUPOB009|Couleur vive||
@@ -588,10 +588,10 @@ POPUPOB020|Rouge||
 POPUPOB021|Violet||
 POPUPOB022|Jaune||
 POPUPOB023|Gris||
-POPUPOB024|Décalage haut:||
-POPUPOB025|Décalage gauche (sauf '/'):||
+POPUPOB024|DÃ©calage haut:||
+POPUPOB025|DÃ©calage gauche (sauf '/'):||
 POPUPOB026|Couloir:||
-POPUPOB027|Options génériques||
+POPUPOB027|Options gÃ©nÃ©riques||
 POPUPOB028|Placement||
 POPUPOB029|Activer panneau||
 POPUPOB030|Texte sur le panneau||#'
@@ -603,65 +603,65 @@ POPUPOB035|Altitude (pieds):||
 POPUPOB036|Vitesse (noeuds):||
 POPUPOB037|Cap:||
 POPUPOB038|Objet DF||
-POPUPOB039|Signal - Hauteur (HAAT) - Gain - Directivité||
-POPUPOB040|Largeur de faisceau - Relèvement||
+POPUPOB039|Signal - Hauteur (HAAT) - Gain - DirectivitÃ©||
+POPUPOB040|Largeur de faisceau - RelÃ¨vement||
 POPUPOB041|Antenne omni||
-POPUPOB042|Antenne dirigée||
+POPUPOB042|Antenne dirigÃ©e||
 POPUPOB043|Inutile||
 POPUPOB044|Adopter objet||
 POPUPOB045|Adopter article||
-POPUPOB046|Relèvement DF:||
-POPUPOB047|Cercles de probabilité||
+POPUPOB046|RelÃ¨vement DF:||
+POPUPOB047|Cercles de probabilitÃ©||
 POPUPOB048|Objet Map View||
 POPUPOB049|Min (mi):||
 POPUPOB050|Max (mi):||
 #
 # PopUp "Configure Internet"
 WPUPCFI001|Configurer Internet||
-WPUPCFI002|Hôte ||
+WPUPCFI002|HÃ´te ||
 WPUPCFI003|Port ||
-WPUPCFI004|(Hôte secondaire)||
-WPUPCFI005|Hôte1||
+WPUPCFI004|(HÃ´te secondaire)||
+WPUPCFI005|HÃ´te1||
 WPUPCFI006|Port1||
-WPUPCFI007|Hôte2||
+WPUPCFI007|HÃ´te2||
 WPUPCFI008|Port2||
-WPUPCFI009|Code d'accès||#'
+WPUPCFI009|Code d'accÃ¨s||#'
 WPUPCFI010|(Laisser vide si nul)||
-WPUPCFI011|Reconnexion sur erreur réseau ?||
+WPUPCFI011|Reconnexion sur erreur rÃ©seau ?||
 WPUPCFI012|Fonction IGate ?||
 WPUPCFI013|Diffusion de messages par le TNC lorsqu'en IGate ?||#'
 WPUPCFI014|Archivage des transactions IGate ?|||
-WPUPCFI015|Paramètres du filtre||
+WPUPCFI015|ParamÃ¨tres du filtre||
 #
 # PopUp "Configure Database"
-WPUPCFID01|Configurer base de données (TBD)||
-WPUPCFID02|Hôte ||
+WPUPCFID01|Configurer base de donnÃ©es (TBD)||
+WPUPCFID02|HÃ´te ||
 WPUPCFID03|Port ||
-WPUPCFID04|(Hôte secondaire)||
-WPUPCFID05|Hôte1||
+WPUPCFID04|(HÃ´te secondaire)||
+WPUPCFID05|HÃ´te1||
 WPUPCFID06|Port1||
-WPUPCFID07|Hôte2||
+WPUPCFID07|HÃ´te2||
 WPUPCFID08|Port2||
-WPUPCFID09|Code d'accès||#'
+WPUPCFID09|Code d'accÃ¨s||#'
 WPUPCFID10|(Laisser vide si nul)||
-WPUPCFID11|Reconnexion sur erreur réseau ?||
+WPUPCFID11|Reconnexion sur erreur rÃ©seau ?||
 WPUPCFID12|Fonction IGate ?||
 WPUPCFID13|Diffusion de messages par le TNC lorsqu'en IGate ?||#'
 WPUPCFID14|Archivage des transactions IGate ?|||
-WPUPCFID15|Paramètres du filtre||
+WPUPCFID15|ParamÃ¨tres du filtre||
 #
 # PopUp "Configure AGWPE"
 WPUPCFIA01|Configurer AGWPE||
-WPUPCFIA02|Hôte ||
+WPUPCFIA02|HÃ´te ||
 WPUPCFIA03|Port ||
-WPUPCFIA04|(Hôte secondaire)||
-WPUPCFIA05|Hôte1||
+WPUPCFIA04|(HÃ´te secondaire)||
+WPUPCFIA05|HÃ´te1||
 WPUPCFIA06|Port1||
-WPUPCFIA07|Hôte2||
+WPUPCFIA07|HÃ´te2||
 WPUPCFIA08|Port2||
-WPUPCFIA09|Code d'accès||#'
+WPUPCFIA09|Code d'accÃ¨s||#'
 WPUPCFIA10|(Laisser vide si nul)||
-WPUPCFIA11|Reconnexion sur erreur réseau ?||
+WPUPCFIA11|Reconnexion sur erreur rÃ©seau ?||
 WPUPCFIA12|Fonction IGate ?||
 WPUPCFIA13|Diffusion de messages par le TNC lorsqu'en IGate ?||#'
 WPUPCFIA14|Archivage des transactions IGate ?|||
@@ -669,16 +669,16 @@ WPUPCFIA15|RadioPort de transmission||
 #
 # PopUp "Configure Audio Alarms"
 WPUPCFA001|Configurer alarmes sonores||
-WPUPCFA002|Commande audio à utiliser||
+WPUPCFA002|Commande audio Ã  utiliser||
 WPUPCFA003|Alarme pour:||
 WPUPCFA004|Fichier sonore||
 WPUPCFA005|Nouvelle station||
 WPUPCFA006|Nouveau message||
-WPUPCFA007|Proximité||
+WPUPCFA007|ProximitÃ©||
 WPUPCFA008|Ouverture de bande||
 WPUPCFA009|Distance minimum||
 WPUPCFA010|Distance maximum||
-WPUPCFA011|Alerte météo||
+WPUPCFA011|Alerte mÃ©tÃ©o||
 #
 # PopUp "Configure Speech"
 WPUPCFSP01|Configurer parole||
@@ -686,10 +686,10 @@ WPUPCFSP02|Parole pour:||
 WPUPCFSP03|Nouvelle station||
 WPUPCFSP04|Alerte nouveau message||
 WPUPCFSP05|Texte nouveau message||
-WPUPCFSP06|Proximité||
+WPUPCFSP06|ProximitÃ©||
 WPUPCFSP07|Ouverture de bande||
-WPUPCFSP08|Alerte météo||
-WPUPCFSP09|Station suivie à proximité||#'
+WPUPCFSP08|Alerte mÃ©tÃ©o||
+WPUPCFSP09|Station suivie Ã  proximitÃ©||#'
 #
 # PopUp "Track Station"
 WPUPTSP001|Suivre station||
@@ -698,9 +698,9 @@ WPUPTSP003|Casse exacte||
 WPUPTSP004|Correspondance exacte||
 WPUPTSP005|Suivre maintenant !||
 WPUPTSP006|Annuler suivi||
-WPUPTSP007|Télécharger piste||
+WPUPTSP007|TÃ©lÃ©charger piste||
 WPUPTSP008|Indicatif||
-WPUPTSP009|Début de piste (depuis .. heures)||
+WPUPTSP009|DÃ©but de piste (depuis .. heures)||
 WPUPTSP010|Longueur de piste (heures)||
 #
 # PopUp "Messages..."
@@ -723,13 +723,13 @@ WPUPMSB016|*EXPIRATION*||
 WPUPMSB017|*ANNULE*||
 WPUPMSB018|*REJETE*||
 WPUPMSB019|Changer chemin||
-WPUPMSB020|Utiliser chemin(s) par défaut||
+WPUPMSB020|Utiliser chemin(s) par dÃ©faut||
 WPUPMSB021|Direct (pas de chemin)||
 WPUPMSB022|Chemin inverse (pour info):||
 #
 # PopUp "Auto Reply"
-WPUPARM001|Modifier réponse automatique||
-WPUPARM002|Réponse:||
+WPUPARM001|Modifier rÃ©ponse automatique||
+WPUPARM002|RÃ©ponse:||
 #
 # PopUp "Help Index"
 WPUPHPI001|Index d'Aide||#'
@@ -741,33 +741,33 @@ WPUPSTI001|Information de station||
 WPUPSTI002|Composer un message||
 WPUPSTI003|Chercher dans la base FCC||
 WPUPSTI004|Chercher dans la base RAC||
-WPUPSTI005|Paquets recu: %d     Dernière transmission: ||
+WPUPSTI005|Paquets recu: %d     DerniÃ¨re transmission: ||
 WPUPSTI006|Entendu sur le TNC %d, ||
 WPUPSTI007|Entendu ||
-WPUPSTI008|dernièrement sur port local||
-WPUPSTI009|dernièrement sur TNC %d||
-WPUPSTI010|dernièrement sur Internet %d||
-WPUPSTI011|dernièrement dans fichier||
-WPUPSTI012|dernièrement sur inconnu||
-WPUPSTI013|, et a bougé||
+WPUPSTI008|derniÃ¨rement sur port local||
+WPUPSTI009|derniÃ¨rement sur TNC %d||
+WPUPSTI010|derniÃ¨rement sur Internet %d||
+WPUPSTI011|derniÃ¨rement dans fichier||
+WPUPSTI012|derniÃ¨rement sur inconnu||
+WPUPSTI013|, et a bougÃ©||
 WPUPSTI014|Puissance/gain/etc.:||
 WPUPSTI016|Altitude: %.0f%s ||
-WPUPSTI017|Cap: %s° ||
+WPUPSTI017|Cap: %sÂ° ||
 WPUPSTI018|Vitesse: %.1f km/h||
 WPUPSTI019|Vitesse: %.1f milles/h||
 WPUPSTI020|%0.1f milles||
 WPUPSTI021|%0.1f km||
-WPUPSTI022|Distance de ma station: %s  Relèvement de ma station: %s||
-WPUPSTI023|Dernière position : ||
-WPUPSTI024|Données météo %c:%s||
-WPUPSTI025|Cap des vents: %s° Vitesse: %03d km/h||
-WPUPSTI026|Cap des vents: %s° Vitesse: %s milles/h||
+WPUPSTI022|Distance de ma station: %s  RelÃ¨vement de ma station: %s||
+WPUPSTI023|DerniÃ¨re position : ||
+WPUPSTI024|DonnÃ©es mÃ©tÃ©o %c:%s||
+WPUPSTI025|Cap des vents: %sÂ° Vitesse: %03d km/h||
+WPUPSTI026|Cap des vents: %sÂ° Vitesse: %s milles/h||
 WPUPSTI027|   Rafales: %03d km/h||
 WPUPSTI028|   Rafales: %s milles/h||
-WPUPSTI029|Température: %02.1f°C  ||
-WPUPSTI030|Température: %s°F   ||
-WPUPSTI031|Humidité: %s%%   ||
-WPUPSTI032| Humidex: %02.1f°C  ||
+WPUPSTI029|TempÃ©rature: %02.1fÂ°C  ||
+WPUPSTI030|TempÃ©rature: %sÂ°F   ||
+WPUPSTI031|HumiditÃ©: %s%%   ||
+WPUPSTI032| Humidex: %02.1fÂ°C  ||
 WPUPSTI033|Baro: %s hPa||
 WPUPSTI034|Neige: %0.1f (cm/24h||
 WPUPSTI035|Neige: %0.0f (pouces/24h)||
@@ -778,14 +778,14 @@ WPUPSTI039|%0.2f (mm/jour)  ||
 WPUPSTI040|%0.2f (pouces/jour)  ||
 WPUPSTI041|%0.2f (mm/depuis minuit)||
 WPUPSTI042|%0.2f (pouces/depuis minuit)||
-WPUPSTI043|Route des données: %s||
+WPUPSTI043|Route des donnÃ©es: %s||
 WPUPSTI044|Commentaire %02d/%02d %02d:%02d : %s||
 WPUPSTI045|Effacer la piste||
 WPUPSTI046|Pluie Totale: ||
 WPUPSTI047|%0.2f (mm)||
 WPUPSTI048|%0.2f (pouces)||
 WPUPSTI049|Informations suivi||
-WPUPSTI050|Messages non confirmés||
+WPUPSTI050|Messages non confirmÃ©s||
 WPUPSTI051|Info station en direct||
 WPUPSTI052|Info station version||
 WPUPSTI053|Modifier objet/article||
@@ -793,41 +793,41 @@ WPUPSTI054|Sauver piste||
 WPUPSTI055|Echo de:||
 WPUPSTI056|Activer actualisation automatique||
 WPUPSTI057|Omni-DF: %s||
-WPUPSTI058|Relèvement DF: %s||
+WPUPSTI058|RelÃ¨vement DF: %s||
 WPUPSTI059|Etat %02d/%02d %02d:%02d : %s||
-WPUPSTI060|Temp combustible: %02.1f°C  ||
-WPUPSTI061|Temp combustible: %s°F   ||
-WPUPSTI062|Humidité combustible: %s%%   ||
+WPUPSTI060|Temp combustible: %02.1fÂ°C  ||
+WPUPSTI061|Temp combustible: %sÂ°F   ||
+WPUPSTI062|HumiditÃ© combustible: %s%%   ||
 WPUPSTI063|Baro: %0.2f in Hg||
 WPUPSTI064|Chercher alerte NWS||
 WPUPSTI065|Indicatif tactique: %s||
 WPUPSTI066|Assigner un indicatif tactique||
-WPUPSTI067|Portée actuelle : %d milles||
+WPUPSTI067|PortÃ©e actuelle : %d milles||
 WPUPSTI068|nul||
-WPUPSTI069|défaut||
+WPUPSTI069|dÃ©faut||
 WPUPSTI070|HAAT||
 WPUPSTI071|omni||
-WPUPSTI072|portée||
+WPUPSTI072|portÃ©e||
 WPUPSTI073|Mauvais PHG||
 WPUPSTI074|Mauvais SHG||
-WPUPSTI075|Portée DF||
-WPUPSTI076|Pas de signal détecté||
-WPUPSTI077|Signal détecté (peut-être))||
-WPUPSTI078|Signal détecté non décodable||
-WPUPSTI079|Signal faible, parfois décodable||
-WPUPSTI080|Signal brouillé mais copiable||
-WPUPSTI081|Un peu de bruit, avec un signal facilement décodable||
+WPUPSTI075|PortÃ©e DF||
+WPUPSTI076|Pas de signal dÃ©tectÃ©||
+WPUPSTI077|Signal dÃ©tectÃ© (peut-Ãªtre))||
+WPUPSTI078|Signal dÃ©tectÃ© non dÃ©codable||
+WPUPSTI079|Signal faible, parfois dÃ©codable||
+WPUPSTI080|Signal brouillÃ© mais copiable||
+WPUPSTI081|Un peu de bruit, avec un signal facilement dÃ©codable||
 WPUPSTI082|Bon signal avec un peu de bruit||
 WPUPSTI083|Signal presque sans bruit||
 WPUPSTI084|Signal sans bruit||
-WPUPSTI085|Signal très fort sans bruit||
+WPUPSTI085|Signal trÃ¨s fort sans bruit||
 WPUPSTI086|MAUVAIS RELEVEMENT||
 WPUPSTI087|MAUVAIS NRQ||
 WPUPSTI088|Largeur de faisceau DF||
 WPUPSTI089|Longueur DF||
 WPUPSTI090|Invalide||
 WPUPSTI091|Changer la couleur de la piste||
-WPUPSTI092|Effacer relèvements DF||
+WPUPSTI092|Effacer relÃ¨vements DF||
 #
 #
 # PopUp "ALOHA Statistics"
@@ -836,22 +836,22 @@ WPUPALO002|Stations dans le cercle ALOHA: %d||
 WPUPALO003| Digis:                  %d||
 WPUPALO004| Mobiles (en mouvement): %d||
 WPUPALO005| Mobiles (autres):       %d||
-WPUPALO006| Stations météo:         %d||
+WPUPALO006| Stations mÃ©tÃ©o:         %d||
 WPUPALO007| Stations fixes:         %d||
 WPUPALO008|Dernier calcul il y a %d %s %d %s.||
-WPUPALO666|Rayon ALOHA pas encore calculé||
+WPUPALO666|Rayon ALOHA pas encore calculÃ©||
 #
 #
 # FCC-RAC Call Look up
-STIFCC0001|Recherche base de données FCC||
-STIFCC0002|Recherche base de données RAC||
+STIFCC0001|Recherche base de donnÃ©es FCC||
+STIFCC0002|Recherche base de donnÃ©es RAC||
 STIFCC0003|Nom:||
 STIFCC0004|Adresse:||
 STIFCC0005|Ville:||
 STIFCC0006|Etat:||
 STIFCC0007|Code postal:||
 STIFCC0008|License de base ||
-STIFCC0009|License avancée ||
+STIFCC0009|License avancÃ©e ||
 STIFCC0010|5 mots/min ||
 STIFCC0011|12 mots/min ||
 #
@@ -859,12 +859,12 @@ STIFCC0011|12 mots/min ||
 # FCC-RAC Call Look up
 STIFCC0100|Index FCC ancien, restauration||
 STIFCC0101|Recherche d'indicatif||
-STIFCC0102|Indicatif non trouvé !||
+STIFCC0102|Indicatif non trouvÃ© !||
 STIFCC0103|Index RAC ancien, restauration||
 #
 #
 # Band open message
-UMBNDO0001|à une distance de||
+UMBNDO0001|Ã  une distance de||
 #
 #
 # Universal Options
@@ -873,16 +873,16 @@ UNIOP00002|Annuler||
 UNIOP00003|Fermer||
 UNIOP00004|milles||
 UNIOP00005|km||
-UNIOP00006|Périphérique||
+UNIOP00006|PÃ©riphÃ©rique||
 UNIOP00007|Ajouter||
 UNIOP00008|Supprimer||
-UNIOP00009|Propriétés||
+UNIOP00009|PropriÃ©tÃ©s||
 UNIOP00010|Permettre transmission ?||
-UNIOP00011|Activer au démarrage ?||
+UNIOP00011|Activer au dÃ©marrage ?||
 UNIOP00012|km/h||
 UNIOP00013|milles/h||
-UNIOP00014|°C||
-UNIOP00015|°F||
+UNIOP00014|Â°C||
+UNIOP00015|Â°F||
 UNIOP00016|mm||
 UNIOP00017|pouces||
 UNIOP00018|mm/jour||
@@ -896,26 +896,26 @@ UNIOP00025|hPa||
 UNIOP00026|%||
 UNIOP00027|pouces Hg||
 UNIOP00028|mm Hg||
-UNIOP00029|Régler l'horloge système sur celle du GPS ?||
-UNIOP00030|Répéteur digi ?||
+UNIOP00029|RÃ©gler l'horloge systÃ¨me sur celle du GPS ?||
+UNIOP00030|RÃ©pÃ©teur digi ?||
 UNIOP00031|m||
 UNIOP00032|Appliquer|||
 UNIOP00033|Annuler||
 UNIOP00034|min||
 UNIOP00035|hr||
 UNIOP00036|jour||
-UNIOP00037|Envoyer Ctrl+E pour obtenir les données GPS?||
-UNIOP00038|Ajouter un délai||
+UNIOP00037|Envoyer Ctrl+E pour obtenir les donnÃ©es GPS?||
+UNIOP00038|Ajouter un dÃ©lai||
 #
 # PopUp "Station Chooser"
 STCHO00001|Choix de station||
 #
 # DISPLAY WX ALERT
-WPUPWXA001|Alerte météo||
-WPUPWXA002|Liste d'alertes météo||
+WPUPWXA001|Alerte mÃ©tÃ©o||
+WPUPWXA002|Liste d'alertes mÃ©tÃ©o||
 #
 # PopUp "Configure - Interfaces"
-WPUPCIF001|Interfaces installées||
+WPUPCIF001|Interfaces installÃ©es||
 WPUPCIF002|Choix du type d'interface||
 #
 # PopUp "Configure AX.25 TNC"
@@ -924,25 +924,25 @@ WPUPCAX002|Nom de l'interface AX.25||#'
 #
 # Interface device names
 IFDNL00000|Aucune||
-IFDNL00001|TNC port série||
-IFDNL00002|TNC série + GPS sur câble HSP||
-IFDNL00003|GPS port série||
-IFDNL00004|Météo port série||
+IFDNL00001|TNC port sÃ©rie||
+IFDNL00002|TNC sÃ©rie + GPS sur cÃ¢ble HSP||
+IFDNL00003|GPS port sÃ©rie||
+IFDNL00004|MÃ©tÃ©o port sÃ©rie||
 IFDNL00005|Serveur Internet||
 IFDNL00006|TNC AX25||
-IFDNL00007|GPS réseau (par gpsd)||
-IFDNL00008|Météo par réseau||
-IFDNL00009|TNC série + GPS sur câble AUX||
-IFDNL00010|TNC KISS série||
-IFDNL00011|Base de données par réseau (pas encore implémenté)||
-IFDNL00012|AGWPE par réseau||
-IFDNL00013|TNC Multi-Port KISS série||
-IFDNL00014|Base de données SQL (Experimental)||
+IFDNL00007|GPS rÃ©seau (par gpsd)||
+IFDNL00008|MÃ©tÃ©o par rÃ©seau||
+IFDNL00009|TNC sÃ©rie + GPS sur cÃ¢ble AUX||
+IFDNL00010|TNC KISS sÃ©rie||
+IFDNL00011|Base de donnÃ©es par rÃ©seau (pas encore implÃ©mentÃ©)||
+IFDNL00012|AGWPE par rÃ©seau||
+IFDNL00013|TNC Multi-Port KISS sÃ©rie||
+IFDNL00014|Base de donnÃ©es SQL (Experimental)||
 #
 # Interface device info
-IFDIN00000|%s %2d %s sur port série %s   %s||
-IFDIN00001|%s %2d %s connecté à %s:%d   %s||
-IFDIN00002|%s %2d %s avec interface nommée %s   %s||
+IFDIN00000|%s %2d %s sur port sÃ©rie %s   %s||
+IFDIN00001|%s %2d %s connectÃ© Ã  %s:%d   %s||
+IFDIN00002|%s %2d %s avec interface nommÃ©e %s   %s||
 IFDIN00003|%s %2d  %s  %s %s   %s||
 IFDIN00004|%s %2d  %s  %s %s:%d   %s||
 IFDIN00005|%s %2d  %s  %s %s   %s||
@@ -952,45 +952,45 @@ IFDIN00008|ERREUR ||
 IFDIN00009|INCONNU||
 #
 # PopUp "Interface control"
-IFPUPCT000|Contrôle d'interface||#'
-IFPUPCT001|Démarrer||
-IFPUPCT002|Arrêter||
-IFPUPCT003|Démarrer toutes||
-IFPUPCT004|Arrêter toutes||
+IFPUPCT000|ContrÃ´le d'interface||#'
+IFPUPCT001|DÃ©marrer||
+IFPUPCT002|ArrÃªter||
+IFPUPCT003|DÃ©marrer toutes||
+IFPUPCT004|ArrÃªter toutes||
 #
 # IGate control
 IGPUPCF000|Options IGate||
-IGPUPCF001|Arrêter traffic Internet||
+IGPUPCF001|ArrÃªter traffic Internet||
 IGPUPCF002|Autoriser RF vers Internet seulement||
 IGPUPCF003|Autoriser RF->Inet et Inet->RF||
 IGPUPCF004|Voie Igate -> RF   ||
 #
 # WX Station
-WXPUPSI000|Station météo||
-WXPUPSI001|Type de station météo||
-WXPUPSI002|Données courantes||
+WXPUPSI000|Station mÃ©tÃ©o||
+WXPUPSI001|Type de station mÃ©tÃ©o||
+WXPUPSI002|DonnÃ©es courantes||
 WXPUPSI003|Cap des vents||
 WXPUPSI004|Vitesse des vents||
 WXPUPSI005|Rafales||
-WXPUPSI006|Température||
-WXPUPSI007|Précipitation totale||
-WXPUPSI008|Précipitation totale journalière||
-WXPUPSI009|Baromètre||
-WXPUPSI010|Humidité||
-WXPUPSI011|Peet Bros ULTIMETER 2000 (mode acquisition de données)||
+WXPUPSI006|TempÃ©rature||
+WXPUPSI007|PrÃ©cipitation totale||
+WXPUPSI008|PrÃ©cipitation totale journaliÃ¨re||
+WXPUPSI009|BaromÃ¨tre||
+WXPUPSI010|HumiditÃ©||
+WXPUPSI011|Peet Bros ULTIMETER 2000 (mode acquisition de donnÃ©es)||
 WXPUPSI012|Peet Bros ULTIMETER II||
 WXPUPSI013|Peet Bros ULTIMETER 2000 (mode paquet)||
-WXPUPSI014|Précipitation horaire totale||
-WXPUPSI015|Total précipitation 24 hrs||
+WXPUPSI014|PrÃ©cipitation horaire totale||
+WXPUPSI015|Total prÃ©cipitation 24 hrs||
 WXPUPSI016|Qualimetrics Q-Net||
 WXPUPSI017|Peet Bros ULTIMETER 2000 (mode complet)||
-WXPUPSI018|Point de rosée||
+WXPUPSI018|Point de rosÃ©e||
 WXPUPSI019|Vents max.||
-WXPUPSI020|Facteur éolien||
+WXPUPSI020|Facteur Ã©olien||
 WXPUPSI021|Facteur humidex||
 WXPUPSI022|Baro 3 heures||
-WXPUPSI023|Température max.||
-WXPUPSI024|Température min.||
+WXPUPSI023|TempÃ©rature max.||
+WXPUPSI024|TempÃ©rature min.||
 WXPUPSI025|Radio Shack WX-200/Oregon Scientific WM-918||
 WXPUPSI026|Davis Weather Monitor II/Wizard III/Vantage Pro||
 WXPUPSI027|LaCrosse WX-23xx||
@@ -999,15 +999,15 @@ WXPUPSI028|Davis APRS Data Logger||
 # Station Lists
 LHPUPNI000|Toutes stations||
 LHPUPNI001|Stations mobiles||
-LHPUPNI002|Stations météo||
+LHPUPNI002|Stations mÃ©tÃ©o||
 LHPUPNI003|Stations locales (via TNC)||
-LHPUPNI004|Dernières stations||
+LHPUPNI004|DerniÃ¨res stations||
 LHPUPNI005|Objets et articles||
 LHPUPNI006|Mes objets et articles||
 LHPUPNI010|No.||
 LHPUPNI011|Indicatif||
 LHPUPNI012|#Paq||
-LHPUPNI013|Heure dernière pos.||
+LHPUPNI013|Heure derniÃ¨re pos.||
 LHPUPNI014|Chemin||
 LHPUPNI015|PHG||
 LHPUPNI016|Commentaires||
@@ -1037,7 +1037,7 @@ PULDNMAT02|Voir cartes alertes en desous des autres cartes||
 #
 # Error/popup messages
 POPEM00001|Erreur localisation !||
-POPEM00002|Station %s non trouvée !||
+POPEM00002|Station %s non trouvÃ©e !||
 POPEM00003|Erreur de suivi !||
 POPEM00004|Erreur d'interface !||#'
 POPEM00005|Nom de port AX.25 invalide %s||
@@ -1046,50 +1046,50 @@ POPEM00007|Indicatif invalide %s||
 POPEM00008|Destination AX25 indicatif ou relais digi invalide||
 POPEM00009|Erreur ouverture socket AX.25, %s||
 POPEM00010|Erreur liaison socket AX.25, %s||
-POPEM00011|Pas de connection à l'indicatif AX.25 %s||#'
+POPEM00011|Pas de connection Ã  l'indicatif AX.25 %s||#'
 POPEM00012|Erreur AX.25 sur sortie UI||
-POPEM00013|Problème avec fichier axports||
+POPEM00013|ProblÃ¨me avec fichier axports||
 POPEM00014|Nom de port AX.25 invalide %s||
 POPEM00015|Erreur ouverture d'interface %d Erreur majeure||#'
-POPEM00016|Erreur ouverture d'interface %d Dépassement de temps||#'
+POPEM00016|Erreur ouverture d'interface %d DÃ©passement de temps||#'
 POPEM00017|Plus d'interfaces disponible !||#'
-POPEM00018|Demande de donnée - Message à une ligne||
+POPEM00018|Demande de donnÃ©e - Message Ã  une ligne||
 POPEM00019|Transmission hors service port %d||
-POPEM00020|Erreur base de données !||
-POPEM00021|Support AX.25 non compilé dans Xastir !||#'
-POPEM00022|Erreur d'entrée !||#'
-POPEM00023|Aucun nom de lieu spécifié !||
-POPEM00024|Le nom de lieu spécifié est en cours d'utilisation !||#'
-POPEM00025|Pas trouvé !||
-POPEM00026|Suivi commencera quand elle apparaîtra||
+POPEM00020|Erreur base de donnÃ©es !||
+POPEM00021|Support AX.25 non compilÃ© dans Xastir !||#'
+POPEM00022|Erreur d'entrÃ©e !||#'
+POPEM00023|Aucun nom de lieu spÃ©cifiÃ© !||
+POPEM00024|Le nom de lieu spÃ©cifiÃ© est en cours d'utilisation !||#'
+POPEM00025|Pas trouvÃ© !||
+POPEM00026|Suivi commencera quand elle apparaÃ®tra||
 POPEM00027|Mauvaise info.  Certains champs vides ?||
 POPEM00028|Ne peut ouvrir fichier||
-POPEM00029|Trouvé !||
-POPEM00030|Symbole de station météo||
-POPEM00031|Changé en symbole météo '/_', autres possibilités:  '\_'  '/W'  et  '\W'||
+POPEM00029|TrouvÃ© !||
+POPEM00030|Symbole de station mÃ©tÃ©o||
+POPEM00031|ChangÃ© en symbole mÃ©tÃ©o '/_', autres possibilitÃ©s:  '\_'  '/W'  et  '\W'||
 POPEM00032|Attention: utilise symbole du "National Weather Service" !||
-POPEM00033|Pas de données GPS !||
-POPEM00034|TX de ma position désactivé jusqu'a réception de bonnes données GPS !||#'
+POPEM00033|Pas de donnÃ©es GPS !||
+POPEM00034|TX de ma position dÃ©sactivÃ© jusqu'a rÃ©ception de bonnes donnÃ©es GPS !||#'
 POPEM00035|Avertissement||
 POPEM00036|Avis||
-POPEM00037|Interface HSP présente: temporisation GPS augmentée||
-POPEM00038|Conflit de nom avec un Objet/Item/Station déjà existant||
-POPEM00039|Caractère illégal, remplacé par un point||
-POPEM00040|Le chemin de sortie personnalisé a été perdu||
-POPEM00041|Traitement d'un autre fichier en cours. Attendez, puis réessayez||
+POPEM00037|Interface HSP prÃ©sente: temporisation GPS augmentÃ©e||
+POPEM00038|Conflit de nom avec un Objet/Item/Station dÃ©jÃ  existant||
+POPEM00039|CaractÃ¨re illÃ©gal, remplacÃ© par un point||
+POPEM00040|Le chemin de sortie personnalisÃ© a Ã©tÃ© perdu||
+POPEM00041|Traitement d'un autre fichier en cours. Attendez, puis rÃ©essayez||
 POPEM00042|L'object ne m'appartient pas ! Essayez d'adopter l'objet d'abord.||
 POPEM00043|Ce n'est pas un objet ou article !||
-POPEM00044|Récupération de piste Findu : Échec||
-POPEM00045|Récupération de piste Findu : Terminé||
-POPEM00046|La bibliothèque Berkeley DB ne correspond pas ! Désactivation du cache des cartes.||
-POPEM00047|Toutes les transmissions sont DESACTIVEES. Les balises d'urgences ne seront PAS envoyées!||
+POPEM00044|RÃ©cupÃ©ration de piste Findu : Ã‰chec||
+POPEM00045|RÃ©cupÃ©ration de piste Findu : TerminÃ©||
+POPEM00046|La bibliothÃ¨que Berkeley DB ne correspond pas ! DÃ©sactivation du cache des cartes.||
+POPEM00047|Toutes les transmissions sont DESACTIVEES. Les balises d'urgences ne seront PAS envoyÃ©es!||
 POPEM00048|Mode balise d'URGENCE!||
 POPEM00049|MODE BALISE D'URGENCE, transmission toutes les 60 secondes!||
-POPEM00050|Interfaces ou trans.position DESACTIVEES.  Les balises d'urgences ne seront PAS envoyées!||
-POPEM00051|Réseau alternatif (ALTNET) activé (Menu Fichier->Configurer->Defauts)||
+POPEM00050|Interfaces ou trans.position DESACTIVEES.  Les balises d'urgences ne seront PAS envoyÃ©es!||
+POPEM00051|RÃ©seau alternatif (ALTNET) activÃ© (Menu Fichier->Configurer->Defauts)||
 POPEM00052|Indicatif est VIDE!||
 POPEM00053|Message est VIDE!||
-POPEM00054|Vous essayez de communiquer avec vous même!||
+POPEM00054|Vous essayez de communiquer avec vous mÃªme!||
 #
 # Jump Location
 JMLPO00001|Afficher Cartes Favorites||
@@ -1098,31 +1098,31 @@ JMLPO00003|Nouveau nom de lieu:||
 #
 # Bulletins
 BULMW00001|Bulletins||
-BULMW00002|Limiter la portée à (0, aucune limite)||
-BULMW00003|Changer portée||
+BULMW00002|Limiter la portÃ©e Ã  (0, aucune limite)||
+BULMW00003|Changer portÃ©e||
 #
 # All Message Traffic
 AMTMW00001|Tout trafic des messages||
-AMTMW00002|Limiter la portée à (0, aucune limite)||
+AMTMW00002|Limiter la portÃ©e Ã  (0, aucune limite)||
 #
 # Speech Strings
-SPCHSTR001|kilomètres||
-SPCHSTR002|mètres||
+SPCHSTR001|kilomÃ¨tres||
+SPCHSTR002|mÃ¨tres||
 SPCHSTR003|milles||
 SPCHSTR004|yards||
 SPCHSTR005|%s, distance est %d %s.||
 SPCHSTR006|%s, distance est %.1f %s.||
 SPCHSTR007|%s, distance est %d %s %s %s.||
 SPCHSTR008|%s, distance est %.1f %s %s %s.||
-SPCHSTR009|Nouvelle alerte météo||
+SPCHSTR009|Nouvelle alerte mÃ©tÃ©o||
 SPCHSTR010|Nouvel indicatif||
-SPCHSTR011|Reçu, D X, %s, à une distance de %.1f %s||
+SPCHSTR011|ReÃ§u, D X, %s, Ã  une distance de %.1f %s||
 #
 #
 SPCHDIRN00|au nord de||
 SPCHDIRS00|au sud de||
-SPCHDIRE00|à l'est de||
-SPCHDIRW00|à l'ouest de||
+SPCHDIRE00|Ã  l'est de||
+SPCHDIRW00|Ã  l'ouest de||
 SPCHDIRNE0|au nord-est de||
 SPCHDIRNW0|au nord-ouest de||
 SPCHDIRSE0|au sud-est de||
@@ -1134,31 +1134,31 @@ SYMSEL0002|Table de symboles primaire||
 SYMSEL0003|Table de symboles secondaire||
 #
 # Print Properties Dialog
-PRINT0001|Propriétés d'impression||
+PRINT0001|PropriÃ©tÃ©s d'impression||
 PRINT0002|Taille du papier||
 PRINT0003|Rotation automatique d'image||
-PRINT0004|Tourner image 90° à gauche||
+PRINT0004|Tourner image 90Â° Ã  gauche||
 PRINT0005|Proportion automatique d'image||
-PRINT0006|Échelle:||
-PRINT0007|Forcer le fond à être blanc||
+PRINT0006|Ã‰chelle:||
+PRINT0007|Forcer le fond Ã  Ãªtre blanc||
 PRINT0008|Imprimer en noir et blanc||
 PRINT0016|Inverser couleurs||
-PRINT0009|Résolution Postscript:||
-PRINT0010|Prévisualiser||
+PRINT0009|RÃ©solution Postscript:||
+PRINT0010|PrÃ©visualiser||
 PRINT0011|Imprimer dans un fichier||
 PRINT0012|Sauvegarde de l'image dans un fichier...||
 PRINT0013|Conversion Postscript...||
-PRINT0014|Création du fichier d'impression finie||
+PRINT0014|CrÃ©ation du fichier d'impression finie||
 PRINT0015|Etat d'impression||
 #
 # Print Properties Dialog
-PRINT1001|Directement à:||
+PRINT1001|Directement Ã :||
 PRINT1002|Via Previewer:||
 #
 # Locate Feature Dialog
 FEATURE001|Nom:||
 FEATURE002|Etat/Province:||
-FEATURE003|Comté:||
+FEATURE003|ComtÃ©:||
 FEATURE004|Quadrant de carte:||
 FEATURE005|Type :||
 FEATURE006|Fichier GNIS :||
@@ -1174,41 +1174,41 @@ GEOCODE002|Recherche :||
 GEOCODE003|Filtre pays :||
 GEOCODE004|Rechercher||
 GEOCODE005|Effacer||
-GEOCODE006|Résultats :||
-GEOCODE007|Aller à||
+GEOCODE006|RÃ©sultats :||
+GEOCODE007|Aller Ã ||
 GEOCODE008|Marquer||
 GEOCODE009|Fermer||
 GEOCODE010|Recherche en cours...||
-GEOCODE011|Aucun résultat trouvé||
+GEOCODE011|Aucun rÃ©sultat trouvÃ©||
 GEOCODE012|Erreur : %s||
-GEOCODE013|%d résultat(s) trouvé(s)||
-GEOCODE014|Données (C) Contributeurs OpenStreetMap||
+GEOCODE013|%d rÃ©sultat(s) trouvÃ©(s)||
+GEOCODE014|DonnÃ©es (C) Contributeurs OpenStreetMap||
 GEOCODE015|Aucun (Monde entier)||
 GEOCODE023|Service non disponible||
-GEOCODE024|Entrez un lieu à rechercher||
+GEOCODE024|Entrez un lieu Ã  rechercher||
 GEOCODE025|Vider le cache||
-GEOCODE026|Cache vidé avec succès||
-GEOCODE027|Échec du vidage du cache||
+GEOCODE026|Cache vidÃ© avec succÃ¨s||
+GEOCODE027|Ã‰chec du vidage du cache||
 GEOCODE028|Serveur Nominatim :||
-GEOCODE029|Cache activé :||
+GEOCODE029|Cache activÃ© :||
 GEOCODE030|Expiration du cache (jours) :||
 GEOCODE031|E-mail utilisateur :||
-GEOCODE032|Pays par défaut :||
-GEOCODE033|Paramètres||
+GEOCODE032|Pays par dÃ©faut :||
+GEOCODE033|ParamÃ¨tres||
 GEOCODE034|Enregistrer||
 GEOCODE035|Annuler||
 GEOCODE036|Appliquer||
-GEOCODE037|Paramètres de géocodage||
+GEOCODE037|ParamÃ¨tres de gÃ©ocodage||
 #
 # Geocoding Configuration Dialog
-GEOCFG001|Paramètres de géocodage||
+GEOCFG001|ParamÃ¨tres de gÃ©ocodage||
 GEOCFG002|URL du serveur :||
 GEOCFG003|Adresse e-mail :||
-GEOCFG004|(Optionnel mais recommandé)||
-GEOCFG005|Pays par défaut :||
+GEOCFG004|(Optionnel mais recommandÃ©)||
+GEOCFG005|Pays par dÃ©faut :||
 #
 # Coordinate Calculator Dialog
-COORD001|Calculatrice de coordonées||
+COORD001|Calculatrice de coordonÃ©es||
 COORD002|Calc||
 COORD003|Calculer||
 COORD004|Effacer||
@@ -1218,14 +1218,14 @@ COORD007|Longitude ou||
 COORD008|Zone||
 COORD009|UTM vers l'est||
 COORD010|UTM vers le nord||
-COORD011|               Degrés décimaux:  ||
-COORD012|      Degrés/Minutes décimales:  ||
-COORD013|  Degrés/Minutes/secondes déc.:  ||
+COORD011|               DegrÃ©s dÃ©cimaux:  ||
+COORD012|      DegrÃ©s/Minutes dÃ©cimales:  ||
+COORD013|  DegrÃ©s/Minutes/secondes dÃ©c.:  ||
 COORD014| Universal Transverse Mercator:  ||
-COORD015|Syst. de réf. grille militaire:  ||
+COORD015|Syst. de rÃ©f. grille militaire:  ||
 COORD016|     Grille Locator Maidenhead:  ||
-COORD017| **         Désolé, entrée non reconnue !          **||
-COORD018| **   SVP utilisez l'un de ces formats d'entrée:   **||
+COORD017| **         DÃ©solÃ©, entrÃ©e non reconnue !          **||
+COORD018| **   SVP utilisez l'un de ces formats d'entrÃ©e:   **||
 #
 #
 # Smart Beaconing Dialog
@@ -1250,22 +1250,22 @@ GAMMA002|Correction de gamma||
 #
 # 
 # Map labels font Dialog
-MAPFONT001|Changer police de caratères||
-MAPFONT002|Police de caratères||
-MAPFONT003|Police de caratère des cartes Minusc||
-MAPFONT004|Police de caratère des cartes Petite||
-MAPFONT005|Police de caratère des cartes Moyenne||
-MAPFONT006|Police de caratère des cartes Large||
-MAPFONT007|Police de caratère des cartes Enorme||
-MAPFONT008|Police de caratère des cartes Border||
-MAPFONT009|Police de caratère des menus||
-MAPFONT010|Police de caratère des Stations||
-MAPFONT011|Police de caratère de l'ID ATV||
+MAPFONT001|Changer police de caratÃ¨res||
+MAPFONT002|Police de caratÃ¨res||
+MAPFONT003|Police de caratÃ¨re des cartes Minusc||
+MAPFONT004|Police de caratÃ¨re des cartes Petite||
+MAPFONT005|Police de caratÃ¨re des cartes Moyenne||
+MAPFONT006|Police de caratÃ¨re des cartes Large||
+MAPFONT007|Police de caratÃ¨re des cartes Enorme||
+MAPFONT008|Police de caratÃ¨re des cartes Border||
+MAPFONT009|Police de caratÃ¨re des menus||
+MAPFONT010|Police de caratÃ¨re des Stations||
+MAPFONT011|Police de caratÃ¨re de l'ID ATV||
 #
 #
 #
 # Distance/Bearing on status line
-PULDNDB001|Etat dist/relèvement||
+PULDNDB001|Etat dist/relÃ¨vement||
 #
 #
 # GPS Transfer Operations
@@ -1283,7 +1283,7 @@ GPS011|Violet||
 #
 #
 # Map Properties Dialog
-MAPP001|Caractéristiques des cartes||
+MAPP001|CaractÃ©ristiques des cartes||
 MAPP002|Max   Min   Carte  Afficher USGS Auto||
 MAPP003|Zoom  Zoom  Couche Remplie  DRG  Cartes Voie/Fichier||
 MAPP004|Modifier Couche->||
@@ -1310,12 +1310,12 @@ TIME008|secondes||
 #
 # Map Caching
 CACHE001|La carte se trouve dans le cache||
-CACHE002|Chargement de la carte en mémoire||
-CACHE003|Carte non trouvée dans le cache...||
+CACHE002|Chargement de la carte en mÃ©moire||
+CACHE003|Carte non trouvÃ©e dans le cache...||
 #
 #
 # Map Screen Misc
-RANGE001|ÉCHELLE||
+RANGE001|Ã‰CHELLE||
 #
 #
 # GPS Status
@@ -1324,11 +1324,11 @@ GPSS002|DGPS||
 GPSS003|SPS valide||
 GPSS004|Invalide||
 GPSS005|Sats/vue||
-GPSS006|Repère||
-GPSS007|! Les données GPS ont plus de 30 secondes !||
+GPSS006|RepÃ¨re||
+GPSS007|! Les donnÃ©es GPS ont plus de 30 secondes !||
 GPSS008|Simulation||
 GPSS009|Manuel||
-GPSS010|Estimé||
+GPSS010|EstimÃ©||
 GPSS011|RTK flottant||
 GPSS012|RTK||
 #
@@ -1337,32 +1337,32 @@ GPSS012|RTK||
 CADPUD001|Object surface||
 CADPUD002|Etiquette surface:||
 CADPUD003|Commentaire:||
-CADPUD004|Probabilité (%):||
+CADPUD004|ProbabilitÃ© (%):||
 CADPUD005|OK||
 CADPUD006|Dialogue CAD||
-CADPUD007|Montrer/Éditer les détails||
+CADPUD007|Montrer/Ã‰diter les dÃ©tails||
 CADPUD008|Annulerl||
 CADPUD009|Effacer les objets CAD ?||
 CADPUD010|Tout effacer||
-CADPUD011|Effacer la sélection||
+CADPUD011|Effacer la sÃ©lection||
 CADPUD012|Continue||
-CADPUD013|pointilliés||
-CADPUD014|Double pointilliés||
+CADPUD013|pointilliÃ©s||
+CADPUD014|Double pointilliÃ©s||
 #
 #
 # Format strings for map metadata in top border
 #"XASTIR Map of <utm_coord> (upper left) to <utm_coord> (lower right).  UTM <grid_size> m grid, <wgs84> datum. ",
-MDATA001|Carte XASTIR de %s (haut gauche) à %s (bas droit).  UTM %d m grid, %s datum. ||
+MDATA001|Carte XASTIR de %s (haut gauche) Ã  %s (bas droit).  UTM %d m grid, %s datum. ||
 #
 #
 # Format strings for map metadata in top border
 #"XASTIR Map of <utm_coord> (upper left) to <utm_coord> (lower right).  UTM <grid_size> m grid, <wgs84> datum. ",
-MDATA002|carte XASTIR de %s (haut gauche) à %s %s (bas droit).  Lat/Long grid, %s datum.||
+MDATA002|carte XASTIR de %s (haut gauche) Ã  %s %s (bas droit).  Lat/Long grid, %s datum.||
 #
 #
 # Format strings for map metadata in top border
 #"XASTIR Map of <utm_coord> (upper left) to <utm_coord> (lower right).  UTM <grid_size> m grid, <wgs84> datum. ",
-MDATA003|Carte XASTIR Map de %s (haut gauche) à %s (bas droit).  UTM zones, %s datum.||
+MDATA003|Carte XASTIR Map de %s (haut gauche) Ã  %s (bas droit).  UTM zones, %s datum.||
 #
 # Text interpretation of integer values of database type and schema type
 # used for sql database configuration in interface_gui.c
@@ -1379,10 +1379,10 @@ XADBMST002|Postgreql avec Postgis||
 # DB_MYSQL 
 XADBMST003|MySQL (spatial)||
 # XASTIR_SCHEMA_SIMPLE]
-XASCHEMA01|Schéma simple Xastir||
+XASCHEMA01|SchÃ©ma simple Xastir||
 # XASTIR_SCHEMA_SIMPLE]
-XASCHEMA02|Schéma CAD Xastir||
+XASCHEMA02|SchÃ©ma CAD Xastir||
 # XASTIR_SCHEMA_SIMPLE]
-XASCHEMA03|Schéma complet Xastir||
+XASCHEMA03|SchÃ©ma complet Xastir||
 # XASTIR_SCHEMA_SIMPLE]
-XASCHEMA04|Schéma APRSWorld||
+XASCHEMA04|SchÃ©ma APRSWorld||

--- a/config/language-German.sys
+++ b/config/language-German.sys
@@ -2,7 +2,7 @@
 # Copyright (C) 2000-2026 The Xastir Group
 #
 # This is the German Language file used for all the prompts in xastir
-# Dies ist die deutsche Sprachdatei für Menus und Textausgaben in Xastir
+# Dies ist die deutsche Sprachdatei fÃ¼r Menus und Textausgaben in Xastir
 #
 # Creator        : Kai Altenfelder, DL3LBA <ka@suse.de>
 # Maintained by  : The Xastir Group <xastir@xastir.org>
@@ -19,8 +19,8 @@
 #
 # Warnung:
 # Einige Texte enthalten Formatierungsbefehle wie %s oder %d, diese sollten
-# beibehalten werden. Falsche Formatbefehle können zu einem Programmabsturz
-# führen.
+# beibehalten werden. Falsche Formatbefehle kÃ¶nnen zu einem Programmabsturz
+# fÃ¼hren.
 #
 # Hauptmenu
 MENUTB0001|Datei|D|
@@ -36,12 +36,12 @@ PULDNFI001|Einstellungen|E|
 PULDNFI002|Protokolldatei laden|P|
 PULDNFI003|Test|T|
 PULDNFI004|Beenden|B|
-PULDNFI007|Debug Level ändern|D|
+PULDNFI007|Debug Level Ã¤ndern|D|
 PULDNFI010|TNC protokollieren||
 PULDNFI011|Netz protokollieren||
 PULDNFI012|IGate protokollieren||
 PULDNFI013|Wetter protokollieren||
-PULDNFI014|PNG-Schnapschüsse||
+PULDNFI014|PNG-SchnapschÃ¼sse||
 PULDNFI015|Karte drucken|d|
 PULDNFI016|KML Snapshots||
 #
@@ -81,21 +81,21 @@ PULDNMP002|Automatische Karten||
 PULDNMP003|Gitter||
 PULDNMP004|Ebenen||
 PULDNMP010|Kartenbeschriftung||
-PULDNMP009|Flächen einfärben||
+PULDNMP009|FlÃ¤chen einfÃ¤rben||
 PULDNMP007|Wetterwarnung||
 PULDNMP005|Hintergrundfarbe|H|
 PULDNMP006|Textdarstellung|T|
 PULDNMP026|Symbol Umrandung|U|
-PULDNMP011|Mauszeiger-Menü|M|
-PULDNMP008|Intensität|I|
+PULDNMP011|Mauszeiger-MenÃ¼|M|
+PULDNMP008|IntensitÃ¤t|I|
 PULDNMP021|Autom. Karten - PixelKarten aus||
 PULDNMP022|Neue Karten beim Start indizieren||
-PULDNMP023|Index: Neue Karten hinzufügen|N|
+PULDNMP023|Index: Neue Karten hinzufÃ¼gen|N|
 PULDNMP024|Index: ALLE Karten reindizieren|r|
 PULDNMP025|Fonts||
 PULDNMP015|Xfontsel||
 PULDNMP027|Karten neu laden (nicht vom Cache)||
-PULDNMP028|Lösche gesamten Karten-Cache!||
+PULDNMP028|LÃ¶sche gesamten Karten-Cache!||
 PULDNMP029|Standort suchen||
 PULDNMP030|Konfiguration USGS DRG||
 PULDNMP031|Kartenrand ein||
@@ -103,14 +103,14 @@ PULDNMP032|Geocoding-Einstellungen||
 MPUPTGR017|Internet-Karten Timeout [Sek]||
 #
 # PopUp "Configure USGS DRG"
-MPUPDRG001|Wähle darzustellende Objekte:||
-MPUPDRG002|färbe Hintergrundkarten (XOR)||
+MPUPDRG001|WÃ¤hle darzustellende Objekte:||
+MPUPDRG002|fÃ¤rbe Hintergrundkarten (XOR)||
 MPUPDRG003|Schwarz||
-MPUPDRG004|Weiß||
+MPUPDRG004|WeiÃŸ||
 MPUPDRG005|Blau||
 MPUPDRG006|Rot||
 MPUPDRG007|Braun||
-MPUPDRG008|Grün||
+MPUPDRG008|GrÃ¼n||
 MPUPDRG009|Violett||
 MPUPDRG010|Gelb||
 MPUPDRG011|Hellblau||
@@ -128,22 +128,22 @@ PULDNMMC03|250k Topo|2|
 PULDNMMC04|100k Topo|1|
 PULDNMMC05|24k Topo|4|
 PULDNMMC06|Verz. expandieren|e|
-PULDNMMC07|Verz/Karten gewählt:||
-PULDNMMC08|Verz. löschen|l|
-PULDNMMC09|Alles wählen|A|
+PULDNMMC07|Verz/Karten gewÃ¤hlt:||
+PULDNMMC08|Verz. lÃ¶schen|l|
+PULDNMMC09|Alles wÃ¤hlen|A|
 #
 # Karten - Hintergrundfarbe
 PULDNMBC01|Grau||
 PULDNMBC02|Helles Grau||
 PULDNMBC03|Dunkelblau||
 PULDNMBC04|Hellblau||
-PULDNMBC05|Grün||
-PULDNMBC06|Hellgrün||
+PULDNMBC05|GrÃ¼n||
+PULDNMBC06|HellgrÃ¼n||
 PULDNMBC07|Gelb||
 PULDNMBC08|Zartes Gelb||
-PULDNMBC09|Rötliches Braun||
+PULDNMBC09|RÃ¶tliches Braun||
 PULDNMBC10|Rot||
-PULDNMBC11|Weiß||
+PULDNMBC11|WeiÃŸ||
 PULDNMBC12|Schwarz||
 #
 # Karten - Stil der Stationstexte
@@ -156,7 +156,7 @@ PULDNMSL04|DropShadow||
 PULDNMIO01|Keine Umrandung|K|
 PULDNMIO02|Schwarze Umrandung|S|
 PULDNMIO03|Graue  Umrandung|G|
-PULDNMIO04|Weiße Umrandung|W|
+PULDNMIO04|WeiÃŸe Umrandung|W|
 #
 # Schalter
 PULDNOT001|An||
@@ -172,7 +172,7 @@ PULDNDP040|Nichts||
 PULDNDP041|Meine Daten||
 PULDNDP042|TNC||
 PULDNDP027|- Direkt||
-PULDNDP043|- Über Digi||
+PULDNDP043|- Ãœber Digi||
 PULDNDP034|Netzwerk||
 PULDNDP019|Alte Daten einbeziehen||
 PULDNDP044|Stationen||
@@ -184,8 +184,8 @@ PULDNDP045|Objekte||
 PULDNDP026|- Wetter Objekte||
 PULDNDP039|- Regenmengen Objekte||
 PULDNDP031|- Andere Objekte||
-PULDNDP057|- Wählen Sie Flugzeug Objekte/Items||
-PULDNDP058|- Wählen Sie Schiff Objekte/Items||
+PULDNDP057|- WÃ¤hlen Sie Flugzeug Objekte/Items||
+PULDNDP058|- WÃ¤hlen Sie Schiff Objekte/Items||
 PULDNDP033|Anzeige filtern||
 PULDNDP010|Rufzeichen||
 PULDNDP012|Symbol||
@@ -194,7 +194,7 @@ PULDNDP007|Spur||
 PULDNDP003|Kurs||
 PULDNDP004|Geschwindigkeit||
 PULDNDP017|- kurz||
-PULDNDP002|Höhe||
+PULDNDP002|HÃ¶he||
 PULDNDP009|Wetterdaten||
 PULDNDP046|- Wetter Text||
 PULDNDP018|-- nur Temperatur||
@@ -213,25 +213,25 @@ PULDNDP037|- Kurs zeigen||
 PULDNDP038|- Symbol zeigen||
 PULDNDP005|Entfernung/Richtung||
 PULDNDP024|Alter des letzten Empfangs||
-PULDNDP015|Stationen löschen|l|
-PULDNDP016|Spuren löschen|S|
-PULDNDP025|ObjektHistorie löschen||
+PULDNDP015|Stationen lÃ¶schen|l|
+PULDNDP016|Spuren lÃ¶schen|S|
+PULDNDP025|ObjektHistorie lÃ¶schen||
 PULDNDP048|ObjektHistorie erneut laden||
-PULDNDP049|Löschen aller taktischen Calls||
-PULDNDP050|Löschen Verlauf taktische Calls||
-PULDNDP051|Nur taktische Calls wählen||
+PULDNDP049|LÃ¶schen aller taktischen Calls||
+PULDNDP050|LÃ¶schen Verlauf taktische Calls||
+PULDNDP051|Nur taktische Calls wÃ¤hlen||
 PULDNDP052|- Wegpunkte bezeichnen||
 PULDNDP055|Exportieren|E|
 PULDNDP056|Export in KML-Datei||
 #
-# Maßeinheiten
-PULDNUT001|Englische Maße||
+# MaÃŸeinheiten
+PULDNUT001|Englische MaÃŸe||
 PULDNUT002|Metrisch||
 #
 # Menu "Nachrichten"
 PULDNMG001|Schicke Nachricht an|N|
-PULDNMG002|Öffne Gruppen Nachricht|G|
-PULDNMG003|Lösche alle ausgehenden Nachrichten|L|
+PULDNMG002|Ã–ffne Gruppen Nachricht|G|
+PULDNMG003|LÃ¶sche alle ausgehenden Nachrichten|L|
 PULDQUS001|Abfrage Stationen allgemein|S|
 PULDQUS002|Abfrage Internet-Gateways|I|
 PULDQUS003|Abfrage Wetterstationen|W|
@@ -257,7 +257,7 @@ PULDNHEL01|Version|V|
 PULDNHEL02|Hilfe Index|I|
 PULDNHEL03|NOTFALL BAKEN MODUS EINSCHALTEN|E|
 PULDNHEL04|!!! NOTFALL BAKEN MODUS !!!||
-PULDNHEL05|Über Xastir||
+PULDNHEL05|Ãœber Xastir||
 #
 # Mauszeiger PopUp Menu
 POPUPMA001|Mauszeiger-Menu||
@@ -275,7 +275,7 @@ POPUPMA010|Ebene 8192||
 POPUPMA017|Ganze Welt||
 POPUPMA016|Letzte Ansicht||
 POPUPMA018|Objekt Neu||
-POPUPMA019|Objekt Ändern||
+POPUPMA019|Objekt Ã„ndern||
 POPUPMA025|Meine Station hierhin!|h|
 POPUPMA011|nach oben||
 POPUPMA012|nach unten||
@@ -288,15 +288,15 @@ POPUPMA023|Modifikationstasten aktiv!||
 POPUPMA024|Bitte Umschalt/Num/Rollen/andere Modifikationstasten ausschalten||
 POPUPMA026|Zentrieren & Zoom||
 POPUPMA027|    Breite||
-POPUPMA028|     Länge||
+POPUPMA028|     LÃ¤nge||
 POPUPMA029|CAD-Objekte zeichnen||
 POPUPMA030|Zeichnen||
-POPUPMA031|Polygon abschließen||
-POPUPMA032|CAD-Polygone löschen||
+POPUPMA031|Polygon abschlieÃŸen||
+POPUPMA032|CAD-Polygone lÃ¶schen||
 POPUPMA033|**NICHT BENUTZT**||
 POPUPMA034|Selbstdefinierter Zoom||
 POPUPMA035|10% verkleinern||
-POPUPMA036|10% vergrößern||
+POPUPMA036|10% vergrÃ¶ÃŸern||
 POPUPMA037|Bereich||
 POPUPMA038|Quadrat||
 POPUPMA039|Quadratfuss||
@@ -304,16 +304,16 @@ POPUPMA040|Quadratmeter||
 POPUPMA041|Peilung||
 POPUPMA042|Grad||
 POPUPMA043|Bearbeite mehrdeutige Position||
-POPUPMA044|Mehrdeutige Position, Ihre Position kann sich sprunghaft verändern.||
+POPUPMA044|Mehrdeutige Position, Ihre Position kann sich sprunghaft verÃ¤ndern.||
 POPUPMA045|Vordefinierte Objekte||
 POPUPMA046|CAD-Polygone||
 POPUPMA047|CAD-Objekte ein||
 POPUPMA048|CAD-Label ein||
 POPUPMA049|CAD-Kommentare ein||
 POPUPMA050|CAD-Wahrscheinlichkeit ein||
-POPUPMA051|CAD-Flächenmaß ein||
+POPUPMA051|CAD-FlÃ¤chenmaÃŸ ein||
 POPUPMA052|sq||
-POPUPMA053|Fuß||
+POPUPMA053|FuÃŸ||
 POPUPMA054|Meter||
 POPUPMA055|Meilen|
 #
@@ -334,8 +334,8 @@ BBARSTA009|Kartenebenen sind AN||
 BBARSTA010|Kartenebenen sind AUS||
 BBARSTA011|Automatische Antwort AUS!||
 BBARSTA012|Datei beendet..||
-BBARSTA013|Öffne GPS Port||
-BBARSTA014|Schließe GPS Port||
+BBARSTA013|Ã–ffne GPS Port||
+BBARSTA014|SchlieÃŸe GPS Port||
 BBARSTA015|GPS RMC String empfangen||
 BBARSTA016|GPS GGA String empfangen||
 BBARSTA017|Netz vom Host getrennt||
@@ -344,28 +344,28 @@ BBARSTA019|Suche Host %s||
 BBARSTA020|Verbunden mit %s||
 BBARSTA021|Netzverbindung fehlgeschlagen!||
 BBARSTA022|Konnte keinen Socket erstellen!||
-BBARSTA023|Keine IP für Host!||
+BBARSTA023|Keine IP fÃ¼r Host!||
 BBARSTA024|Kein Host angegeben||
 BBARSTA025|Host gefunden, verbinde %d||
 BBARSTA026|Warte auf GPS Daten via HSP..||
 BBARSTA027|Setze HSP auf TNC Daten..||
 BBARSTA028|Laden von %s||
-BBARSTA029|Öffne WX Port||
-BBARSTA030|Schließe WX Port||
-BBARSTA031|Prüfe Hostname %d||
+BBARSTA029|Ã–ffne WX Port||
+BBARSTA030|SchlieÃŸe WX Port||
+BBARSTA031|PrÃ¼fe Hostname %d||
 BBARSTA032|Dekodiere Wetterdaten||
 BBARSTA033|Echo vom Digipeater||
 BBARSTA034|Lade Wetterwarnungs-Karten||
 BBARSTA035|Warte auf GPS Daten via AUX..||
 BBARSTA036|Setze AUX auf TNC Daten..||
 BBARSTA037|Dekodiere GPS Daten||
-BBARSTA038|eigene Position geändert||
+BBARSTA038|eigene Position geÃ¤ndert||
 BBARSTA039|Indizieren %s||
 BBARSTA040|APRS(tm) Station %s||
 BBARSTA041|Warten auf GPS Daten..||
 BBARSTA042|Senden von Objekten||
 BBARSTA043|Protokoll||
-BBARSTA044|ALOHA Entfernung beträgt %d%s||
+BBARSTA044|ALOHA Entfernung betrÃ¤gt %d%s||
 BBARSTA045|Lade Symbole...||
 BBARSTA046|Lade Symbole neu...||
 BBARSTA047|Initialisiere meine Station...||
@@ -387,7 +387,7 @@ WPUPDPD008|Nur meine||
 # PopUp "Station - Station finden"
 WPUPLSP001|Finde Station||
 WPUPLSP002|Rufzeichen||
-WPUPLSP003|Groß/Klein||# ???
+WPUPLSP003|GroÃŸ/Klein||# ???
 WPUPLSP004|Exakt||# ???
 WPUPLSP005|Finde jetzt!||
 WPUPLSP006|Notfall-Suche!||
@@ -419,10 +419,10 @@ WPUPCFD023|Sende Wetter Rohdaten?||
 WPUPCFD024|Komprimiertes Format beim Senden von Objekten?||
 WPUPCFD025|Alternatives Netz?||
 WPUPCFD026|Sende Positionsmeldung in folgenden Intervallen||
-WPUPCFD027|PopUp-Fenster für neue Bekanntmachungen||
+WPUPCFD027|PopUp-Fenster fÃ¼r neue Bekanntmachungen||
 WPUPCFD028|Warnung bei Modifikationstasten||
 WPUPCFD029|Anzeige bei Entfernung Null||
-WPUPCFD030|Position Dubletten-Prüfung aus||
+WPUPCFD030|Position Dubletten-PrÃ¼fung aus||
 WPUPCFD031|Vordefinierte Objekte aus Datei laden||
 WPUPCFD032|Meine Spuren in einer Farbe||
 WPUPCFD033|ALTNET:||
@@ -432,20 +432,20 @@ WPUPCFTM01|Einstellung des Zeitverhaltens|||
 WPUPCFTM02|SendeIntervall Position [Min]||
 WPUPCFTM03|Station schemenhaft nach [Min]||
 WPUPCFTM04|Max SendeIntervall Objekt [Min]||
-WPUPCFTM05|Alte Station anzeigen für [Std]||
+WPUPCFTM05|Alte Station anzeigen fÃ¼r [Std]||
 WPUPCFTM06|GPS Abfrage alle [Sek]||
-WPUPCFTM07|Station löschen nach [Tage]||
+WPUPCFTM07|Station lÃ¶schen nach [Tage]||
 WPUPCFTM08|Timeout Pos-Voraussage [Min]||
 WPUPCFTM09|Abstand zw. seriellen Zeichen (ms)||
 WPUPCFTM10|Neue Spur Zeit (Min)||
 WPUPCFTM11|Neue Spur Intervall (Grad)||
 WPUPCFTM12|RINO -> Objekt Intervall (min), 0 = Aus||
-WPUPCFTM13|Schnapschuß-Intervall (min)||
+WPUPCFTM13|SchnapschuÃŸ-Intervall (min)||
 WPUPCFTM14|Aircraft Ghost/Clear Time (min), 0 = Disabled||
 #
 # PopUp "Koordinatensystem"
 WPUPCFC001|Koordinatensystem||
-WPUPCFC002|Koordinatensystem wählen||
+WPUPCFC002|Koordinatensystem wÃ¤hlen||
 WPUPCFC003|dd.ddddd|d|
 WPUPCFC004|dd mm.mmm|m|
 WPUPCFC005|dd mm ss.s|s|
@@ -458,9 +458,9 @@ WPUPCFG001|GPS Einstellungen||
 WPUPCFG003|GPS Port||
 WPUPCFG002|GPS Position benutzen?||
 WPUPCFG004|GPS Optionen||
-WPUPCFG005|Eigenständiger GPS||
+WPUPCFG005|EigenstÃ¤ndiger GPS||
 WPUPCFG006|TNC mit GPS verbunden (HSP Kabel)||
-WPUPCFG007|TNC mit GPS verbunden über Ctrl-E||
+WPUPCFG007|TNC mit GPS verbunden Ã¼ber Ctrl-E||
 WPUPCFG008|GPS-Abfrage alle||
 WPUPCFG009|5 Sek||
 WPUPCFG010|15 Sek||
@@ -469,12 +469,12 @@ WPUPCFG012|1 Minute||
 WPUPCFG013|2 Minuten||
 WPUPCFG014|5 Minuten||
 WPUPCFG015|10 Minuten||
-WPUPCFG016|GPS über Netzwerk verbunden||
+WPUPCFG016|GPS Ã¼ber Netzwerk verbunden||
 WPUPCFG017|gpsd Host||
 WPUPCFG018|gpsd Port||
-WPUPCFG019|GPS über Netz via gpsd||
+WPUPCFG019|GPS Ã¼ber Netz via gpsd||
 WPUPCFG020|Wiederverbinden nach Fehler?||
-WPUPCFG021|Wetter über Netzwerk||
+WPUPCFG021|Wetter Ã¼ber Netzwerk||
 WPUPCFG022|Wetterstation Host||
 WPUPCFG023|Wetterstation Port||
 #
@@ -501,17 +501,17 @@ WPUPCFT019|38400 bps||
 WPUPCFT020|57600 bps||
 WPUPCFT021|115200 bps||
 WPUPCFT022|230400 bps||
-WPUPCFT023|Einstellungen für TNC mit GPS über HSP-Kabel||
+WPUPCFT023|Einstellungen fÃ¼r TNC mit GPS Ã¼ber HSP-Kabel||
 WPUPCFT024|Datenart||
 WPUPCFT025|Automatisch||
-WPUPCFT026|Binär||
+WPUPCFT026|BinÃ¤r||
 WPUPCFT027|ASCII||
-WPUPCFT028|Einstellungen für TNC mit GPS über AUX-Kabel||
-WPUPCFT029|Einstellungen für TNC mit GPS über INVALID ENUM: %d||
+WPUPCFT028|Einstellungen fÃ¼r TNC mit GPS Ã¼ber AUX-Kabel||
+WPUPCFT029|Einstellungen fÃ¼r TNC mit GPS Ã¼ber INVALID ENUM: %d||
 WPUPCFT030|KISS TNC konfigurieren||
 WPUPCFT031|TNC Konfigurationsdateien||
-WPUPCFT032|Datei für TNC-Setup|| 
-WPUPCFT033|Datei für TNC-Shutdown||
+WPUPCFT032|Datei fÃ¼r TNC-Setup|| 
+WPUPCFT033|Datei fÃ¼r TNC-Shutdown||
 WPUPCFT034|KISS Parameter||
 WPUPCFT035|TXDelay (in 10 ms Einheiten)||
 WPUPCFT036|Persistence (0 to 255)||
@@ -519,7 +519,7 @@ WPUPCFT037|SlotTime (in 10 ms Einheiten)||
 WPUPCFT038|TxTail (in 10 ms Einheiten)||
 WPUPCFT039|Voll-Duplex||
 WPUPCFT040|Multi-Port KISS TNC konfigurieren||
-WPUPCFT041|Funkgerät Port||
+WPUPCFT041|FunkgerÃ¤t Port||
 WPUPCFT042|Unklarer UNPROTO Pfad!||
 WPUPCFT043|Bitte kuerzeren Pfad eingeben, z.B. WIDE2-2 oder RELAY,WIDE2-2||
 WPUPCFT044|Unklarer IGATE Pfad!||
@@ -529,7 +529,7 @@ WPUPCFT047|KISS-Modus beim Start aktivieren||
 # 
 # PopUp "Einstellungen Wetterstation"
 WPUPCFWX01|Einstellungen Wetterstation||
-WPUPCFWX02|Device für Wetterstation||
+WPUPCFWX02|Device fÃ¼r Wetterstation||
 WPUPCFWX03|Regenmesser-Korrektur (globale Einstellung)||
 WPUPCFWX04|.1 inch/2.5mm||
 WPUPCFWX05|.01 inch/.25mm||
@@ -543,15 +543,15 @@ WPUPCFS003|Breite||
 WPUPCFS004|Grad||
 WPUPCFS005|Min||
 WPUPCFS006|(N/S)||
-WPUPCFS007|Länge||
+WPUPCFS007|LÃ¤nge||
 WPUPCFS008|(E/W)||
 WPUPCFS009|Stations-Symbol||
 WPUPCFS010|Gruppe/Overlay||
 WPUPCFS011|Symbol||
 WPUPCFS028|Auswahl||
-WPUPCFS012|Leistung - Höhe - Gewinn - Richtung||
+WPUPCFS012|Leistung - HÃ¶he - Gewinn - Richtung||
 WPUPCFS013|Kein PHG||
-WPUPCFS014|Antennen Höhe||
+WPUPCFS014|Antennen HÃ¶he||
 WPUPCFS015|Antennen Gewinn||
 WPUPCFS016|Rundstrahler||
 WPUPCFS017|Kommentar:||
@@ -571,13 +571,13 @@ WPUPCFS029|Position in komprimiertem Format senden|k|
 POPUPOB001|Objekt/Item||
 POPUPOB002|Name||
 POPUPOB003|Objekt setzen||
-POPUPOB004|Objekt löschen||
-POPUPOB005|Objekt ändern||
+POPUPOB004|Objekt lÃ¶schen||
+POPUPOB005|Objekt Ã¤ndern||
 POPUPOB006|Item setzen||
-POPUPOB007|Flächenobjekt||
-POPUPOB008|als Flächenobjekt||
+POPUPOB007|FlÃ¤chenobjekt||
+POPUPOB008|als FlÃ¤chenobjekt||
 POPUPOB009|Helle Farben||
-POPUPOB010|Flächen füllen||
+POPUPOB010|FlÃ¤chen fÃ¼llen||
 POPUPOB011|Kreis||
 POPUPOB012|Linie-Rechts '/'||
 POPUPOB013|Linie-Links '\'||
@@ -585,14 +585,14 @@ POPUPOB014|Dreieck||
 POPUPOB015|Rechteck||
 POPUPOB016|Schwarz||
 POPUPOB017|Blau||
-POPUPOB018|Grün||
+POPUPOB018|GrÃ¼n||
 POPUPOB019|Cyan||
 POPUPOB020|Rot||
 POPUPOB021|Violett||
 POPUPOB022|Gelb||
 POPUPOB023|Grau||
 POPUPOB024|nach oben:||
-POPUPOB025|nach links (außer '/'):||
+POPUPOB025|nach links (auÃŸer '/'):||
 POPUPOB026|Korridor:||
 POPUPOB027|Allgemeine Optionen||
 POPUPOB028|Position||
@@ -600,19 +600,19 @@ POPUPOB029|als Signpost-Objekt||
 POPUPOB030|Signpost-Text||
 POPUPOB031|Signpost Objekt||
 POPUPOB032|Komprimierung einschalten||
-POPUPOB033|Item löschen||
-POPUPOB034|Item ändern||
-POPUPOB035|Höhe [ft]:||
+POPUPOB033|Item lÃ¶schen||
+POPUPOB034|Item Ã¤ndern||
+POPUPOB035|HÃ¶he [ft]:||
 POPUPOB036|Geschwindigkeit [Knoten]:||
 POPUPOB037|Kurs:||
 POPUPOB038|als Peil-Objekt||
-POPUPOB039|Leistung - Höhe - Gewinn - Richtung||
-POPUPOB040|Öffnungswinkel - Richtung||
+POPUPOB039|Leistung - HÃ¶he - Gewinn - Richtung||
+POPUPOB040|Ã–ffnungswinkel - Richtung||
 POPUPOB041|Rundstrahlantenne||
 POPUPOB042|Richtantenne||
 POPUPOB043|unbekannt||
-POPUPOB044|Objekt übernehmen||
-POPUPOB045|Item übernehmen||
+POPUPOB044|Objekt Ã¼bernehmen||
+POPUPOB045|Item Ã¼bernehmen||
 POPUPOB046|DF Peilung:||
 POPUPOB047|Wahrscheinlichkeitskreise||
 POPUPOB048|Map View Objekt||
@@ -670,15 +670,15 @@ WPUPCFIA13|Nachrichten aus Internet via TNC aussenden wenn I-Gate?||
 WPUPCFIA14|I-Gate Transaktionen protokollieren?|||
 WPUPCFIA15|FunkPort Senden||
 #
-# PopUp "Einstellungen für Audio Alarm"
-WPUPCFA001|Einstellungen für Audio Alarm||
+# PopUp "Einstellungen fÃ¼r Audio Alarm"
+WPUPCFA001|Einstellungen fÃ¼r Audio Alarm||
 WPUPCFA002|Audio Abspielkommando||
 WPUPCFA003|Alarm an||
 WPUPCFA004|abzuspielende Audio Datei||
 WPUPCFA005|Neue Station||
 WPUPCFA006|Neue Nachricht||
-WPUPCFA007|Annäherung||
-WPUPCFA008|Bandöffnung||
+WPUPCFA007|AnnÃ¤herung||
+WPUPCFA008|BandÃ¶ffnung||
 WPUPCFA009|Minimum Entfernung||
 WPUPCFA010|Maximum Entfernung||
 WPUPCFA011|Wetter Warnung||
@@ -689,22 +689,22 @@ WPUPCFSP02|Sprachausgabe bei:||
 WPUPCFSP03|Neuer Station||
 WPUPCFSP04|Neuer Nachricht||
 WPUPCFSP05|Neuer Text in Nachricht||
-WPUPCFSP06|Annäherungswarnung||
-WPUPCFSP07|Bandöffnung||
+WPUPCFSP06|AnnÃ¤herungswarnung||
+WPUPCFSP07|BandÃ¶ffnung||
 WPUPCFSP08|Neuer Wetterwarnung||
-WPUPCFSP09|Annäherung verfolgter Station||
+WPUPCFSP09|AnnÃ¤herung verfolgter Station||
 #
 # PopUp "Verfolge Station"
 WPUPTSP001|Verfolge Station|| 
 WPUPTSP002|Rufzeichen|| 
-WPUPTSP003|Groß/Klein|| 
+WPUPTSP003|GroÃŸ/Klein|| 
 WPUPTSP004|Exakt|| 
 WPUPTSP005|Verfolge jetzt!|| 
 WPUPTSP006|Verfolgung aufheben|| 
 WPUPTSP007|Spur aus dem Internet||
 WPUPTSP008|Rufzeichen||
 WPUPTSP009|Start der Spur (vor ... Std)||
-WPUPTSP010|Länge der Spur (Std)||
+WPUPTSP010|LÃ¤nge der Spur (Std)||
 #
 # PopUp "Nachrichten..."
 WPUPMSB001|Nachricht Fenster %d||
@@ -713,25 +713,25 @@ WPUPMSB003|Stationsrufzeichen:||
 WPUPMSB004|Gruppenrufzeichen:||
 WPUPMSB005|Neues/Refresh Rufzeichen||
 WPUPMSB006|Neue Gruppe||
-WPUPMSB007|Lösche alte Nachrichten||
+WPUPMSB007|LÃ¶sche alte Nachrichten||
 WPUPMSB008|Nachricht:||
 WPUPMSB009|Sende jetzt!||
 WPUPMSB010|Pfad:||
-WPUPMSB011|Wartende Nachrichten zurücknehmen||
+WPUPMSB011|Wartende Nachrichten zurÃ¼cknehmen||
 WPUPMSB012|Kick Timer||
 WPUPMSB013|Seq||
 WPUPMSB014|Typ||
 WPUPMSB015|Rundmeldung||
 WPUPMSB016|*TIMEOUT*||
 WPUPMSB017|*ABBRUCH*||
-WPUPMSB018|*ZURÜCKGEWIESEN*||
-WPUPMSB019|Pfad ändern||
+WPUPMSB018|*ZURÃœCKGEWIESEN*||
+WPUPMSB019|Pfad Ã¤ndern||
 WPUPMSB020|Standard-Pfad(e) benutzen||
 WPUPMSB021|Direkt (kein Pfad)||
 WPUPMSB022|Umgekehrter Pfad (Hinweis):||
 #
 # PopUp "Automatische Antwort"
-WPUPARM001|Automatische Antwort ändern||
+WPUPARM001|Automatische Antwort Ã¤ndern||
 WPUPARM002|Antwort:||
 #
 # PopUp "Hilfe Index"
@@ -744,18 +744,18 @@ WPUPSTI001|Stations-Info||
 WPUPSTI002|Sende Nachricht||
 WPUPSTI003|Suche in FCC Datenbank||
 WPUPSTI004|Suche in RAC Datenbank||
-WPUPSTI005|Pakete empfangen: %d     Zuletzt gehört: ||
-WPUPSTI006|Gehört über TNC auf Device %d, ||
-WPUPSTI007|Gehört ||
-WPUPSTI008|zuletzt über Lokal||
-WPUPSTI009|zuletzt über TNC auf Device %d||
-WPUPSTI010|zuletzt über Internet auf Device %d||
-WPUPSTI011|zuletzt über Datei||
-WPUPSTI012|zuletzt über Unbekannt||
-WPUPSTI013|, und hat die Position geändert||
+WPUPSTI005|Pakete empfangen: %d     Zuletzt gehÃ¶rt: ||
+WPUPSTI006|GehÃ¶rt Ã¼ber TNC auf Device %d, ||
+WPUPSTI007|GehÃ¶rt ||
+WPUPSTI008|zuletzt Ã¼ber Lokal||
+WPUPSTI009|zuletzt Ã¼ber TNC auf Device %d||
+WPUPSTI010|zuletzt Ã¼ber Internet auf Device %d||
+WPUPSTI011|zuletzt Ã¼ber Datei||
+WPUPSTI012|zuletzt Ã¼ber Unbekannt||
+WPUPSTI013|, und hat die Position geÃ¤ndert||
 WPUPSTI014|Momentane Leistung/Gewinn:||
-WPUPSTI016|Höhe: %.0f %s ||
-WPUPSTI017|Kurs: %s° ||
+WPUPSTI016|HÃ¶he: %.0f %s ||
+WPUPSTI017|Kurs: %sÂ° ||
 WPUPSTI018|Geschwindigkeit: %.1fkm/h||
 WPUPSTI019|Geschwindigkeit: %.1fmph||
 WPUPSTI020|%0.1f Meilen||
@@ -765,12 +765,12 @@ WPUPSTI023|Letzte Position: ||
 WPUPSTI024|Wetter Daten %c:%s||
 WPUPSTI025|Wind Richtung: %s Geschwindigkeit: %03d km/h||
 WPUPSTI026|Wind Richtung: %s Geschwindigkeit: %s mph||
-WPUPSTI027| Böe: %03d km/h||
-WPUPSTI028| Böe: %s mph||
-WPUPSTI029|Temperatur: %02.1f°C   ||
-WPUPSTI030|Temperatur: %s°F   ||
+WPUPSTI027| BÃ¶e: %03d km/h||
+WPUPSTI028| BÃ¶e: %s mph||
+WPUPSTI029|Temperatur: %02.1fÂ°C   ||
+WPUPSTI030|Temperatur: %sÂ°F   ||
 WPUPSTI031|Feuchte: %s%%   ||
-WPUPSTI032|rel.Feuchte: %02.1f°C  ||
+WPUPSTI032|rel.Feuchte: %02.1fÂ°C  ||
 WPUPSTI033|Luftdruck: %s hPa||
 WPUPSTI034|Schnee: %0.1f cm/24h||
 WPUPSTI035|Schnee: %0.0f Inch/24h||
@@ -783,7 +783,7 @@ WPUPSTI041|%0.2f mm/seit 0:00||
 WPUPSTI042|%0.2f Inch/seit 0:00||
 WPUPSTI043|Datenpfad: %s||
 WPUPSTI044|Kommentar %02d/%02d %02d:%02d : %s||
-WPUPSTI045|Lösche Spur||
+WPUPSTI045|LÃ¶sche Spur||
 WPUPSTI046|Regen gesamt: ||
 WPUPSTI047|%0.2f mm||
 WPUPSTI048|%0.2f Inch||
@@ -791,15 +791,15 @@ WPUPSTI049|Trace Anfrage||
 WPUPSTI050|Unbest. Nachrichten||
 WPUPSTI051|Stationsanfrage||
 WPUPSTI052|Stationsversion||
-WPUPSTI053|Objekt/Item ändern||
+WPUPSTI053|Objekt/Item Ã¤ndern||
 WPUPSTI054|Spur speichern||
-WPUPSTI055|Echo gehört von:||
+WPUPSTI055|Echo gehÃ¶rt von:||
 WPUPSTI056|Automatische Aktualisierung||
 WPUPSTI057|Omni-DF: %s||
 WPUPSTI058|Peil-Richtung: %s||
 WPUPSTI059|Status %02d/%02d %02d:%02d : %s||
-WPUPSTI060|Brennstofftemp.: %02.1f°C  ||
-WPUPSTI061|Brennstofftemp.: %s°F   ||
+WPUPSTI060|Brennstofftemp.: %02.1fÂ°C  ||
+WPUPSTI061|Brennstofftemp.: %sÂ°F   ||
 WPUPSTI062|Brennstofffeuchte: %s%%   ||
 WPUPSTI063|Baro: %0.2f in Hg||
 WPUPSTI064|NWS Wetterwarnung holen||
@@ -815,7 +815,7 @@ WPUPSTI073|PHG fehlerhaft||
 WPUPSTI074|SHG fehlerhaft||
 WPUPSTI075|DF Bereich||
 WPUPSTI076|Kein Signal erkannt||
-WPUPSTI077|mögliches Signal||
+WPUPSTI077|mÃ¶gliches Signal||
 WPUPSTI078|Signal erkannt, nicht lesbar||
 WPUPSTI079|Schwaches Signal, schlecht lesbar||
 WPUPSTI080|Verrauschtes Signal aber lesbar||
@@ -823,13 +823,13 @@ WPUPSTI081|Signal lesbar, etwas Rauschen||
 WPUPSTI082|Gutes Signal mit Restrauschen||
 WPUPSTI083|Sehr gutes Signal||
 WPUPSTI084|Hervorragendes  Signal||
-WPUPSTI085|Außerordentlich starkes Signal||
+WPUPSTI085|AuÃŸerordentlich starkes Signal||
 WPUPSTI086|SCHLECHTE PEILUNG||
 WPUPSTI087|NRQ fehlerhaft||
-WPUPSTI088|DF Öffnungswinkel||
-WPUPSTI089|DF Länge||
-WPUPSTI090|ungültig||
-WPUPSTI091|Wegfarbe ändern||
+WPUPSTI088|DF Ã–ffnungswinkel||
+WPUPSTI089|DF LÃ¤nge||
+WPUPSTI090|ungÃ¼ltig||
+WPUPSTI091|Wegfarbe Ã¤ndern||
 WPUPSTI092|Clear DF Bearing||
 #
 #
@@ -848,7 +848,7 @@ WPUPALO666|ALOHA Radius noch nicht berechnet||
 STIFCC0001|FCC Datenbank Abfrage||
 STIFCC0002|RAC Datenbank Abfrage||
 STIFCC0003|Name:||
-STIFCC0004|Straße:||
+STIFCC0004|StraÃŸe:||
 STIFCC0005|Stadt:||
 STIFCC0006|Staat:||
 STIFCC0007|PLZ:||
@@ -871,19 +871,19 @@ UMBNDO0001|in Entfernung von||
 # Allgemeine Optionen
 UNIOP00001|Ok||
 UNIOP00002|Abbrechen||
-UNIOP00003|Schließen||
+UNIOP00003|SchlieÃŸen||
 UNIOP00004|Meilen||
 UNIOP00005|km||
 UNIOP00006|Geraet||
-UNIOP00007|Hinzufügen||
-UNIOP00008|Löschen||
+UNIOP00007|HinzufÃ¼gen||
+UNIOP00008|LÃ¶schen||
 UNIOP00009|Eigenschaften||
 UNIOP00010|Senden erlaubt?||
 UNIOP00011|Beim Start aktivieren?||
 UNIOP00012|km/h||
 UNIOP00013|mph||
-UNIOP00014|°C||
-UNIOP00015|°F||
+UNIOP00014|Â°C||
+UNIOP00015|Â°F||
 UNIOP00016|mm||
 UNIOP00017|Inch||
 UNIOP00018|mm/Tag||
@@ -892,7 +892,7 @@ UNIOP00020|mm/h||
 UNIOP00021|Inch/h||
 UNIOP00022|mm ab 0:00||
 UNIOP00023|Inch ab 0:00||
-UNIOP00024|°||
+UNIOP00024|Â°||
 UNIOP00025|hPa||
 UNIOP00026|%||
 UNIOP00027|Inch Hg||
@@ -917,11 +917,11 @@ WPUPWXA002|Liste der Wetterwarnungen||
 #
 # PopUp "Einstellungen - Schnittstellen"
 WPUPCIF001|Installierte Schnittstellen||
-WPUPCIF002|Wähle Schnittstellentyp||
+WPUPCIF002|WÃ¤hle Schnittstellentyp||
 #
 # PopUp "Einstellungen AX.25 TNC"
 WPUPCAX001|Einstellungen AX.25 TNC||
-WPUPCAX002|AX.25 Gerätename||
+WPUPCAX002|AX.25 GerÃ¤tename||
 #
 # Interface device names 
 IFDNL00000|Kein||
@@ -931,19 +931,19 @@ IFDNL00003|Serieller GPS||
 IFDNL00004|Serielle Wetterstation||
 IFDNL00005|Internet Server||
 IFDNL00006|AX.25 TNC||
-IFDNL00007|GPS über Netzwerk (via gpsd)||
-IFDNL00008|Wetter über Netzwerk||
+IFDNL00007|GPS Ã¼ber Netzwerk (via gpsd)||
+IFDNL00008|Wetter Ã¼ber Netzwerk||
 IFDNL00009|Serieller TNC + GPS mit AUX-Kabel||
 IFDNL00010|Serieller KISS TNC||
-IFDNL00011|Datenbank über Netz (Noch nicht implementiert)||
-IFDNL00012|AGWPE über Netz||
+IFDNL00011|Datenbank Ã¼ber Netz (Noch nicht implementiert)||
+IFDNL00012|AGWPE Ã¼ber Netz||
 IFDNL00013|Serieller Multi-Port KISS TNC||
 IFDNL00014|SQL Datenbank (experimentell)||
 #
 # Interface device info 
 IFDIN00000|%s %2d %s an ser. Schnittstelle %s   %s||
 IFDIN00001|%s %2d %s verbunden mit %s:%d   %s||
-IFDIN00002|%s %2d %s über Geraet namens %s   %s||
+IFDIN00002|%s %2d %s Ã¼ber Geraet namens %s   %s||
 IFDIN00003|%s %2d  %s  %s %s   %s||
 IFDIN00004|%s %2d  %s  %s %s:%d   %s||
 IFDIN00005|%s %2d  %s  %s %s   %s||
@@ -972,7 +972,7 @@ WXPUPSI001|Wetterstation Typ||
 WXPUPSI002|Aktuelle Werte||
 WXPUPSI003|Windrichtung||
 WXPUPSI004|Windgeschwindigkeit||
-WXPUPSI005|Wind Böen||
+WXPUPSI005|Wind BÃ¶en||
 WXPUPSI006|Temperatur||
 WXPUPSI007|Regenmenge||
 WXPUPSI008|Regenmenge heute||
@@ -988,9 +988,9 @@ WXPUPSI017|Peet Bros ULTIMETER 2000 Type (Complete Mode)||
 WXPUPSI018|Taupunkt||
 WXPUPSI019|Wind Spitze||
 WXPUPSI020|Windauskuehlungsfaktor (Windchill)||
-WXPUPSI021|Gefühlte Temp.||
+WXPUPSI021|GefÃ¼hlte Temp.||
 WXPUPSI022|3 Std. Druck||
-WXPUPSI023|Höchsttemp.||
+WXPUPSI023|HÃ¶chsttemp.||
 WXPUPSI024|Tiefsttemp.||
 WXPUPSI025|Radio Shack WX-200/Oregon Scientific WM-918||
 WXPUPSI026|Davis Weather Monitor II/Wizard III/Vantage Pro||
@@ -1001,7 +1001,7 @@ WXPUPSI028|Davis APRS Data Logger||
 LHPUPNI000|Stationsliste||
 LHPUPNI001|Mobile Stationen||
 LHPUPNI002|Wetterstationen||
-LHPUPNI003|Lokale Stationen (über TNC)||
+LHPUPNI003|Lokale Stationen (Ã¼ber TNC)||
 LHPUPNI004|Letzte Stationen||
 LHPUPNI005|Objekte & Punkte||
 LHPUPNI006|Eigene Objekte & Punkte||
@@ -1014,26 +1014,26 @@ LHPUPNI015|PHG||
 LHPUPNI016|Kommentar||
 LHPUPNI100|CSE||
 LHPUPNI101|SPD||
-LHPUPNI102|Höhe||
+LHPUPNI102|HÃ¶he||
 LHPUPNI103|Breite||
-LHPUPNI104|Länge||
+LHPUPNI104|LÃ¤nge||
 LHPUPNI105|Pakete||
 LHPUPNI106|LSV||
 LHPUPNI107|CFMS||
 LHPUPNI108|DFMS||
 LHPUPNI200|CSE||
 LHPUPNI201|SPD||
-LHPUPNI202|Böen||
+LHPUPNI202|BÃ¶en||
 LHPUPNI203|Temp||
 LHPUPNI204|Feucht||
 LHPUPNI205|Druck||
 LHPUPNI206|Rn-h||
 LHPUPNI207|Rn-0||
 LHPUPNI208|Rn24||
-LHPUPNI209|Breite/Länge oder UTM||
+LHPUPNI209|Breite/LÃ¤nge oder UTM||
 #
 # Stil der Wetterwarnungskarten
-PULDNMAT01|Zeige Warnungen über Karten||
+PULDNMAT01|Zeige Warnungen Ã¼ber Karten||
 PULDNMAT02|Zeige Warnungen unter Karten||
 #
 # Fehlermeldungen
@@ -1041,44 +1041,44 @@ POPEM00001|Suchfehler!||
 POPEM00002|Station %s wurde nicht gefunden!||
 POPEM00003|Tracking Fehler!||
 POPEM00004|Schnittstellenfehler!||
-POPEM00005|Ungültiger AX.25 Port Name %s||
-POPEM00006|Ungültiger AX.25 Port Name %s||
-POPEM00007|Ungültiges Rufzeichen %s||
-POPEM00008|AX.25 Ziel-Rufzeichen oder Digipeater ungültig||
-POPEM00009|Kann AX.25-Socket nicht öffnen, %s||
+POPEM00005|UngÃ¼ltiger AX.25 Port Name %s||
+POPEM00006|UngÃ¼ltiger AX.25 Port Name %s||
+POPEM00007|UngÃ¼ltiges Rufzeichen %s||
+POPEM00008|AX.25 Ziel-Rufzeichen oder Digipeater ungÃ¼ltig||
+POPEM00009|Kann AX.25-Socket nicht Ã¶ffnen, %s||
 POPEM00010|Kann AX.25-Socket nicht binden, %s||
 POPEM00011|Kann AX.25-Rufzeichen nicht konnektieren, %s||
 POPEM00012|AX.25-Fehler auf Ausgang des UI||
 POPEM00013|AX.25-Problem mit axports Datei||
-POPEM00014|AX.25 ungültiger Port-Name %s||
-POPEM00015|Fehler beim Öffnen des Interface %d Hard Fail||
-POPEM00016|Fehler beim Öffnen des Interface %d Time Out||
-POPEM00017|Keine weiteren Schnittstellen verfügbar!||
+POPEM00014|AX.25 ungÃ¼ltiger Port-Name %s||
+POPEM00015|Fehler beim Ã–ffnen des Interface %d Hard Fail||
+POPEM00016|Fehler beim Ã–ffnen des Interface %d Time Out||
+POPEM00017|Keine weiteren Schnittstellen verfÃ¼gbar!||
 POPEM00018|Datenanfrage - Single Message Line||
 POPEM00019|Senden abgeschaltet bei Port %d||
 POPEM00020|Datenbankfehler!||
-POPEM00021|AX.25-Unterstützung nicht in Xastir kompiliert!||
+POPEM00021|AX.25-UnterstÃ¼tzung nicht in Xastir kompiliert!||
 POPEM00022|Eingabefehler!||
 POPEM00023|Es wurde kein Name angegeben!||
 POPEM00024|Der angegebene Name ist nicht mehr frei!||
 POPEM00025|Nicht gefunden!||
 POPEM00026|Verfolgung wird bei Erscheinen der Station aufgenommen||
 POPEM00027|Falsche Eingabe.  Einige Felder leer?||
-POPEM00028|Kann Datei nicht öffnen||
+POPEM00028|Kann Datei nicht Ã¶ffnen||
 POPEM00029|Gefunden!||
-POPEM00030|Symbol für Wetterstation||
-POPEM00031|Geändert auf Wettersymbol '/_', auch möglich:  '\_'  '/W'  und  '\W'||
+POPEM00030|Symbol fÃ¼r Wetterstation||
+POPEM00031|GeÃ¤ndert auf Wettersymbol '/_', auch mÃ¶glich:  '\_'  '/W'  und  '\W'||
 POPEM00032|Warnung: Symbol des National Weather Service wird benutzt!||
 POPEM00033|Keine GPS Daten!||
-POPEM00034|Position wird nicht gesendet bis gültige GPS-Daten!||
+POPEM00034|Position wird nicht gesendet bis gÃ¼ltige GPS-Daten!||
 POPEM00035|Warnung||
 POPEM00036|Hinweis||
-POPEM00037|HSP Interface vorhanden: GPS-Abfrageintervalle größer||
+POPEM00037|HSP Interface vorhanden: GPS-Abfrageintervalle grÃ¶ÃŸer||
 POPEM00038|Der Name steht im Konflikt mit einem bereits existierenden Objekt, einer Markierung oder Station||
-POPEM00039|Nicht zulässige Zeichen gefunden||
+POPEM00039|Nicht zulÃ¤ssige Zeichen gefunden||
 POPEM00040|Der nutzerspezifische Pfad ging verloren||
 POPEM00041|Erstelle andere Datei. Bitte etwas warten und danach neu versuchen||
-POPEM00042|Kein eigenes Objekt! Versuchen Sie erst das Obkekt zu übernehmen.||
+POPEM00042|Kein eigenes Objekt! Versuchen Sie erst das Obkekt zu Ã¼bernehmen.||
 POPEM00043|Kein Objekt/Item!||
 POPEM00044|Findu-Wegdaten: fehlgeschlagen||
 POPEM00045|Findu-Wegdaten: fertig||
@@ -1099,14 +1099,14 @@ JMLPO00003|Neuer Name:||
 #
 # "Zeige - Bekanntmachungen"
 BULMW00001|Bekanntmachungen||
-BULMW00002|Bereich einschränken auf (0: unbegrenzt)||
+BULMW00002|Bereich einschrÃ¤nken auf (0: unbegrenzt)||
 BULMW00003|neuen Bereich setzen||
 #
 # "Zeige - Nachrichten"
 AMTMW00001|Nachrichtenverkehr||
-AMTMW00002|Bereich einschränken auf (0: unbegrenzt)||
+AMTMW00002|Bereich einschrÃ¤nken auf (0: unbegrenzt)||
 #
-# Texte für Sprachsynthese
+# Texte fÃ¼r Sprachsynthese
 SPCHSTR001|kilometer||
 SPCHSTR002|meter||
 SPCHSTR003|meilen||
@@ -1117,33 +1117,33 @@ SPCHSTR007|%s, entfernung ist %d %s %s %s.||
 SPCHSTR008|%s, entfernung ist %.1f %s %s %s.||
 SPCHSTR009|neue wetterwarnung||
 SPCHSTR010|neues rufzeichen||
-SPCHSTR011|D X gehört, %s, in einer entfernung von %.1f %s||
+SPCHSTR011|D X gehÃ¶rt, %s, in einer entfernung von %.1f %s||
 #
-SPCHDIRN00|nördlich von||
-SPCHDIRS00|südlich von||
-SPCHDIRE00|östlich von||
+SPCHDIRN00|nÃ¶rdlich von||
+SPCHDIRS00|sÃ¼dlich von||
+SPCHDIRE00|Ã¶stlich von||
 SPCHDIRW00|westlich von||
-SPCHDIRNE0|nordöstlich von||
+SPCHDIRNE0|nordÃ¶stlich von||
 SPCHDIRNW0|nordwestlich von||
-SPCHDIRSE0|südöstlich von||
-SPCHDIRSW0|südwestlich von||
+SPCHDIRSE0|sÃ¼dÃ¶stlich von||
+SPCHDIRSW0|sÃ¼dwestlich von||
 #
 # Symbolauswahl Dialog
 SYMSEL0001|Symbol-Auswahl||
-SYMSEL0002|Primäre Symbol-Tabelle||
-SYMSEL0003|Sekundäre Symbol-Tabelle||
+SYMSEL0002|PrimÃ¤re Symbol-Tabelle||
+SYMSEL0003|SekundÃ¤re Symbol-Tabelle||
 #
 # Druckereinstellungen Dialog
 PRINT0001|Druck Eigenschaften||
-PRINT0002|Papiergröße||
+PRINT0002|PapiergrÃ¶ÃŸe||
 PRINT0003|Automatisch drehen
-PRINT0004|90° im Gegenuhrzeigersinn drehen||
+PRINT0004|90Â° im Gegenuhrzeigersinn drehen||
 PRINT0005|Automatisch skalieren||
 PRINT0006|Skalierung:||
-PRINT0007|Standardhintergrund durch Weiß ersetzen||
-PRINT0008|Schwarz/Weiß-Druck||
+PRINT0007|Standardhintergrund durch WeiÃŸ ersetzen||
+PRINT0008|Schwarz/WeiÃŸ-Druck||
 PRINT0016|Farben invertieren||
-PRINT0009|Postscript Auflösung:||
+PRINT0009|Postscript AuflÃ¶sung:||
 PRINT0010|Vorschau||
 PRINT0011|In Datei drucken||
 PRINT0012|Gebe Bild auf Datei aus...||
@@ -1153,7 +1153,7 @@ PRINT0015|Druckerstatus||
 #
 # Druckereinstellungen Dialog
 PRINT1001|Direkt an:||
-PRINT1002|Über Vorschau:||
+PRINT1002|Ãœber Vorschau:||
 #
 # Locate Feature Dialog
 FEATURE001|Name:||
@@ -1171,20 +1171,20 @@ FEATURE011|Geocoding Datei||
 # Geocoding Dialog (Nominatim)
 GEOCODE001|Standort suchen||
 GEOCODE002|Suchanfrage:||
-GEOCODE003|Länderfilter:||
+GEOCODE003|LÃ¤nderfilter:||
 GEOCODE004|Suchen||
-GEOCODE005|Löschen||
+GEOCODE005|LÃ¶schen||
 GEOCODE006|Ergebnisse:||
 GEOCODE007|Gehe zu||
 GEOCODE008|Markieren||
-GEOCODE009|Schließen||
-GEOCODE010|Suche läuft...||
+GEOCODE009|SchlieÃŸen||
+GEOCODE010|Suche lÃ¤uft...||
 GEOCODE011|Keine Ergebnisse gefunden||
 GEOCODE012|Fehler: %s||
 GEOCODE013|%d Ergebnis(se) gefunden||
 GEOCODE014|Daten (C) OpenStreetMap-Mitwirkende||
 GEOCODE015|Keine (Weltweit)||
-GEOCODE023|Dienst nicht verfügbar||
+GEOCODE023|Dienst nicht verfÃ¼gbar||
 GEOCODE024|Geben Sie einen Ort zum Suchen ein||
 GEOCODE025|Cache leeren||
 GEOCODE026|Cache erfolgreich geleert||
@@ -1211,18 +1211,18 @@ GEOCFG005|Standardland:||
 COORD001|Koordinatenumrechnung||
 COORD002|Umrechnen||
 COORD003|Umrechnen||
-COORD004|Löschen||
+COORD004|LÃ¶schen||
 COORD005|UTM||
 COORD006|Breitengrad oder||
-COORD007|Längengrad oder||
+COORD007|LÃ¤ngengrad oder||
 COORD008|Zone||
-COORD009|UTM östlich||
-COORD010|UTM nördlich||
+COORD009|UTM Ã¶stlich||
+COORD010|UTM nÃ¶rdlich||
 COORD011|                   Dezimal Grad: ||
 COORD012|           Grad/Dezimal Minuten: ||
 COORD013|  Grad/Minuten/Dezimal Sekunden: ||
 COORD014|  Universal Transverse Mercator: ||
-COORD015|Militärisches Koordinatensystem: ||
+COORD015|MilitÃ¤risches Koordinatensystem: ||
 COORD016|        Maidenhead Grid Locator: ||
 COORD017| **             Ihre Eingabe war fehlerhaft !            **||
 COORD018| ** Bitte nutzen Sie eines der folgenden Eingabeformate: **||
@@ -1254,7 +1254,7 @@ MAPFONT002|Fonts||
 MAPFONT003|Map Font Winzig||
 MAPFONT004|Map Font Klein||
 MAPFONT005|Map Font Mittel||
-MAPFONT006|Map Font Groß||
+MAPFONT006|Map Font GroÃŸ||
 MAPFONT007|Map Font Riesig||
 MAPFONT008|Map Font Border||
 MAPFONT009|Menu Font||
@@ -1266,13 +1266,13 @@ PULDNDB001|Entf./Richtung in Status||
 #
 #
 # GPS Transfer Operations
-GPS001|GPS-Übertragung||
+GPS001|GPS-Ãœbertragung||
 GPS002|Dateiname||
-GPS003|Farbe wählen||
+GPS003|Farbe wÃ¤hlen||
 GPS004|Rot||
-GPS005|Grün||
+GPS005|GrÃ¼n||
 GPS006|Schwarz||
-GPS007|Weiß||
+GPS007|WeiÃŸ||
 GPS008|Orange||
 GPS009|Blau||
 GPS010|Gelb||
@@ -1281,10 +1281,10 @@ GPS011|Violett||
 #
 # Karten-Eigenschaften Dialog
 MAPP001|Karten-Eigenschaften||
-MAPP002|Max   Min   Karten gefüllt  USGS automat.||
+MAPP002|Max   Min   Karten gefÃ¼llt  USGS automat.||
 MAPP003|Zoom  Zoom  Ebene  zeichnen DRG  Karte Pfad/Dateiname||
-MAPP004|Ebene ändern->||
-MAPP005|gefüllt->||
+MAPP004|Ebene Ã¤ndern->||
+MAPP005|gefÃ¼llt->||
 MAPP006|Ja ||
 MAPP007|Nein||
 MAPP008|aut.Karte->||
@@ -1318,30 +1318,30 @@ RANGE001|ENTFERNUNGS-SKALIERUNG||
 # GPS Status
 GPSS001|WAAS oder PPS||
 GPSS002|DGPS||
-GPSS003|gültig SPS||
-GPSS004|ungültig||
+GPSS003|gÃ¼ltig SPS||
+GPSS004|ungÃ¼ltig||
 GPSS005|Sats/Anzeige||
 GPSS006|Fix||
-GPSS007|!GPS-Daten sind älter als 30 Sekunden!||
+GPSS007|!GPS-Daten sind Ã¤lter als 30 Sekunden!||
 GPSS008|Simulation||
 GPSS009|Manuell||
-GPSS010|Schätzung||
+GPSS010|SchÃ¤tzung||
 GPSS011|FRTK||
 GPSS012|RTK||
 #
 #
 # Popup cad_dialog to obtain CAD object data
-CADPUD001|Flächenobjekt||
-CADPUD002|Flächen-Label:||
+CADPUD001|FlÃ¤chenobjekt||
+CADPUD002|FlÃ¤chen-Label:||
 CADPUD003|Kommentar:||
 CADPUD004|Wahrscheinlichkeit (%):||
 CADPUD005|OK||
 CADPUD006|CAD-Dialog||
-CADPUD007|Details zeigen/ändern||
+CADPUD007|Details zeigen/Ã¤ndern||
 CADPUD008|Abbrechen||
-CADPUD009|CAD-Objekte löschen?||
-CADPUD010|Alle löschen||
-CADPUD011|Ausgewählte löschen||
+CADPUD009|CAD-Objekte lÃ¶schen?||
+CADPUD010|Alle lÃ¶schen||
+CADPUD011|AusgewÃ¤hlte lÃ¶schen||
 CADPUD012|durchgezogen||
 CADPUD013|gestrichelt||
 CADPUD014|doppelt gestrichelt||
@@ -1354,7 +1354,7 @@ MDATA001|XASTIR Karte von %s (oben links) to %s (unten rechts).  UTM %d m Gitter
 #
 # Format strings for map metadata in top border
 #"XASTIR Map of <utm_coord> (upper left) to <utm_coord> (lower right).  UTM <grid_size> m grid, <wgs84> datum. ",
-MDATA002|XASTIR Karte von %s (oben links) to %s %s (unten rechts).  Breite/Länge Gitter, %s Datum.||
+MDATA002|XASTIR Karte von %s (oben links) to %s %s (unten rechts).  Breite/LÃ¤nge Gitter, %s Datum.||
 #
 #
 # Format strings for map metadata in top border

--- a/config/language-Italian.sys
+++ b/config/language-Italian.sys
@@ -6,14 +6,14 @@
 # Last Modified  : Tue 31 Aug 11:00:00 CEST 2004 by IK0YUP
 #
 # comment lines with pound signs in front are ignored
-# Il formato del file è il seguente:
+# Il formato del file Ã¨ il seguente:
 # ID (10 caratteri alfanum)|(Stringa associata all'ID)|TastiDiSceltaRapida|#commento
 # WARNING:
 # Some strings contain formatting commands like %s and %d, you should not
 # change these. Wrong format strings could produce a segfault!
 #
 #
-# Menù Principale
+# MenÃ¹ Principale
 MENUTB0001|Dati|D|
 MENUTB0002|Liste|L|
 MENUTB0004|Mappe|M|
@@ -22,7 +22,7 @@ MENUTB0006|Messaggi|e|
 MENUTB0010|Interfacce|I|
 MENUTB0009|Guida|G|
 #
-# Menù Dati
+# MenÃ¹ Dati
 PULDNFI001|Configura|C|
 PULDNFI002|Apri file di registro|A|
 PULDNFI003|Test||
@@ -36,7 +36,7 @@ PULDNFI014|Cattura schermo in PNG||
 PULDNFI015|Stampa|P|
 PULDNFI016|KML Snapshots||
 #
-# Menù Visualizza
+# MenÃ¹ Visualizza
 PULDNVI001|Bollettini|B|
 PULDNVI002|Dati Packet in arrivo|P|
 PULDNVI003|Stazioni Mobili|M|
@@ -60,9 +60,9 @@ PULDNCF002|Sistema di Coordinate|C|
 PULDNCF006|Allarmi Audio|A|
 PULDNCF007|Annunci Vocali|p|
 PULDNCF008|Salva la Configurazione Ora!|C|
-# (per unità vedere PULDNDP006)
+# (per unitÃ  vedere PULDNDP006)
 #
-# Menù Mappe
+# MenÃ¹ Mappe
 PULDNMP001|Scegli mappa|C|
 PULDNMP012|Vai alla posizione...|J|#NUOVA funzione dalla v. 0.3.2
 PULDNMP014|Localizza Elemento Mappa|E|
@@ -77,8 +77,8 @@ PULDNMP007|Mappe Allarme Meteo|W|
 PULDNMP005|Colore dello sfondo della mappa|B|
 PULDNMP006|Etichette Stazione|S|
 PULDNMP026|Stile Bordo Icone|O|
-PULDNMP011|Menù sul puntatore del mouse|M|
-PULDNMP008|Intensità Mappa|I|
+PULDNMP011|MenÃ¹ sul puntatore del mouse|M|
+PULDNMP008|IntensitÃ  Mappa|I|
 PULDNMP021|Mappe Automatche - Disabilita Mappe Raster||
 PULDNMP022|Indicizza Mappe all' Avvio||
 PULDNMP023|Indice: Aggiungi Nuove Mappe|N|
@@ -123,7 +123,7 @@ PULDNMMC07|Cartella/Mappa Selezionata:||
 PULDNMMC08|Clear Dirs|C|
 PULDNMMC09|Select All|S|
 #
-# Menù Colori dello sfondo delle mappe.
+# MenÃ¹ Colori dello sfondo delle mappe.
 PULDNMBC01|Grigio||
 PULDNMBC02|Rosa||
 PULDNMBC03|Blu mare||
@@ -154,7 +154,7 @@ PULDNOT001|Attiva||
 PULDNOT002|Disattiva||
 PULDNOT003|Breve||
 #
-# Manù Stazioni
+# ManÃ¹ Stazioni
 PULDNDP014|Localizza Stazione|L|
 PULDNDP001|Segui Stazione|T|
 PULDNDP022|Scarica il percorso da Findu||
@@ -183,15 +183,15 @@ PULDNDP012|Simboli|Y|
 PULDNDP011|- Ruota Simboli|R|
 PULDNDP007|Percorsi delle stazioni|i|
 PULDNDP003|Direzione|C|
-PULDNDP004|Velocità|S|
-PULDNDP017|- Visualizza basse velocità||
+PULDNDP004|VelocitÃ |S|
+PULDNDP017|- Visualizza basse velocitÃ ||
 PULDNDP002|Altitudine||A
 PULDNDP009|Informazioni Meteo|W|
 PULDNDP046|- Visualizza Testo Meteo||
 PULDNDP018|-- Visualizza solo Temperatura||
 PULDNDP047|- Visualizza Vento||
 PULDNDP054|Display Aloha Circle||
-PULDNDP013|Ambiguità di posizione|
+PULDNDP013|AmbiguitÃ  di posizione|
 PULDNDP008|Potenza/Guadagno|P|
 PULDNDP021|- Potenza/Guadagno - default||
 PULDNDP020|- Potenza/Guadagno - stazioni mobili||
@@ -203,7 +203,7 @@ PULDNDP036|- Visualizza Arc||
 PULDNDP037|- Visualizza Rotta||
 PULDNDP038|- Visualizza Simbolo||
 PULDNDP005|Distanza/Direzione|D|
-PULDNDP024|Visualizza Età Ultimo Rapporto||
+PULDNDP024|Visualizza EtÃ  Ultimo Rapporto||
 PULDNDP015|Elimina tutte le stazioni|C|
 PULDNDP016|Elimina tutti i percorsi|T|
 PULDNDP025|Cancella Storico Oggetti/Dettagli||
@@ -228,14 +228,14 @@ PULDQUS002|Cerca le stazioni Gateway|I|
 PULDQUS003|Cerca le stazioni meteo|W|
 PULDNMG004|Imposta risposta automatica ai messaggi in arrivo|S|
 PULDNMG005|Risposta automatica ai messaggi in arrivo|R|
-PULDNMG006|Modalità Satellite Ack|M|
+PULDNMG006|ModalitÃ  Satellite Ack|M|
 PULDNMG007|Show Pending Messages|P|
 #
 # Menu "Interfaces"
 PULDNTNT04|Interface Control||
 PULDNTNT03|Disabilita Trasmissioni: TUTTE||
 PULDNTNT05|Disabilita Trasmissioni: Mia Posizione||
-PULDNTNT06|Disabilita Trasmissioni: Oggetti/Entità||
+PULDNTNT06|Disabilita Trasmissioni: Oggetti/EntitÃ ||
 PULDNTNT11|Abilita la porta del Server||
 PULDNTNT01|Trasmetti Ora!|T|
 PULDNTNT07|Carica tracciato GPS|F|
@@ -243,7 +243,7 @@ PULDNTNT08|Carica rotte GPS|R|
 PULDNTNT09|Carica punti GPS|W|
 PULDNTNT10|Ricevi Waypoints Garmin RINO|G|
 #
-# Menù Aiuto
+# MenÃ¹ Aiuto
 PULDNHEL01|Versione di Xastir|A|
 PULDNHEL02|Indice Guida|I|
 PULDNHEL03|EMERGENCY BEACON MODE ENABLE|E|
@@ -265,9 +265,9 @@ POPUPMA009|Livello 1024||
 POPUPMA010|Livello 8192|| 
 POPUPMA017|Tutto il mondo||
 POPUPMA016|Ultima posizione e zoom||
-POPUPMA018|Oggetto/Entità->Crea||
-POPUPMA019|Oggetto/Entità->Modifica||
-POPUPMA025|Muovi La mia Stazione Quì|H|
+POPUPMA018|Oggetto/EntitÃ ->Crea||
+POPUPMA019|Oggetto/EntitÃ ->Modifica||
+POPUPMA025|Muovi La mia Stazione QuÃ¬|H|
 POPUPMA011|Sposta in alto||
 POPUPMA012|Sposta in basso||
 POPUPMA013|Sposta a sinistra||
@@ -336,7 +336,7 @@ BBARSTA020|Connesso a %s||
 BBARSTA021|Connessione fallita!||
 BBARSTA022|Non posso utilizzare la porta di rete!||
 BBARSTA023|Risoluzione IP host fallita!||
-BBARSTA024|Non è stato specificato nessun host||
+BBARSTA024|Non Ã¨ stato specificato nessun host||
 BBARSTA025|Host trovato, connessione a %d||
 BBARSTA026|Sto attendendo dati dal GPS via HSP..||
 BBARSTA027|Libero HSP, ricezione dati da TNC..||
@@ -386,14 +386,14 @@ WPUPLSP007|Ricerca su FCC/RAC||
 #
 # Configure defaults popup
 WPUPCFD001|Parametri originali||
-WPUPCFD002|Dopo quanto tempo una stazione è da considerarsi vecchia?||
+WPUPCFD002|Dopo quanto tempo una stazione Ã¨ da considerarsi vecchia?||
 WPUPCFD003|15 Minuti||
 WPUPCFD004|30 Minuti||
 WPUPCFD005|45 Minuti||
 WPUPCFD006|1 Ora||
 WPUPCFD007|90 Minuti||
 WPUPCFD008|2 Ore||
-WPUPCFD009|Dopo quanto tempo una stazione verrà cancellata?||
+WPUPCFD009|Dopo quanto tempo una stazione verrÃ  cancellata?||
 WPUPCFD010|6 Ore||
 WPUPCFD011|12 Ore||
 WPUPCFD012|1 Giorno||
@@ -422,7 +422,7 @@ WPUPCFD033|ALTNET:||
 WPUPCFTM01|Configura Temporizzazioni||
 WPUPCFTM02|Intervallo TX posizione (min)||
 WPUPCFTM03|Tempo di Ghosting della stazione (min)||
-WPUPCFTM04|Max Intervallo TX Oggetto/Entità (min)||
+WPUPCFTM04|Max Intervallo TX Oggetto/EntitÃ  (min)||
 WPUPCFTM05|Clear Time della stazione (ore)||
 WPUPCFTM06|Intervallo controllo GPS (sec)||
 WPUPCFTM07|Tempo eliminazione stazione (giorni)||
@@ -504,10 +504,10 @@ WPUPCFT031|File di configurazione del TNC||
 WPUPCFT032|Nome File configurazione TNC|| 
 WPUPCFT033|Nome File dello Shutdown TNC||
 WPUPCFT034|Parametri KISS||
-WPUPCFT035|Ritardo TX (unità di 10 ms)||
+WPUPCFT035|Ritardo TX (unitÃ  di 10 ms)||
 WPUPCFT036|Persistenza (0 to 255)||
-WPUPCFT037|SlotTime (unità di 10 ms)||
-WPUPCFT038|Coda Tx (unità di 10 ms)||
+WPUPCFT037|SlotTime (unitÃ  di 10 ms)||
+WPUPCFT038|Coda Tx (unitÃ  di 10 ms)||
 WPUPCFT039|Full Duplex||
 WPUPCFT040|Configura TNC Multi-Port KISS||
 WPUPCFT041|Porta Radio||
@@ -546,7 +546,7 @@ WPUPCFS014|Altezza antenna||
 WPUPCFS015|Guadagno antenna||
 WPUPCFS016|Omni||
 WPUPCFS017|Commenti:||
-WPUPCFS018|Ambiguità posizione||
+WPUPCFS018|AmbiguitÃ  posizione||
 WPUPCFS019|Nessuna||
 WPUPCFS020|cerchio di.11 miglia||
 WPUPCFS021|cerchio di1.15 miglia||
@@ -558,13 +558,13 @@ WPUPCFS026|cerchio di18.53 chilometri||
 WPUPCFS027|cerchio di 111.19 chilometri||
 WPUPCFS029|Invia posizioni compresse|C|
 #
-# PopUp "Oggetto/Entità"
-POPUPOB001|Oggetto/Entità||
+# PopUp "Oggetto/EntitÃ "
+POPUPOB001|Oggetto/EntitÃ ||
 POPUPOB002|Nome||
 POPUPOB003|Imposta Oggetto||
 POPUPOB004|Elimina Oggetto||
 POPUPOB005|Modifica Oggetto||
-POPUPOB006|Crea Nuova Entità||
+POPUPOB006|Crea Nuova EntitÃ ||
 POPUPOB007|Oggetto Area||
 POPUPOB008|Abilita Oggetto Area||
 POPUPOB009|Colore Brillante||
@@ -591,13 +591,13 @@ POPUPOB029|Abilita simbolo postazione||
 POPUPOB030|Dati:||
 POPUPOB031|Simbolo postazione||
 POPUPOB032|Abilita compressione||
-POPUPOB033|Elimina Entità||
-POPUPOB034|Modifica Entità||
+POPUPOB033|Elimina EntitÃ ||
+POPUPOB034|Modifica EntitÃ ||
 POPUPOB035|Altitudine (piedi):||
-POPUPOB036|Velocità (nodi):||
+POPUPOB036|VelocitÃ  (nodi):||
 POPUPOB037|Direzione:||
 POPUPOB038|Oggetto DF||
-POPUPOB039|Segnale - Altezza(HAAT) - Guadagno - Direttività||
+POPUPOB039|Segnale - Altezza(HAAT) - Guadagno - DirettivitÃ ||
 POPUPOB040|Larghezza fascio - Puntamento||
 POPUPOB041|Antenna Omni||
 POPUPOB042|Antenna Direzionale||
@@ -683,7 +683,7 @@ WPUPCFSP05|Nuovo corpo del messaggio||
 WPUPCFSP06|Allarme di vicinanza||
 WPUPCFSP07|Apertura di banda||
 WPUPCFSP08|Allarme Meteo||
-WPUPCFSP09|Avviso Prossimità Stazione Tracciata||
+WPUPCFSP09|Avviso ProssimitÃ  Stazione Tracciata||
 #
 # Track Stazione
 WPUPTSP001|Segui Stazione||
@@ -746,22 +746,22 @@ WPUPSTI012|Ascoltata l'ultima volta via Unknown||
 WPUPSTI013|, e ha cambiato posizione||
 WPUPSTI014|Potenza attuale:||
 WPUPSTI016|Altitudine: %.0f%s||
-WPUPSTI017| Direzione: %s° ||
-WPUPSTI018| Velocità: %.1f km/ora||
-WPUPSTI019| Velocità: %.1f miglia/ora||
+WPUPSTI017| Direzione: %sÂ° ||
+WPUPSTI018| VelocitÃ : %.1f km/ora||
+WPUPSTI019| VelocitÃ : %.1f miglia/ora||
 WPUPSTI020|%0.1f Miglia||
 WPUPSTI021|%0.1f chilometri||
 WPUPSTI022|Distanza dalla mia Stazione: %s, direzione rispetto alla mia stazione: %s||
 WPUPSTI023|Ultima posizione: ||
 WPUPSTI024|Dati meteorologici %c:%s||
-WPUPSTI025|Direzione del vento: %s°, Velocità: %03d km/ora||
-WPUPSTI026|Direzione del vento: %s°, Velocità: %s miglia/ora||
+WPUPSTI025|Direzione del vento: %sÂ°, VelocitÃ : %03d km/ora||
+WPUPSTI026|Direzione del vento: %sÂ°, VelocitÃ : %s miglia/ora||
 WPUPSTI027| Picco: %03d km/ora||
 WPUPSTI028| Picco: %s MPH||
-WPUPSTI029|Temperatura: %02.1f°C ||
-WPUPSTI030|Temperatura: %s°F ||
-WPUPSTI031|Umidità: %s%%  ||
-WPUPSTI032|Humidex: %02.1f°C ||
+WPUPSTI029|Temperatura: %02.1fÂ°C ||
+WPUPSTI030|Temperatura: %sÂ°F ||
+WPUPSTI031|UmiditÃ : %s%%  ||
+WPUPSTI032|Humidex: %02.1fÂ°C ||
 WPUPSTI033|Pressione: %s mb ||
 WPUPSTI034|Neve: %0.1f (cm/24ora) ||
 WPUPSTI035|Neve: %0.0f (inch/24ora) ||
@@ -782,16 +782,16 @@ WPUPSTI049|Richiesta traccia||
 WPUPSTI050|Richiesta Messaggi non Riconosciuti||
 WPUPSTI051|Richiesta Stazioni Dirette||
 WPUPSTI052|Richiesta Versione Stazione||
-WPUPSTI053|Modifica Oggetto/Entità||
+WPUPSTI053|Modifica Oggetto/EntitÃ ||
 WPUPSTI054|Registra Tracciato||
 WPUPSTI055|Ripetuto da:||
 WPUPSTI056|Abilita Aggiornamento Automatico||
 WPUPSTI057|Omni-DF: %s||
 WPUPSTI058|Puntamento DF: %s||
 WPUPSTI059|Stato %02d/%02d %02d:%02d : %s||
-WPUPSTI060|Temp Carburante: %02.1f°C  ||
-WPUPSTI061|Temp Carburante: %s°F   ||
-WPUPSTI062|Umidità Carburante: %s%%   ||
+WPUPSTI060|Temp Carburante: %02.1fÂ°C  ||
+WPUPSTI061|Temp Carburante: %sÂ°F   ||
+WPUPSTI062|UmiditÃ  Carburante: %s%%   ||
 WPUPSTI063|Pressione: %0.2f in Hg||
 WPUPSTI064|Ricevi avvisi NWS||
 WPUPSTI065|Chiamata tattica: %s||
@@ -840,7 +840,7 @@ STIFCC0001|Ricerca nel database FCC||
 STIFCC0002|Ricerca nel database RAC||
 STIFCC0003|Nome:||
 STIFCC0004|Indirizzo:||
-STIFCC0005|Città:||
+STIFCC0005|CittÃ :||
 STIFCC0006|Stato:||
 STIFCC0007|Codice Postale:||
 STIFCC0008|Informazioni base||
@@ -867,7 +867,7 @@ UNIOP00005|Chilometri||
 UNIOP00006|Periferica||
 UNIOP00007|Aggiungi||
 UNIOP00008|Cancella||
-UNIOP00009|Proprietà||
+UNIOP00009|ProprietÃ ||
 UNIOP00010|Consenti la trasmissione?||
 UNIOP00011|Attiva all'avvio?||
 UNIOP00012|km/ora||
@@ -961,22 +961,22 @@ WXPUPSI000|Stazione Meteo||
 WXPUPSI001|Tipo di Stazione meteo||
 WXPUPSI002|Dati correnti||
 WXPUPSI003|Direzione del vento||
-WXPUPSI004|Velocità del vento||
+WXPUPSI004|VelocitÃ  del vento||
 WXPUPSI005|Raffiche||
 WXPUPSI006|Temperatura||
 WXPUPSI007|Pioggia totale||
 WXPUPSI008|Pioggia totale odierna||
 WXPUPSI009|Pressione||
-WXPUPSI010|Umidità||
-WXPUPSI011|Peet Bros ULTIMETER 2000 (Modalità Data Logging)||
+WXPUPSI010|UmiditÃ ||
+WXPUPSI011|Peet Bros ULTIMETER 2000 (ModalitÃ  Data Logging)||
 WXPUPSI012|Peet Bros ULTIMETER II ||
-WXPUPSI013|Peet Bros ULTIMETER 2000 (Modalità Packet)||
+WXPUPSI013|Peet Bros ULTIMETER 2000 (ModalitÃ  Packet)||
 WXPUPSI014|Pioggia (ultima ora)||
 WXPUPSI015|Pioggia (24 ore)||
 WXPUPSI016|Qualimetrics Q-Net||
 WXPUPSI017|Peet Bros ULTIMETER 2000 Type (Complete Mode)||
 WXPUPSI018|Temp.rugiada||
-WXPUPSI019|Velocità massima vento||
+WXPUPSI019|VelocitÃ  massima vento||
 WXPUPSI020|Vento Freddo||
 WXPUPSI021|Indice Termico||
 WXPUPSI022|Pressione ultime 3 Ore||
@@ -1015,7 +1015,7 @@ LHPUPNI200|CSE||
 LHPUPNI201|SPD||
 LHPUPNI202|GST||
 LHPUPNI203|Temperatura||
-LHPUPNI204|Umidità||
+LHPUPNI204|UmiditÃ ||
 LHPUPNI205|Pressione||
 LHPUPNI206|RN-H||
 LHPUPNI207|RNSM||
@@ -1045,16 +1045,16 @@ POPEM00015|Errore nell'apertura dell'interfaccia %d (Fallito)||
 POPEM00016|Errore nell'apertura dell'interfaccia %d (Tempo scaduto)||
 POPEM00017|Non sono disponibili altre interfacce!||
 POPEM00018|Richiesta dati - Messaggio su linea singola|
-POPEM00019|La trasmissione dalla porta %d è disattivata|
+POPEM00019|La trasmissione dalla porta %d Ã¨ disattivata|
 POPEM00020|Errore del Database!|
 POPEM00021|Supporto AX.25 non compilato in Xastir!||
 POPEM00022|Errore di input!|
 POPEM00023|Non e' stato specificato alcun nome per questo punto!|
-POPEM00024|Il nome assegnato al punto è già in uso!|
+POPEM00024|Il nome assegnato al punto Ã¨ giÃ  in uso!|
 POPEM00025|Non trovato!||
-POPEM00026|Il tracciamento verrà visualizzato quando appare||
+POPEM00026|Il tracciamento verrÃ  visualizzato quando appare||
 POPEM00027|Informazione non completa. Campi vuoti?||
-POPEM00028|Non è possibile aprire il file||
+POPEM00028|Non Ã¨ possibile aprire il file||
 POPEM00029|Trovato!||
 POPEM00030|Simbolo Stazione Meteo||
 POPEM00031|Cambiato al simbolo Meteo '/_', altre opzioni:  '\_'  '/W'  e  '\W'||
@@ -1101,10 +1101,10 @@ SPCHSTR001|chilometri||
 SPCHSTR002|metri||
 SPCHSTR003|miglia||
 SPCHSTR004|yards||
-SPCHSTR005|%s, distanza è %d %s.||
-SPCHSTR006|%s, distanza è %.1f %s.||
-SPCHSTR007|%s, distanza è %d %s %s %s.||
-SPCHSTR008|%s, distanza è %.1f %s %s %s.||
+SPCHSTR005|%s, distanza Ã¨ %d %s.||
+SPCHSTR006|%s, distanza Ã¨ %.1f %s.||
+SPCHSTR007|%s, distanza Ã¨ %d %s %s %s.||
+SPCHSTR008|%s, distanza Ã¨ %.1f %s %s %s.||
 SPCHSTR009|Nuovo Allarme Meteo||
 SPCHSTR010|Nuovo Nominativo||
 SPCHSTR011|Ascoltato, D X, %s, alla distanza di %.1f %s||
@@ -1124,10 +1124,10 @@ SYMSEL0002|Tabella Primaria||
 SYMSEL0003|Tabella Secondaria||
 #
 # Finestra di dialogo proprieta di stampa
-PRINT0001|Proprietà di Stampa||
+PRINT0001|ProprietÃ  di Stampa||
 PRINT0002|Formato Carta||
 PRINT0003|Ruota Immagine automaticamente
-PRINT0004|Ruota Immagine di 90° in senso antiorario||
+PRINT0004|Ruota Immagine di 90Â° in senso antiorario||
 PRINT0005|Ridimensiona immagine||
 PRINT0006|Scala:||
 PRINT0007|Sfondo bianco||
@@ -1221,11 +1221,11 @@ COORD018| **   Please use one of the following input formats:   **||
 # Smart Beaconing Dialog
 SMARTB001|SmartBeaconing||
 SMARTB002|Tasso Alto (secs):||
-SMARTB003|Alta Velocità (mph):||
-SMARTB004|Alta Velocità (kmh):||
+SMARTB003|Alta VelocitÃ  (mph):||
+SMARTB004|Alta VelocitÃ  (kmh):||
 SMARTB005|Tasso Basso (mins):||
-SMARTB006|Bassa Velocità (mph):||
-SMARTB007|Bassa Velocità (kmh):||
+SMARTB006|Bassa VelocitÃ  (mph):||
+SMARTB007|Bassa VelocitÃ  (kmh):||
 SMARTB008|Giro Minimo (gradi):||
 SMARTB009|Inclinazione Giro:||
 SMARTB010|Tempo di Attesa (secondi):||
@@ -1270,7 +1270,7 @@ GPS011|Viola||
 #
 #
 # Map Properties Dialog
-MAPP001|Proprietà Mappa||
+MAPP001|ProprietÃ  Mappa||
 MAPP002|Max   Min  Disegna Mappa USGS Auto||
 MAPP003|Zoom  Zoom Livello Riempi DRG Map  Percorso/Nome File||
 MAPP004|Cambia Livello->||

--- a/config/language-Portuguese.sys
+++ b/config/language-Portuguese.sys
@@ -54,7 +54,7 @@ PULDNVI015|GPS Status||
 PULDNVI016|ALOHA Statistics||
 #
 # Menu de configuracao
-PULDNCF004|Estação|E|
+PULDNCF004|EstaÃ§Ã£o|E|
 PULDNCF001|Pre-definidos|P|
 PULDNCF003|Momento certo|T|
 PULDNCF002|Sistema de coordenadas|S|
@@ -91,7 +91,7 @@ PULDNMP028|Flush Entire Map Cache!||
 PULDNMP029|Pesquisar local||
 PULDNMP030|Configure USGS DRG||
 PULDNMP031|Enable Map Border||
-PULDNMP032|Configurações de geocodificação||
+PULDNMP032|ConfiguraÃ§Ãµes de geocodificaÃ§Ã£o||
 MPUPTGR017|Internet Map Timeout (sec)||
 #
 # PopUp "Configure USGS DRG"
@@ -176,7 +176,7 @@ PULDNDP045|Mostrar objectos/items||
 PULDNDP026|- Mostrar objectos/items metereologicos||
 PULDNDP039|- Mostrar objectos de medida de agua/Items||
 PULDNDP031|- Mostrar outros objectos/Items||
-PULDNDP057|- Selecionar objetos avião / Itens||
+PULDNDP057|- Selecionar objetos aviÃ£o / Itens||
 PULDNDP058|- Seleccione navio Objetos / Itens||
 PULDNDP033|Filtrar monitor||
 PULDNDP010|Mostrar indicativo|i|
@@ -334,7 +334,7 @@ BBARSTA017|Rede desligada do servidor||
 BBARSTA018|Ligacao fechada por excesso de tempo!||
 BBARSTA019|A procurar servidor %s||
 BBARSTA020|Ligado a %s||
-BBARSTA021|Falha na ligacao à rede!||
+BBARSTA021|Falha na ligacao Ã  rede!||
 BBARSTA022|Pode nao ligar ao socket!||
 BBARSTA023|Nao ha IP para o servidor!||
 BBARSTA024|Nao ha servidor especificado||
@@ -366,7 +366,7 @@ BBARSTA049|Reading tiles...||
 BBARSTA050|Downloading tiles...||
 BBARSTA051|Downloading tile %li of %li||
 #
-# Visualização do trafego de packet
+# VisualizaÃ§Ã£o do trafego de packet
 WPUPDPD001|Visualizacao do trafego||
 WPUPDPD002|So dados do TNC||
 WPUPDPD003|So dados da rede||
@@ -682,7 +682,7 @@ WPUPCFSP03|&lt;- Anuncia nova estacao||
 WPUPCFSP04|&lt;- Anuncia alerta de nova mensagem||
 WPUPCFSP05|&lt;- Anuncia corpo de nova mensagem||
 WPUPCFSP06|&lt;- Anuncia a proximidade de estacoes||
-WPUPCFSP07|&lt;- Anuncia DX condição de banda aberta||
+WPUPCFSP07|&lt;- Anuncia DX condiÃ§Ã£o de banda aberta||
 WPUPCFSP08|&lt;- Anuncia alerta sobre condicoes do tempo||
 WPUPCFSP09|Alerta de proximidade da estacao rastreada||
 #
@@ -705,7 +705,7 @@ WPUPMSB003|Indicativo de estacao:||
 WPUPMSB004|Indicativos de grupos:||
 WPUPMSB005|Novo/Refresh indicativo||
 WPUPMSB006|Novo grupo||
-WPUPMSB007|Limpar história da mensagem||
+WPUPMSB007|Limpar histÃ³ria da mensagem||
 WPUPMSB008|Mensagem:||
 WPUPMSB009|Enviar agora!||
 WPUPMSB010|Encaminhamento:||
@@ -740,29 +740,29 @@ WPUPSTI005|%d: pacotes recebidos, ultimo recebido na data: ||
 WPUPSTI006|Ouvido via TNC no dispositivo: %d, ||
 WPUPSTI007|Ouvido ||
 WPUPSTI008|Ultima vez via local||
-WPUPSTI009|UÚltima vez via TNC no dispositivo: %d||
+WPUPSTI009|UÃšltima vez via TNC no dispositivo: %d||
 WPUPSTI010|Ultima vez via internet no dispositivo: %d||
 WPUPSTI011|Ultima vez via ficheiro||
 WPUPSTI012|Ultima vez via desconhecida||
 WPUPSTI013|, e mudou de posicao||
 WPUPSTI014|Actual potencia/ganho:||
 WPUPSTI016|Altitude: %.1f%s ||
-WPUPSTI017|Curso: %s° ||
+WPUPSTI017|Curso: %sÂ° ||
 WPUPSTI018|Velocidade: %.1f km/h||
 WPUPSTI019|Velocidade: %.1f mph||
 WPUPSTI020|%0.1f milhas||
 WPUPSTI021|%0.1f km||
-WPUPSTI022|Distancia desde a minha estacaão %s, curso desde a minha estacao %s||
+WPUPSTI022|Distancia desde a minha estacaÃ£o %s, curso desde a minha estacao %s||
 WPUPSTI023|Ultima posicao: ||
 WPUPSTI024|Dados da estacao meteorologica %c:%s||
-WPUPSTI025|Curso do vento: %s°  Velocidade: %03d km/h||
-WPUPSTI026|Curso do vento: %s°  Velocidade: %s mph||
+WPUPSTI025|Curso do vento: %sÂ°  Velocidade: %03d km/h||
+WPUPSTI026|Curso do vento: %sÂ°  Velocidade: %s mph||
 WPUPSTI027| Rajada: %03d Km/h||
 WPUPSTI028| Rajada: %s mph||
-WPUPSTI029|Temperatura: %02.1f°C   ||
-WPUPSTI030|Temperatura: %s°F   ||
+WPUPSTI029|Temperatura: %02.1fÂ°C   ||
+WPUPSTI030|Temperatura: %sÂ°F   ||
 WPUPSTI031|Humidade: %s%%   ||
-WPUPSTI032|Indice da humidade: %02.1f°C  ||
+WPUPSTI032|Indice da humidade: %02.1fÂ°C  ||
 WPUPSTI033|Pressao barometrica: %s mb||
 WPUPSTI034|Neve: %0.1f (cm/24h)||
 WPUPSTI035|Neve: %0.0f (plg/24h)||
@@ -790,8 +790,8 @@ WPUPSTI056|Activar actualizacao automatica||
 WPUPSTI057|Omni-DF: %s||
 WPUPSTI058|DF dirigido: %s||
 WPUPSTI059|Estados %02d/%02d %02d:%02d : %s||
-WPUPSTI060|Temp do combustivel: %02.1f°C  ||
-WPUPSTI061|Temp do combustivel: %s°F   ||
+WPUPSTI060|Temp do combustivel: %02.1fÂ°C  ||
+WPUPSTI061|Temp do combustivel: %sÂ°F   ||
 WPUPSTI062|Mistura do combustevel: %s%%   ||
 WPUPSTI063|Baro: %0.2f em Hg||
 WPUPSTI064|Procurar alerta de NWS||
@@ -840,7 +840,7 @@ WPUPALO666|ALOHA radius not calculated yet||
 STIFCC0001|Procurar FCC banco de datos||
 STIFCC0002|Procurar RAC banco de datos||
 STIFCC0003|Nome:||
-STIFCC0004|Rua/Avª:||
+STIFCC0004|Rua/AvÂª:||
 STIFCC0005|Cidade:||
 STIFCC0006|Estado:||
 STIFCC0007|Codigo postal:||
@@ -957,7 +957,7 @@ IGPUPCF002|So permite trafego de RF para Inet||
 IGPUPCF003|Permite trafego de RF->Inet e Inet->RF||
 IGPUPCF004|Caminho Igate -> RF   ||
 #
-# Estação meteorologica
+# EstaÃ§Ã£o meteorologica
 WXPUPSI000|Estacao meteorologica||
 WXPUPSI001|Tipo de estacao meteorologica||
 WXPUPSI002|Datos actuais||
@@ -1053,7 +1053,7 @@ POPEM00022|Erro de entrada!|
 POPEM00023|Nome de localizacao nao especificada!|
 POPEM00024|Nome de localizacao especificada em uso!|
 POPEM00025|Nao encontrado!||
-POPEM00026|O rastreamento começara quando ele aparecer||
+POPEM00026|O rastreamento comeÃ§ara quando ele aparecer||
 POPEM00027|Info impropia. Alguns campos vazios?||
 POPEM00028|Nao se pode abrir o ficheiro||
 POPEM00029|Encontrado!||
@@ -1119,7 +1119,7 @@ SPCHDIRNW0|nordoeste of||
 SPCHDIRSE0|sudeste of||
 SPCHDIRSW0|sudoeste of||
 #
-# Dialogo da seleção do simbolo
+# Dialogo da seleÃ§Ã£o do simbolo
 SYMSEL0001|Selecionar simbolo||
 SYMSEL0002|Tabela de simbolo primario||
 SYMSEL0003|Tabela de simbolo secundario||
@@ -1128,7 +1128,7 @@ SYMSEL0003|Tabela de simbolo secundario||
 PRINT0001|Propriedades da impressora||
 PRINT0002|Largura do papel||
 PRINT0003|Auto-rodar imagem
-PRINT0004|Rodar imagem 90° CCW||
+PRINT0004|Rodar imagem 90Â° CCW||
 PRINT0005|Auto-balancear imagem||
 PRINT0006|Balanca:||
 PRINT0007|Forcar a pre-definida cor de fundo a branco||
@@ -1162,7 +1162,7 @@ FEATURE011|Geocoding File||
 # Geocoding Dialog (Nominatim)
 GEOCODE001|Pesquisar local||
 GEOCODE002|Consulta de pesquisa:||
-GEOCODE003|Filtro de país:||
+GEOCODE003|Filtro de paÃ­s:||
 GEOCODE004|Pesquisar||
 GEOCODE005|Limpar||
 GEOCODE006|Resultados:||
@@ -1175,28 +1175,28 @@ GEOCODE012|Erro: %s||
 GEOCODE013|%d resultado(s) encontrado(s)||
 GEOCODE014|Dados (C) Colaboradores do OpenStreetMap||
 GEOCODE015|Nenhum (Mundial)||
-GEOCODE023|Serviço não disponível||
+GEOCODE023|ServiÃ§o nÃ£o disponÃ­vel||
 GEOCODE024|Digite um local para pesquisar||
 GEOCODE025|Limpar cache||
 GEOCODE026|Cache limpo com sucesso||
 GEOCODE027|Falha ao limpar o cache||
 GEOCODE028|Servidor Nominatim:||
 GEOCODE029|Cache habilitado:||
-GEOCODE030|Expiração do cache (dias):||
-GEOCODE031|E-mail do usuário:||
-GEOCODE032|País padrão:||
-GEOCODE033|Configurações||
+GEOCODE030|ExpiraÃ§Ã£o do cache (dias):||
+GEOCODE031|E-mail do usuÃ¡rio:||
+GEOCODE032|PaÃ­s padrÃ£o:||
+GEOCODE033|ConfiguraÃ§Ãµes||
 GEOCODE034|Salvar||
 GEOCODE035|Cancelar||
 GEOCODE036|Aplicar||
-GEOCODE037|Configurações de geocodificação||
+GEOCODE037|ConfiguraÃ§Ãµes de geocodificaÃ§Ã£o||
 #
 # Geocoding Configuration Dialog
-GEOCFG001|Configurações de geocodificação||
+GEOCFG001|ConfiguraÃ§Ãµes de geocodificaÃ§Ã£o||
 GEOCFG002|URL do servidor:||
-GEOCFG003|Endereço de e-mail:||
+GEOCFG003|EndereÃ§o de e-mail:||
 GEOCFG004|(Opcional mas recomendado)||
-GEOCFG005|País padrão:||
+GEOCFG005|PaÃ­s padrÃ£o:||
 #
 # Dialogo do calculo de coordenadas
 COORD001|Calcular coordenadas||

--- a/config/language-Spanish.sys
+++ b/config/language-Spanish.sys
@@ -1,20 +1,20 @@
 # Copyright (C) 2000-2026 The Xastir Group
 #
-# Este es el archivo del Lenguaje Español usado para todas, consultas en Xastir.
+# Este es el archivo del Lenguaje EspaÃ±ol usado para todas, consultas en Xastir.
 #
 # Creador        : por Jose R. Marte A. <hi8gn@amsat.org>
 # Mantenido por  : El Xastir Grupo <xastir@xastir.org>
-# Ult. Revisión  : 05/20/2003, Por Jose R. Marte A. <hi8gn@amsat.org>
+# Ult. RevisiÃ³n  : 05/20/2003, Por Jose R. Marte A. <hi8gn@amsat.org>
 #
-# Líneas de comentarios con un signo de libra en frente son ignorado
+# LÃ­neas de comentarios con un signo de libra en frente son ignorado
 # El formato del archivo es como sigue:
-# Id (10 caractéres alfa numérico)|(Cadena asociada con id)|TeclaRápida|#comentario
+# Id (10 caractÃ©res alfa numÃ©rico)|(Cadena asociada con id)|TeclaRÃ¡pida|#comentario
 #
 # AVISO:
 # Algunas cadenas de letras contienen comando de formato como %s y %d, usted no
-# debería cambiar eso. Cadena de formatos errados podrían producir un segfault!
+# deberÃ­a cambiar eso. Cadena de formatos errados podrÃ­an producir un segfault!
 #
-# Menú Principal
+# MenÃº Principal
 MENUTB0001|Archivo|A|
 MENUTB0002|Visualizar|V|
 MENUTB0004|Mapas|M|
@@ -23,48 +23,48 @@ MENUTB0006|Mensajes|e|
 MENUTB0010|Interfaces|I|
 MENUTB0009|Ayuda|y|
 #
-# Menú archivo
+# MenÃº archivo
 PULDNFI001|Configurar|C|
-PULDNFI002|Abrir Bitácora|B|
+PULDNFI002|Abrir BitÃ¡cora|B|
 PULDNFI003|Prueba|P|
 PULDNFI004|Salir|S|
-PULDNFI007|Cambia nivel Depuración|D|
-PULDNFI010|Bitácora del TNC|T|
-PULDNFI011|Bitácora de Internet|I|
-PULDNFI012|Bitácora del I-Gate|G|
-PULDNFI013|Bitácora del WX|W|
-PULDNFI014|Activa PNG Instantánea||
+PULDNFI007|Cambia nivel DepuraciÃ³n|D|
+PULDNFI010|BitÃ¡cora del TNC|T|
+PULDNFI011|BitÃ¡cora de Internet|I|
+PULDNFI012|BitÃ¡cora del I-Gate|G|
+PULDNFI013|BitÃ¡cora del WX|W|
+PULDNFI014|Activa PNG InstantÃ¡nea||
 PULDNFI015|Imprimir Mapa|P|
 PULDNFI016|KML Snapshots||
 #
-# Menú visor
+# MenÃº visor
 PULDNVI001|Boletines|B|
 PULDNVI002|Datos entrantes|D|
-PULDNVI003|Estaciones Móviles|M|
+PULDNVI003|Estaciones MÃ³viles|M|
 PULDNVI004|Todas las Estaciones|T|
 PULDNVI009|Estaciones Locales|L|
-PULDNVI012|Últimas Estaciones|U|
-PULDNVI005|Estaciones Meteorológicas|E|
-PULDNVI008|Su Estación Meteorológica|S|
+PULDNVI012|Ãšltimas Estaciones|U|
+PULDNVI005|Estaciones MeteorolÃ³gicas|E|
+PULDNVI008|Su EstaciÃ³n MeteorolÃ³gica|S|
 PULDNVI007|Alerta del tiempo|A|
-PULDNVI011|Tráficos de Mensajes|f|
+PULDNVI011|TrÃ¡ficos de Mensajes|f|
 PULDNVI013|Tiempo de Inicio|I|
 PULDNVI014|Tiempo Transcurrido||
 PULDNVI015|GPS Status||
 PULDNVI016|ALOHA Statistics||
 #
-# Menú de Configuración
-PULDNCF004|Estación|E|
+# MenÃº de ConfiguraciÃ³n
+PULDNCF004|EstaciÃ³n|E|
 PULDNCF001|Predefinidos|P|
-PULDNCF003|Cronómetro|t|
+PULDNCF003|CronÃ³metro|t|
 PULDNCF002|Sistema de Coordenada|C|
 PULDNCF006|Alarmas de Audio|A|
 PULDNCF007|Sintetizador de Voz|S|
-PULDNCF008|Guardar Configuración!|G|
+PULDNCF008|Guardar ConfiguraciÃ³n!|G|
 #
-# Menú de Mapas
+# MenÃº de Mapas
 PULDNMP001|Seleccionar Mapas|M|
-PULDNMP012|Saltar a una Locación|S|
+PULDNMP012|Saltar a una LocaciÃ³n|S|
 PULDNMP014|Localice rasgo del Mapa|L|
 PULDNMP016|Disable Fast Zoom/Pan/Home||
 PULDNMP013|Desactive todos los Mapas||
@@ -77,7 +77,7 @@ PULDNMP007|Alerta Mapa WX||
 PULDNMP005|Color de fondo|C|
 PULDNMP006|Etiquetas de estiones|E|
 PULDNMP026|Icon Outline Style|O|
-PULDNMP011|Menú Indicador del Ratón|R|
+PULDNMP011|MenÃº Indicador del RatÃ³n|R|
 PULDNMP008|Intensidad del Mapa|I|
 PULDNMP021|Auto Mapa - Desactivar Mapas de Trama||
 PULDNMP022|Indezar Mapas en Inicio||
@@ -87,10 +87,10 @@ PULDNMP025|Fonts||
 PULDNMP015|Xfontsel||
 PULDNMP027|Re-download Maps (Not from cache)||
 PULDNMP028|Flush Entire Map Cache!||
-PULDNMP029|Buscar ubicación||
+PULDNMP029|Buscar ubicaciÃ³n||
 PULDNMP030|Configure USGS DRG||
 PULDNMP031|Enable Map Border||
-PULDNMP032|Configuración de geocodificación||
+PULDNMP032|ConfiguraciÃ³n de geocodificaciÃ³n||
 MPUPTGR017|Internet Map Timeout (segundo)||
 #
 # PopUp "Configure USGS DRG"
@@ -111,7 +111,7 @@ MPUPDRG014|Light Gray||
 MPUPDRG015|Light Brown||
 #
 # Seleccion de Mapas
-WPUPMCP001|Selección de Mapa||
+WPUPMCP001|SelecciÃ³n de Mapa||
 PULDNMMC01|Limpiar|N|
 PULDNMMC02|Vectores|V|
 PULDNMMC03|250k Topo|2|
@@ -124,14 +124,14 @@ PULDNMMC09|Select All|S|
 #
 # Colores de fondo del mapa
 PULDNMBC01|Gris||
-PULDNMBC02|Rosado Místico||
+PULDNMBC02|Rosado MÃ­stico||
 PULDNMBC03|Azul Marino||
 PULDNMBC04|Azul acerado||
 PULDNMBC05|Med. Verde mar||
-PULDNMBC06|Verde Pálido||
-PULDNMBC07|Dorado Pálido||
+PULDNMBC06|Verde PÃ¡lido||
+PULDNMBC07|Dorado PÃ¡lido||
 PULDNMBC08|Dorado Amarillo||
-PULDNMBC09|Marrón Rosado||
+PULDNMBC09|MarrÃ³n Rosado||
 PULDNMBC10|Rojo ladrillo||
 PULDNMBC11|Blanco||
 PULDNMBC12|Negro||
@@ -153,33 +153,33 @@ PULDNOT001|On||
 PULDNOT002|Off||
 PULDNOT003|Corto||
 #
-# Menú de Despliegue de Estaciones
-PULDNDP014|Localizar Estación|L|
-PULDNDP001|Rastreo de Estación|E|
+# MenÃº de Despliegue de Estaciones
+PULDNDP014|Localizar EstaciÃ³n|L|
+PULDNDP001|Rastreo de EstaciÃ³n|E|
 PULDNDP022|Sacar Rastro de Findu|F|
 PULDNDP032|Filtrar Datos||
 PULDNDP040|- Seleccionar Nada||
-PULDNDP041|- Seleccionar Mío||
+PULDNDP041|- Seleccionar MÃ­o||
 PULDNDP042|- Seleccionar TNC||
 PULDNDP027|- Seleccionar Directo||
-PULDNDP043|- Seleccionar Vía Digi||
+PULDNDP043|- Seleccionar VÃ­a Digi||
 PULDNDP034|- Seleccionar Red||
 PULDNDP019|Incluir Datos Expirados||
 PULDNDP044|- Seleccionar Estaciones||
 PULDNDP028|- Seleccionar Estaciones Fijas||
-PULDNDP029|- Seleccionar Estaciones Móviles||
+PULDNDP029|- Seleccionar Estaciones MÃ³viles||
 PULDNDP030|- Seleccionar Estaciones de WX||
 PULDNDP053|  - Select CWOP WX Stations||
-PULDNDP045|- Seleccionar Objetos/Artículos||
-PULDNDP026|- Seleccionar Objetos/Artículos de WX||
-PULDNDP039|- Seleccionar Objetos/Artículos Medidores de Agua||
-PULDNDP031|- Seleccionar Otros Objetos/Artículos||
-PULDNDP057|- Seleccione los objetos aeronáuticos/Artículos||
-PULDNDP058|- Seleccionar objetos del buque / Artículos||
-PULDNDP033|Filtrar Visualización||
+PULDNDP045|- Seleccionar Objetos/ArtÃ­culos||
+PULDNDP026|- Seleccionar Objetos/ArtÃ­culos de WX||
+PULDNDP039|- Seleccionar Objetos/ArtÃ­culos Medidores de Agua||
+PULDNDP031|- Seleccionar Otros Objetos/ArtÃ­culos||
+PULDNDP057|- Seleccione los objetos aeronÃ¡uticos/ArtÃ­culos||
+PULDNDP058|- Seleccionar objetos del buque / ArtÃ­culos||
+PULDNDP033|Filtrar VisualizaciÃ³n||
 PULDNDP010|Mostrar Indicativo|I|
-PULDNDP012|Mostrar Símbolo|D|
-PULDNDP011|- Símbolo Rotado|S|
+PULDNDP012|Mostrar SÃ­mbolo|D|
+PULDNDP011|- SÃ­mbolo Rotado|S|
 PULDNDP007|Mostrar Rastros|R|
 PULDNDP003|Mostrar Curso|C|
 PULDNDP004|Mostrar Velocidad|V|
@@ -187,26 +187,26 @@ PULDNDP017|- Mostrar Velocidad Corta||
 PULDNDP002|Mostrar Altura|A|
 PULDNDP009|Mostrar Informe del Tiempo|T|
 PULDNDP046|- Mostrar Texto||
-PULDNDP018|- Sólo la Temperatura||
-PULDNDP047|- Mostrar Indicación de Viento||
+PULDNDP018|- SÃ³lo la Temperatura||
+PULDNDP047|- Mostrar IndicaciÃ³n de Viento||
 PULDNDP054|Display Aloha Circle||
-PULDNDP013|Mostrar Ambigüedad de Posición||
+PULDNDP013|Mostrar AmbigÃ¼edad de PosiciÃ³n||
 PULDNDP008|Mostrar Potencia/Ganancia|P|
 PULDNDP021|- Usar Pot/Ganancia por Defecto||
-PULDNDP020|- Mostrar Pot/Ganancia Móviles||
+PULDNDP020|- Mostrar Pot/Ganancia MÃ³viles||
 PULDNDP023|Mostrar atributos DF||
 PULDNDP123|Display DF Beamwidth||
 PULDNDP223|Display DF Bearing||
 PULDNDP035|Activar Conteo-Muerto||
 PULDNDP036|- Mostrar Arco||
 PULDNDP037|- Mostrar Curso||
-PULDNDP038|- Mostrar Símbolo||
-PULDNDP005|Mostrar Orientación/Distancia|D|
+PULDNDP038|- Mostrar SÃ­mbolo||
+PULDNDP005|Mostrar OrientaciÃ³n/Distancia|D|
 PULDNDP024|Mostrar Tiempo del Ultimo Informe||
 PULDNDP015|Anular Todas las Estaciones|A|
 PULDNDP016|Limpiar Rastros|n|
-PULDNDP025|Limpiar Historia de Objeto/Artículo||
-PULDNDP048|Recargar Historia de Objeto/Artículo||
+PULDNDP025|Limpiar Historia de Objeto/ArtÃ­culo||
+PULDNDP048|Recargar Historia de Objeto/ArtÃ­culo||
 PULDNDP049|Clear All Tactical Calls||
 PULDNDP050|Clear Tactical Call History||
 PULDNDP051|Select Tactical Calls Only||
@@ -214,45 +214,45 @@ PULDNDP052|- Label Trailpoints||
 PULDNDP055|Export All|E|
 PULDNDP056|Export to KML File||
 #
-# Inglesa/Métrica
+# Inglesa/MÃ©trica
 PULDNUT001|Activar Unidades Inglesa||
-PULDNUT002|Métrica||
+PULDNUT002|MÃ©trica||
 #
-# Menú de Mensajes
+# MenÃº de Mensajes
 PULDNMG001|Enviar Mensaje A|E|
 PULDNMG002|Abrir Mensajes Grupos|G|
 PULDNMG003|Anular todos mensajes saliente|B|
 PULDQUS001|Pregunta General a Estaciones|P|
 PULDQUS002|Pregunta a Estaciones I-Gate|I|
 PULDQUS003|Pregunta a Estaciones WX|W|
-PULDNMG004|Fijar Mensaje en Contestación Automática|F|
-PULDNMG005|Activar Auto contestación de Mensaje|A|
-PULDNMG006|Satélite Modo de Reconocimiento|M|
+PULDNMG004|Fijar Mensaje en ContestaciÃ³n AutomÃ¡tica|F|
+PULDNMG005|Activar Auto contestaciÃ³n de Mensaje|A|
+PULDNMG006|SatÃ©lite Modo de Reconocimiento|M|
 PULDNMG007|Show Pending Messages|P|
 #
-# Menú de Interfaces
+# MenÃº de Interfaces
 PULDNTNT04|Interface Control||
 PULDNTNT03|Desactivar Transmitir: TODOS||
-PULDNTNT05|Desactivar Transmitir: Mi Posición||
-PULDNTNT06|Desactivar Transmitir: Objetos/Artículos||
+PULDNTNT05|Desactivar Transmitir: Mi PosiciÃ³n||
+PULDNTNT06|Desactivar Transmitir: Objetos/ArtÃ­culos||
 PULDNTNT11|Enable Server Port||
 PULDNTNT01|Transmitir Ahora..!|T|
 PULDNTNT07|Coger Huella de GPS|F|
 PULDNTNT08|Coger Rutas de GPS|R|
-PULDNTNT09|Coger VíaPuntos de GPS|W|
+PULDNTNT09|Coger VÃ­aPuntos de GPS|W|
 PULDNTNT10|Fetch Garmin RINO Waypoints|G|
 #
-# Menú de Ayuda
+# MenÃº de Ayuda
 PULDNHEL01|Acerca de|A|
 PULDNHEL02|Indice de Ayuda|I|
 PULDNHEL03|EMERGENCY BEACON MODE ENABLE|E|
 PULDNHEL04|!!! EMERGENCY BEACON MODE !!!||
 PULDNHEL05|About Xastir||
 #
-# Menú de Ratón
+# MenÃº de RatÃ³n
 POPUPMA001|Opciones||
 POPUPMA00c|Centro||
-POPUPMA015|Info de estación||
+POPUPMA015|Info de estaciÃ³n||
 POPUPMA002|Acercar|A|
 POPUPMA003|Alejar|l|
 POPUPMA004|Nivel de Enfoque|N|
@@ -264,16 +264,16 @@ POPUPMA009|Nivel 1024|0|
 POPUPMA010|Nivel 8192|8|
 POPUPMA017|El Mundo Entero|E|
 POPUPMA016|Ultima Pos/Enfoque del Mapa|P|
-POPUPMA018|Crear Objeto/Artículo|C|
-POPUPMA019|Modificar Objeto/Artículo|M|
-POPUPMA025||Mover Mi  Estación Aquí|A|
+POPUPMA018|Crear Objeto/ArtÃ­culo|C|
+POPUPMA019|Modificar Objeto/ArtÃ­culo|M|
+POPUPMA025||Mover Mi  EstaciÃ³n AquÃ­|A|
 POPUPMA011|Paneo arriba|u|
 POPUPMA012|Paneo abajo|d|
 POPUPMA013|Paneo izquierda|l|
 POPUPMA014|Paneo derecha|r|
 POPUPMA020|Medida||
 POPUPMA021|Movimiento||
-POPUPMA022|RastréeMe||
+POPUPMA022|RastrÃ©eMe||
 POPUPMA023|Modificadores Encontrado!||
 POPUPMA024|Por favor apague OFF CapsLock/NumLock/ScrollLock/otro modificadores||
 POPUPMA026|Centre & Enfoque||
@@ -281,7 +281,7 @@ POPUPMA027|  Latitud||
 POPUPMA028| Longitud||
 POPUPMA029|Dibuje Objetos CAD||
 POPUPMA030|Draw||
-POPUPMA031|Cierre el Polígono||
+POPUPMA031|Cierre el PolÃ­gono||
 POPUPMA032|Erase CAD Polygons||
 POPUPMA033|**NOT USED**||
 POPUPMA034|Custom Zoom Level||
@@ -307,12 +307,12 @@ POPUPMA053|ft||
 POPUPMA054|meters||
 POPUPMA055|mi|
 #
-# Menú de Estados de la líneas de Etiquetas
+# MenÃº de Estados de la lÃ­neas de Etiquetas
 BBARZM0001|Foco %s||
 BBARZM0002|Foco %s Tr||
 BBARSTH001|%d/%d Estaciones||
 BBARSTA000|%-9s Nuevo objeto!||
-BBARSTA001|%-9s Nueva estación!||
+BBARSTA001|%-9s Nueva estaciÃ³n!||
 BBARSTA002|%s||
 BBARSTA003|Cargando mapas...||
 BBARSTA004|Mapas cargados...||
@@ -320,24 +320,24 @@ BBARSTA005|Mapa Lat/Long Rejilla es ON||
 BBARSTA006|Mapa Lat/Long Rejilla es OFF||
 BBARSTA007|El uso de Auto Mapas, es ON||
 BBARSTA008|El uso de Auto Mapas, es OFF||
-BBARSTA009|Los Niveles del Mapa están ON||
-BBARSTA010|Los Niveles del Mapa están OFF||
-BBARSTA011|Auto contestación de Mensaje es OFF!||
+BBARSTA009|Los Niveles del Mapa estÃ¡n ON||
+BBARSTA010|Los Niveles del Mapa estÃ¡n OFF||
+BBARSTA011|Auto contestaciÃ³n de Mensaje es OFF!||
 BBARSTA012|Achivo creado..||
 BBARSTA013|Abriendo Puerto GPS||
 BBARSTA014|Cerrando Puerto GPS||
-BBARSTA015|Obtenido GPS RMC Cordón||
-BBARSTA016|Obtenido GPS GGA Cordón||
+BBARSTA015|Obtenido GPS RMC CordÃ³n||
+BBARSTA016|Obtenido GPS GGA CordÃ³n||
 BBARSTA017|Red desconectada del Servidor||
-BBARSTA018|Conexión a Red tiempo vencido!||
+BBARSTA018|ConexiÃ³n a Red tiempo vencido!||
 BBARSTA019|Buscando Servidor %s||
 BBARSTA020|Conectado al %s||
-BBARSTA021|Fracaso en conexión de la Red!||
-BBARSTA022|Podría no atar el sócalo!||
+BBARSTA021|Fracaso en conexiÃ³n de la Red!||
+BBARSTA022|PodrÃ­a no atar el sÃ³calo!||
 BBARSTA023|No IP para el Servidor!||
 BBARSTA024|No Servidor Especificado||
 BBARSTA025|Servidor encontrado, Conectando %d||
-BBARSTA026|Esperando por datos del GPS vía HSP..||
+BBARSTA026|Esperando por datos del GPS vÃ­a HSP..||
 BBARSTA027|Limpiando el HSP datos obtenido del TNC..||
 BBARSTA028|Cargando %s||
 BBARSTA029|Abriendo Puerto WX||
@@ -346,12 +346,12 @@ BBARSTA031|Buscando el Servidor %d||
 BBARSTA032|Datos de WX Decodificado||
 BBARSTA033|Eco desde digipeater||
 BBARSTA034|Cargando Mapas de alerta WX||
-BBARSTA035|Esperando por datos del GPS vía AUX..||
+BBARSTA035|Esperando por datos del GPS vÃ­a AUX..||
 BBARSTA036|Limpiando el AUX datos obtenido del TNC..||
 BBARSTA037|Datos de GPS Decondificado||
-BBARSTA038|Coloque el cambio en mi estación||
+BBARSTA038|Coloque el cambio en mi estaciÃ³n||
 BBARSTA039|Indezando %s||
-BBARSTA040|Estación de Aficionado APRS(tm) %s||
+BBARSTA040|EstaciÃ³n de Aficionado APRS(tm) %s||
 BBARSTA041|Esperando por GPS data..||
 BBARSTA042|Transmitiendo objetos/articulos||
 BBARSTA043|Anotando||
@@ -366,16 +366,16 @@ BBARSTA051|Downloading tile %li of %li||
 #
 # Despliegue Paquete de Datos
 WPUPDPD001|Despligue de Datos||
-WPUPDPD002|sólo datos del TNC||
-WPUPDPD003|sólo datos de la Red||
+WPUPDPD002|sÃ³lo datos del TNC||
+WPUPDPD003|sÃ³lo datos de la Red||
 WPUPDPD004|Datos del TNC y la Red||
 WPUPDPD005|TNC||
 WPUPDPD006|RED||
 WPUPDPD007|Station Capabilities||
 WPUPDPD008|Mine Only||
 #
-# Localizar Estación
-WPUPLSP001|Localizar estación||
+# Localizar EstaciÃ³n
+WPUPLSP001|Localizar estaciÃ³n||
 WPUPLSP002|Localizar Indicativo||
 WPUPLSP003|Macheo Sensible|S|
 WPUPLSP004|Macheo Exacto|E|
@@ -385,30 +385,30 @@ WPUPLSP007|FCC/RAC Lookup||
 #
 # Configurar predefinidos
 WPUPCFD001|Configurar valores predefinidos||
-WPUPCFD002|desde qué intérvalo de tiempo será considerada una estación vieja?||
+WPUPCFD002|desde quÃ© intÃ©rvalo de tiempo serÃ¡ considerada una estaciÃ³n vieja?||
 WPUPCFD003|15 minutos|1|
 WPUPCFD004|30 minutos|3|
 WPUPCFD005|45 minutos|4|
 WPUPCFD006|1 hora|H|
 WPUPCFD007|90 minutos|9|
 WPUPCFD008|2 horas|2|
-WPUPCFD009|desde qué intérvalo de tiempo la estación no será desplegada?||
+WPUPCFD009|desde quÃ© intÃ©rvalo de tiempo la estaciÃ³n no serÃ¡ desplegada?||
 WPUPCFD010|6 horas|6|
 WPUPCFD011|12 horas|o|
-WPUPCFD012|1 Día|D|
-WPUPCFD013|2 Días|s|
+WPUPCFD012|1 DÃ­a|D|
+WPUPCFD013|2 DÃ­as|s|
 WPUPCFD014|1 semana|n|
-WPUPCFD015|Opción modo de Transmisión de la estación||
-WPUPCFD016|Estación Fija|F|
-WPUPCFD017|Estación Móvil c/Hora local|l|
-WPUPCFD018|Estación Móvil c/Fecha-hora Zúlu|Z|
-WPUPCFD019|Estación Móvil c/Horas-segundos Zúlu|u|
-WPUPCFD021|Posición de la estación c/Tiempo|T|
-WPUPCFD022|Posición de la estación, fecha-hora Zulu, y Tiempo|f|
+WPUPCFD015|OpciÃ³n modo de TransmisiÃ³n de la estaciÃ³n||
+WPUPCFD016|EstaciÃ³n Fija|F|
+WPUPCFD017|EstaciÃ³n MÃ³vil c/Hora local|l|
+WPUPCFD018|EstaciÃ³n MÃ³vil c/Fecha-hora ZÃºlu|Z|
+WPUPCFD019|EstaciÃ³n MÃ³vil c/Horas-segundos ZÃºlu|u|
+WPUPCFD021|PosiciÃ³n de la estaciÃ³n c/Tiempo|T|
+WPUPCFD022|PosiciÃ³n de la estaciÃ³n, fecha-hora Zulu, y Tiempo|f|
 WPUPCFD023|Transmitir datos WX en Raw?||
-WPUPCFD024|Comprimir datos objeto/artículo cuando transmita?||
+WPUPCFD024|Comprimir datos objeto/artÃ­culo cuando transmita?||
 WPUPCFD025|Activar Red Alternada?|A|
-WPUPCFD026|Enviar reportes de posición en qué intérvalos?||
+WPUPCFD026|Enviar reportes de posiciÃ³n en quÃ© intÃ©rvalos?||
 WPUPCFD027|Mostrar bulletines Nuevo||
 WPUPCFD028|Avisar si hay teclas Modificadora||
 WPUPCFD029|Ver boletines de zero-distancia||
@@ -417,14 +417,14 @@ WPUPCFD031|Load predefined objects from file||
 WPUPCFD032|My trails in one color||
 WPUPCFD033|ALTNET:||
 #
-# Menu "Configurar - Cronómetro"
-WPUPCFTM01|Configurar Cronómetro||
-WPUPCFTM02|TX Posición Intérvalo (minutos)||
-WPUPCFTM03|Desvanecimiento de la Estación (minutos)||
-WPUPCFTM04|Objeto/Artículo TX Max Intérvalo (minutos)||
-WPUPCFTM05|Limpiar Tiempo de la Estación (horas)||
-WPUPCFTM06|Chequeo Intérvalo del GPS (segundos)||
-WPUPCFTM07|Borrar Tiempo de la Estación (días)||
+# Menu "Configurar - CronÃ³metro"
+WPUPCFTM01|Configurar CronÃ³metro||
+WPUPCFTM02|TX PosiciÃ³n IntÃ©rvalo (minutos)||
+WPUPCFTM03|Desvanecimiento de la EstaciÃ³n (minutos)||
+WPUPCFTM04|Objeto/ArtÃ­culo TX Max IntÃ©rvalo (minutos)||
+WPUPCFTM05|Limpiar Tiempo de la EstaciÃ³n (horas)||
+WPUPCFTM06|Chequeo IntÃ©rvalo del GPS (segundos)||
+WPUPCFTM07|Borrar Tiempo de la EstaciÃ³n (dÃ­as)||
 WPUPCFTM08|Descanso Conteo-Muerto (minutos)||
 WPUPCFTM09|Serial Inter-Char Delay (ms)||
 WPUPCFTM10|Nuevo Tiempo Rastro (min)||
@@ -446,7 +446,7 @@ WPUPCFC008|UTM con zonas especiales||
 # Configurar GPS
 WPUPCFG001|Configurar GPS||
 WPUPCFG003|Puerto exclusivo de GPS||
-WPUPCFG002|Usar Posición GPS?||
+WPUPCFG002|Usar PosiciÃ³n GPS?||
 WPUPCFG004|opciones del GPS||
 WPUPCFG005|GPS Exclusivo||
 WPUPCFG006|TNC conectado a GPS (Cable HSP)||
@@ -462,13 +462,13 @@ WPUPCFG015|10 minutos||
 WPUPCFG016|Red conectada al GPS||
 WPUPCFG017|Servidor GPSD||
 WPUPCFG018|Puerto GPSD||
-WPUPCFG019|Red GPS vía GPSD||
+WPUPCFG019|Red GPS vÃ­a GPSD||
 WPUPCFG020|Reconectar en fallo?||
 WPUPCFG021|Red Conectada a WX||
 WPUPCFG022|Servidor WX||
 WPUPCFG023|Puerto WX||
 #
-# Configurar TNC (baudio también son para WX)
+# Configurar TNC (baudio tambiÃ©n son para WX)
 WPUPCFT001|Configurar TNC||
 WPUPCFT002|Usar TNC?||
 WPUPCFT003|Puerto TNC||
@@ -480,9 +480,9 @@ WPUPCFT008|4800 bps||
 WPUPCFT009|9600 bps||
 WPUPCFT010|19200 bps||
 WPUPCFT011|Rutas del UnProto||
-WPUPCFT012|Ruta 1: %s vía ||
-WPUPCFT013|Ruta 2: %s vía ||
-WPUPCFT014|Ruta 3: %s vía ||
+WPUPCFT012|Ruta 1: %s vÃ­a ||
+WPUPCFT013|Ruta 2: %s vÃ­a ||
+WPUPCFT014|Ruta 3: %s vÃ­a ||
 WPUPCFT015|Modo del Puerto||
 WPUPCFT016|8,N,1||
 WPUPCFT017|7,E,1||
@@ -493,16 +493,16 @@ WPUPCFT021|115200 bps||
 WPUPCFT022|230400 bps||
 WPUPCFT023|Configurar el TNC c/HSP GPS||
 WPUPCFT024|Tipo de Data||
-WPUPCFT025|Auto detección||
+WPUPCFT025|Auto detecciÃ³n||
 WPUPCFT026|Tipo Binario||
 WPUPCFT027|Tipo ASCII||
 WPUPCFT028|Configurar el TNC c/AUX GPS||
 WPUPCFT029|Configurar el TNC c/MAL ENUM: %d||
 WPUPCFT030|Configurar un KISS TNC||
-WPUPCFT031|Archivos de Configuración del TNC||
+WPUPCFT031|Archivos de ConfiguraciÃ³n del TNC||
 WPUPCFT032|Arreglar Archivo del TNC|| 
 WPUPCFT033|Archivo de apagar TNC||
-WPUPCFT034|Parámetros TNC KISS modo||
+WPUPCFT034|ParÃ¡metros TNC KISS modo||
 WPUPCFT035|TXDelay (10 ms unidades)||
 WPUPCFT036|Persistence (0 to 255)||
 WPUPCFT037|SlotTime (10 ms unidades)||
@@ -517,17 +517,17 @@ WPUPCFT045|Transmitting w/Dubious UNPROTO Path!||
 WPUPCFT046|Transmitting w/Dubious IGATE Path!||
 WPUPCFT047|Init KISS-mode on startup||
 #
-# Configurar el Puerto de la Estación Meteorológica
-WPUPCFWX01|Configurar el Puerto de la Estación Meteorológica||
-WPUPCFWX02|Dispositivo de la Estación Meteorológica||
-WPUPCFWX03|Tipo Medida de lluvia (Configuración Global)||
+# Configurar el Puerto de la EstaciÃ³n MeteorolÃ³gica
+WPUPCFWX01|Configurar el Puerto de la EstaciÃ³n MeteorolÃ³gica||
+WPUPCFWX02|Dispositivo de la EstaciÃ³n MeteorolÃ³gica||
+WPUPCFWX03|Tipo Medida de lluvia (ConfiguraciÃ³n Global)||
 WPUPCFWX04|0.1 pg / 2.5 mm||
 WPUPCFWX05|0.01 pg / 0.25 mm||
 WPUPCFWX06|0.1 mm||
-WPUPCFWX07|No Corrección||
+WPUPCFWX07|No CorrecciÃ³n||
 #
-# Configurar la Estación
-WPUPCFS001|Configurar la estación||
+# Configurar la EstaciÃ³n
+WPUPCFS001|Configurar la estaciÃ³n||
 WPUPCFS002|Indicativo||
 WPUPCFS003|Latitud||
 WPUPCFS004|grd||
@@ -535,44 +535,44 @@ WPUPCFS005|min||
 WPUPCFS006|(N/S)||
 WPUPCFS007|Longitud||
 WPUPCFS008|(E/W)||
-WPUPCFS009|Símbolo de la estación||
+WPUPCFS009|SÃ­mbolo de la estaciÃ³n||
 WPUPCFS010|Grupo/sobrepuesto||
-WPUPCFS011|Símbolo||
+WPUPCFS011|SÃ­mbolo||
 WPUPCFS028|Seleccione||
-WPUPCFS012|Potencia - Altura (HAAT) - Ganancia y Dirección||
+WPUPCFS012|Potencia - Altura (HAAT) - Ganancia y DirecciÃ³n||
 WPUPCFS013|Desactive PHG||
 WPUPCFS014|Altura de la Antena||
 WPUPCFS015|Ganancia de la Antena||
 WPUPCFS016|Omni||
 WPUPCFS017|Comentarios:||
-WPUPCFS018|Posición ambigüa||
+WPUPCFS018|PosiciÃ³n ambigÃ¼a||
 WPUPCFS019|Ninguna||
 WPUPCFS020|.11 milla||
 WPUPCFS021|1.15 millas||
 WPUPCFS022|11.51 millas||
 WPUPCFS023|69.09 millas||
-WPUPCFS024|.18 kilómetro||
-WPUPCFS025|1.85 kilómetros||
-WPUPCFS026|18.53 kilómetros||
-WPUPCFS027|111.19 kilómetros||
-WPUPCFS029|Envío de posición comprimida|C|
+WPUPCFS024|.18 kilÃ³metro||
+WPUPCFS025|1.85 kilÃ³metros||
+WPUPCFS026|18.53 kilÃ³metros||
+WPUPCFS027|111.19 kilÃ³metros||
+WPUPCFS029|EnvÃ­o de posiciÃ³n comprimida|C|
 #
-# Diálogo de Objeto/Artículo
-POPUPOB001|Objeto/Arículo||
+# DiÃ¡logo de Objeto/ArtÃ­culo
+POPUPOB001|Objeto/ArÃ­culo||
 POPUPOB002|Nombre:||
 POPUPOB003|Crear Nuevo Objeto||
 POPUPOB004|Borrar Objeto||
 POPUPOB005|Modificar Objeto||
-POPUPOB006|Crear Nuevo Artículo||
+POPUPOB006|Crear Nuevo ArtÃ­culo||
 POPUPOB007|Area de Objeto||
 POPUPOB008|Activar Area de Objeto||
 POPUPOB009|Color Luminoso||
 POPUPOB010|Area Colorida||
-POPUPOB011|Círculo||
-POPUPOB012|Línea-Derecha '/'||
-POPUPOB013|Línea-Izquierda '\'||
-POPUPOB014|Triángulo||
-POPUPOB015|Rectángulo||
+POPUPOB011|CÃ­rculo||
+POPUPOB012|LÃ­nea-Derecha '/'||
+POPUPOB013|LÃ­nea-Izquierda '\'||
+POPUPOB014|TriÃ¡ngulo||
+POPUPOB015|RectÃ¡ngulo||
 POPUPOB016|Negro||
 POPUPOB017|Azul||
 POPUPOB018|Verde||
@@ -584,23 +584,23 @@ POPUPOB023|Gris||
 POPUPOB024|Compense Arriba:||
 POPUPOB025|Compense Izq.(Excepto '/'):||
 POPUPOB026|Corridor:||
-POPUPOB027|Opciones Genéricas||
-POPUPOB028|Situación||
+POPUPOB027|Opciones GenÃ©ricas||
+POPUPOB028|SituaciÃ³n||
 POPUPOB029|Activar Letrero||
 POPUPOB030|Data:||
 POPUPOB031|Letrero Objeto||
-POPUPOB032|Activar Compresión||
-POPUPOB033|Borrar Artículo||
-POPUPOB034|Modificar Artículo||
+POPUPOB032|Activar CompresiÃ³n||
+POPUPOB033|Borrar ArtÃ­culo||
+POPUPOB034|Modificar ArtÃ­culo||
 POPUPOB035|Altitud (Pies):||
 POPUPOB036|Velocidad (Nudos):||
 POPUPOB037|Curso:||
 POPUPOB038|DF Objeto||
-POPUPOB039|Señal - Altura(HAAT) - Ganancia - Dirección||
-POPUPOB040|Dirigiendo - Ancho de la orientación||
+POPUPOB039|SeÃ±al - Altura(HAAT) - Ganancia - DirecciÃ³n||
+POPUPOB040|Dirigiendo - Ancho de la orientaciÃ³n||
 POPUPOB041|Antena Omni-direccional||
 POPUPOB042|Antena Direccional||
-POPUPOB043|Inútil||
+POPUPOB043|InÃºtil||
 POPUPOB044|Adopt Object||
 POPUPOB045|Adopt Item||
 POPUPOB046|DF Bearing:||
@@ -622,8 +622,8 @@ WPUPCFI009|Palabra de Paso||
 WPUPCFI010|Dejar en blanco si nada||
 WPUPCFI011|Reconectar en fallo de la RED?||
 WPUPCFI012|Correr como un I-Gate?||
-WPUPCFI013|Difundir mensajes vía TNC cuando un I-Gate?||
-WPUPCFI014|Bitácora de Transacciones del I-Gate?|||
+WPUPCFI013|Difundir mensajes vÃ­a TNC cuando un I-Gate?||
+WPUPCFI014|BitÃ¡cora de Transacciones del I-Gate?|||
 WPUPCFI015|Parametros de Filtrado||
 #
 # Configurar Base de datos
@@ -639,8 +639,8 @@ WPUPCFID09|Palabra de Paso||
 WPUPCFID10|Dejar en blanco si nada||
 WPUPCFID11|Reconectar en fallo de la RED?||
 WPUPCFID12|Correr como un I-Gate?||
-WPUPCFID13|Difundir mensajes vía TNC cuando un I-Gate?||
-WPUPCFID14|Bitácora de Transacciones del I-Gate?|||
+WPUPCFID13|Difundir mensajes vÃ­a TNC cuando un I-Gate?||
+WPUPCFID14|BitÃ¡cora de Transacciones del I-Gate?|||
 WPUPCFID15|Parametros de Filtrado||
 #
 # Menu "Configurar AGWPE"
@@ -657,35 +657,35 @@ WPUPCFIA10|(dejar en blanco si Nada)||
 WPUPCFIA11|Reconectar en fallo de RED?||
 WPUPCFIA12|Correr como un I-Gate?||
 WPUPCFIA13|Difundir mensajes via TNC cuando un I-Gate?||
-WPUPCFIA14|Bitácora de Transacciones I-Gate?||
+WPUPCFIA14|BitÃ¡cora de Transacciones I-Gate?||
 WPUPCFIA15|Transmitir RadioPuerto||
 #
 # Configurar Alarmas de Audio
 WPUPCFA001|Configurar Alarma de Audio||
-WPUPCFA002|Aplicación Audio||
+WPUPCFA002|AplicaciÃ³n Audio||
 WPUPCFA003|Alarma ON||
 WPUPCFA004|Archivos de Audio||
-WPUPCFA005|Nueva estación||
+WPUPCFA005|Nueva estaciÃ³n||
 WPUPCFA006|Nuevo mensaje||
 WPUPCFA007|Proximidad||
 WPUPCFA008|Banda abierta||
-WPUPCFA009|Mínima distancia||
-WPUPCFA010|Máxima distancia||
+WPUPCFA009|MÃ­nima distancia||
+WPUPCFA010|MÃ¡xima distancia||
 WPUPCFA011|Alerta del Tiempo||
 #
 # Configurar a Festival el sintetizador de Voz
 WPUPCFSP01|Configurar a Festival el Sintetizador de Voz||
 WPUPCFSP02|Fijar en 'ON' la opciones del Sintetizador de Voz||
-WPUPCFSP03|<- Anunciar Nueva Estación||
+WPUPCFSP03|<- Anunciar Nueva EstaciÃ³n||
 WPUPCFSP04|<- Anunciar Alerta de Nuevo Mensaje||
 WPUPCFSP05|<- Anunciar Cuerpo de Nuevo Mensaje||
 WPUPCFSP06|<- Anunciar la Proximidad de estaciones||
-WPUPCFSP07|<- Anunciar DX condición de Banda Abierta||
+WPUPCFSP07|<- Anunciar DX condiciÃ³n de Banda Abierta||
 WPUPCFSP08|<- Anunciar Alerta sobre condiciones del Tiempo||
-WPUPCFSP09|<- Estación Rastreada Alerta de Proximidad||
+WPUPCFSP09|<- EstaciÃ³n Rastreada Alerta de Proximidad||
 #
-# Rastreo de Estación
-WPUPTSP001|Rastreo estación|| 
+# Rastreo de EstaciÃ³n
+WPUPTSP001|Rastreo estaciÃ³n|| 
 WPUPTSP002|Rastreo Indicativo|| 
 WPUPTSP003|Macheo Sensible|| 
 WPUPTSP004|Macheo Exacto|| 
@@ -696,10 +696,10 @@ WPUPTSP008|Indicativo||
 WPUPTSP009|Inicio Del Rastro (hace horas)||
 WPUPTSP010|Longitud del Rastro (horas)||
 #
-# Menú de Mensajes
+# MenÃº de Mensajes
 WPUPMSB001|Enviar mensaje %d||
 WPUPMSB002|Enviar Mensaje a grupo %d||
-WPUPMSB003|Indicativo de Estación:||
+WPUPMSB003|Indicativo de EstaciÃ³n:||
 WPUPMSB004|Indicativos de Grupos:||
 WPUPMSB005|Nuevo/Refresh Indicativo||
 WPUPMSB006|Nuevo grupo||
@@ -720,55 +720,55 @@ WPUPMSB020|Use Default Path(s)||
 WPUPMSB021|Direct (No path)||
 WPUPMSB022|Reverse Path (Hint):||
 #
-# Auto Contestación
-WPUPARM001|Cambiar auto Contestación||
+# Auto ContestaciÃ³n
+WPUPARM001|Cambiar auto ContestaciÃ³n||
 WPUPARM002|Reenviar:||
 #
 # Ayuda / Indice
 WPUPHPI001|Indice de Ayuda|I|
 WPUPHPI002|Visualizar|V|
 #
-# Información de la Estación
+# InformaciÃ³n de la EstaciÃ³n
 WPUPSTI000|Objeto creado desde: %s||
-WPUPSTI001|Info Estación||
+WPUPSTI001|Info EstaciÃ³n||
 WPUPSTI002|Enviar mensaje||
 WPUPSTI003|Buscar datos FCC||
 WPUPSTI004|Buscar datos RAC||
-WPUPSTI005|%d: Paquetes recibidos, último recibido en fecha: ||
-WPUPSTI006|Oído vía TNC en dispositivo: %d, ||
-WPUPSTI007|Oído ||
-WPUPSTI008|Ultima vez vía Local||
-WPUPSTI009|Ultima vez vía TNC en dispositivo: %d||
-WPUPSTI010|Ultima vez vía Internet en dispositivo: %d||
-WPUPSTI011|Ultima vez vía Archivo||
-WPUPSTI012|Ultima vez vía Desconocida||
-WPUPSTI013|, y ha cambiado posición||
+WPUPSTI005|%d: Paquetes recibidos, Ãºltimo recibido en fecha: ||
+WPUPSTI006|OÃ­do vÃ­a TNC en dispositivo: %d, ||
+WPUPSTI007|OÃ­do ||
+WPUPSTI008|Ultima vez vÃ­a Local||
+WPUPSTI009|Ultima vez vÃ­a TNC en dispositivo: %d||
+WPUPSTI010|Ultima vez vÃ­a Internet en dispositivo: %d||
+WPUPSTI011|Ultima vez vÃ­a Archivo||
+WPUPSTI012|Ultima vez vÃ­a Desconocida||
+WPUPSTI013|, y ha cambiado posiciÃ³n||
 WPUPSTI014|Actual Potencia/Ganancia:||
 WPUPSTI016|Altitud: %.1f%s ||
-WPUPSTI017|Curso: %s° ||
+WPUPSTI017|Curso: %sÂ° ||
 WPUPSTI018|Velocidad: %.1f km/h||
 WPUPSTI019|Velocidad: %.1f mph||
 WPUPSTI020|%0.1f millas||
 WPUPSTI021|%0.1f km||
-WPUPSTI022|Distancia desde mi estación %s, Curso desde mi estación %s||
-WPUPSTI023|Ultima posición: ||
-WPUPSTI024|Datos de la estación Meteorológica %c:%s||
-WPUPSTI025|Curso del viento: %s°  Velocidad: %03d km/h||
-WPUPSTI026|Curso del viento: %s°  Velocidad: %s mph||
-WPUPSTI027| Ráfaga: %03d Km/h||
-WPUPSTI028| Ráfaga: %s mph|| 
-WPUPSTI029|Temperatura: %02.1f°C   ||
-WPUPSTI030|Temperatura: %s°F   ||
+WPUPSTI022|Distancia desde mi estaciÃ³n %s, Curso desde mi estaciÃ³n %s||
+WPUPSTI023|Ultima posiciÃ³n: ||
+WPUPSTI024|Datos de la estaciÃ³n MeteorolÃ³gica %c:%s||
+WPUPSTI025|Curso del viento: %sÂ°  Velocidad: %03d km/h||
+WPUPSTI026|Curso del viento: %sÂ°  Velocidad: %s mph||
+WPUPSTI027| RÃ¡faga: %03d Km/h||
+WPUPSTI028| RÃ¡faga: %s mph|| 
+WPUPSTI029|Temperatura: %02.1fÂ°C   ||
+WPUPSTI030|Temperatura: %sÂ°F   ||
 WPUPSTI031| Humedad: %s%%   ||
-WPUPSTI032|Indice de Humedad: %02.1f°C  ||
-WPUPSTI033| Presión Barométrica: %s mb||
+WPUPSTI032|Indice de Humedad: %02.1fÂ°C  ||
+WPUPSTI033| PresiÃ³n BaromÃ©trica: %s mb||
 WPUPSTI034|Nieve: %0.1f (cm/24h)||
 WPUPSTI035|Nieve: %0.0f (plg/24h)||
 WPUPSTI036|Lluvia: ||
 WPUPSTI037|%0.2f (mm/h)  ||
 WPUPSTI038|%0.2f (plg/h)  ||
-WPUPSTI039|%0.2f (mm/día)  ||
-WPUPSTI040|%0.2f (plg/día)  ||
+WPUPSTI039|%0.2f (mm/dÃ­a)  ||
+WPUPSTI040|%0.2f (plg/dÃ­a)  ||
 WPUPSTI041|%0.2f (mm/desde medianoche)||
 WPUPSTI042|%0.2f (mm/desde medianoche)||
 WPUPSTI043|Ruta de Datos: %s||
@@ -779,17 +779,17 @@ WPUPSTI047|%0.2f (mm)||
 WPUPSTI048|%0.2f (plg)||
 WPUPSTI049|Preguntar rastro||
 WPUPSTI050|Pregunta no-conocido Mensaje||
-WPUPSTI051|Pregunta directa a estación||
-WPUPSTI052|Pregunta versión a estación||
-WPUPSTI053|Modificar Objeto/Artículo||
+WPUPSTI051|Pregunta directa a estaciÃ³n||
+WPUPSTI052|Pregunta versiÃ³n a estaciÃ³n||
+WPUPSTI053|Modificar Objeto/ArtÃ­culo||
 WPUPSTI054|Almacenar Rastro||
 WPUPSTI055|Repetido desde:||
-WPUPSTI056|Activar Actualizaciones Automática||
+WPUPSTI056|Activar Actualizaciones AutomÃ¡tica||
 WPUPSTI057|Omni-DF: %s||
 WPUPSTI058|Orientando DF: %s||
 WPUPSTI059|Estados %02d/%02d %02d:%02d : %s||
-WPUPSTI060|Incendio Temp: %02.1f°C  ||
-WPUPSTI061|Incendio Temp: %s°F   ||
+WPUPSTI060|Incendio Temp: %02.1fÂ°C  ||
+WPUPSTI061|Incendio Temp: %sÂ°F   ||
 WPUPSTI062|Humedad de Incendio: %s%%  ||
 WPUPSTI063|Baro: %0.2f en Hg||
 WPUPSTI064|Fetch NWS Alert||
@@ -842,7 +842,7 @@ STIFCC0004|Calle:||
 STIFCC0005|Ciudad:||
 STIFCC0006|Estado:||
 STIFCC0007|Zona Postal:||
-STIFCC0008|Básica ||
+STIFCC0008|BÃ¡sica ||
 STIFCC0009|Advanzada ||
 STIFCC0010|5 wpm ||
 STIFCC0011|12 wpm ||
@@ -867,7 +867,7 @@ UNIOP00006|Dispositivo||
 UNIOP00007|Agregar||
 UNIOP00008|Anular||
 UNIOP00009|Propiedades||
-UNIOP00010|Permitir Transmisión?||
+UNIOP00010|Permitir TransmisiÃ³n?||
 UNIOP00011|Activar en Inicio?||
 UNIOP00012|km/h||
 UNIOP00013|mph||
@@ -875,8 +875,8 @@ UNIOP00014|C||
 UNIOP00015|F||
 UNIOP00016|mm||
 UNIOP00017|pg||
-UNIOP00018|mm/día||
-UNIOP00019|pg/día||
+UNIOP00018|mm/dÃ­a||
+UNIOP00019|pg/dÃ­a||
 UNIOP00020|mm/hora||
 UNIOP00021|pg/hora||
 UNIOP00022|mm/med||
@@ -897,8 +897,8 @@ UNIOP00036|day||
 UNIOP00037|Send Control-E to get GPS data?||
 UNIOP00038|Add Delay||
 #
-# Seleccionar Estación
-STCHO00001|Seleccionar Estación||
+# Seleccionar EstaciÃ³n
+STCHO00001|Seleccionar EstaciÃ³n||
 #
 # DESPLIEGUE ALARMA WX
 WPUPWXA001|Alerta del Tiempo||
@@ -906,30 +906,30 @@ WPUPWXA002|Lista de alerta del Tiempo||
 #
 # Configurar Interfaces
 WPUPCIF001|Interfaces Instalados||
-WPUPCIF002|Elegir Tipo de interfáz||
+WPUPCIF002|Elegir Tipo de interfÃ¡z||
 #
 # Configurar AX.25 TNC
 WPUPCAX001|Configurar AX.25 TNC||
 WPUPCAX002|AX.25 nombre de puerto||
 #
-# Nombres de dispositivos de la Interfáz
+# Nombres de dispositivos de la InterfÃ¡z
 IFDNL00000|Nada||
-IFDNL00001|TNC vía el Puerto Serial||
-IFDNL00002|Serial TNC c/GPS más (cable HSP)||
-IFDNL00003|GPS vía Puerto Serial||
-IFDNL00004|Est. Meteorológica vía Puerto Serial||
-IFDNL00005|Conexión a un Servidor en Internet||
+IFDNL00001|TNC vÃ­a el Puerto Serial||
+IFDNL00002|Serial TNC c/GPS mÃ¡s (cable HSP)||
+IFDNL00003|GPS vÃ­a Puerto Serial||
+IFDNL00004|Est. MeteorolÃ³gica vÃ­a Puerto Serial||
+IFDNL00005|ConexiÃ³n a un Servidor en Internet||
 IFDNL00006|AX.25 TNC||
-IFDNL00007|GPS Enlazado vía el Servidor gpsd||
-IFDNL00008|Est. Meteorológica Enlazada a una RED||
-IFDNL00009|Serial TNC c/GPS más (cable AUX)||
+IFDNL00007|GPS Enlazado vÃ­a el Servidor gpsd||
+IFDNL00008|Est. MeteorolÃ³gica Enlazada a una RED||
+IFDNL00009|Serial TNC c/GPS mÃ¡s (cable AUX)||
 IFDNL00010|Serial KISS TNC||
 IFDNL00011|Red Base de Datos (Aun No Implementada)||
 IFDNL00012|Red AGWPE||
 IFDNL00013|Serial Multi-Port KISS TNC||
 IFDNL00014|SQL Database (Experimental)||
 #
-# Info dispositivo Interfáz
+# Info dispositivo InterfÃ¡z
 IFDIN00000|%s %2d %s sobre serial %s   %s||
 IFDIN00001|%s %2d %s conectado a %s:%d   %s||
 IFDIN00002|%s %2d %s usando dispositivo nombrado %s   %s||
@@ -941,8 +941,8 @@ IFDIN00007|  ARRIBA   ||
 IFDIN00008|  ERROR    ||
 IFDIN00009|DESCONOCIDO||
 #
-# Control de la interfáz
-IFPUPCT000|Control de Interfáz||
+# Control de la interfÃ¡z
+IFPUPCT000|Control de InterfÃ¡z||
 IFPUPCT001|Iniciar||
 IFPUPCT002|Detener||
 IFPUPCT003|Iniciar todos||
@@ -950,33 +950,33 @@ IFPUPCT004|Detener todos||
 #
 # Control de I-Gate
 IGPUPCF000|I-Gate Opciones||
-IGPUPCF001|Desactiva todo el IGate tráfico||
-IGPUPCF002|Sólo Permite tráfico de RF->Inet||
-IGPUPCF003|Permite ambos tráficos RF<->Inet||
+IGPUPCF001|Desactiva todo el IGate trÃ¡fico||
+IGPUPCF002|SÃ³lo Permite trÃ¡fico de RF->Inet||
+IGPUPCF003|Permite ambos trÃ¡ficos RF<->Inet||
 IGPUPCF004|Igate -> RF Ruta   ||
 #
-# Estación Meteorológica
-WXPUPSI000|Estación meteorológica||
-WXPUPSI001|Tipo de estación Meteorológica||
+# EstaciÃ³n MeteorolÃ³gica
+WXPUPSI000|EstaciÃ³n meteorolÃ³gica||
+WXPUPSI001|Tipo de estaciÃ³n MeteorolÃ³gica||
 WXPUPSI002|Datos Actuales||
 WXPUPSI003|Curso del viento||
 WXPUPSI004|Velocidad del viento||
-WXPUPSI005|Ráfaga del viento||
+WXPUPSI005|RÃ¡faga del viento||
 WXPUPSI006|Temperatura||
 WXPUPSI007|Total lluvia||
 WXPUPSI008|Hoy Total lluvia||
-WXPUPSI009|Presión Barométrica||
+WXPUPSI009|PresiÃ³n BaromÃ©trica||
 WXPUPSI010|Humedad Relativa||
 WXPUPSI011|Peet Bros ULTIMETER 2000 Tipo (Modo Datos Log)||
 WXPUPSI012|Peet Bros ULTIMETER II Tipo||
 WXPUPSI013|Peet Bros ULTIMETER 2000 Tipo (Modo Paquete)||
 WXPUPSI014|Actual Tot. hora lluvia||
 WXPUPSI015|Ultimas 24 Tot. lluvias||
-WXPUPSI016|Cualimétricos Q-Net||
+WXPUPSI016|CualimÃ©tricos Q-Net||
 WXPUPSI017|Tipo Peet Bros ULTIMETER 2000 (Modo Completo)||
-WXPUPSI018|Punto de Rocío||
+WXPUPSI018|Punto de RocÃ­o||
 WXPUPSI019|Viento Alto||
-WXPUPSI020|Viento Frío||
+WXPUPSI020|Viento FrÃ­o||
 WXPUPSI021|Indice Caluroso||
 WXPUPSI022|3-Hr Baro||
 WXPUPSI023|Alta Temperat.||
@@ -988,16 +988,16 @@ WXPUPSI028|Davis APRS Data Logger||
 #
 # Listas de Estaciones
 LHPUPNI000|Todas las estaciones||
-LHPUPNI001|Estaciones móviles||
-LHPUPNI002|Estaciones Meteorológicas||
-LHPUPNI003|Estaciones locales (vía TNC)||
+LHPUPNI001|Estaciones mÃ³viles||
+LHPUPNI002|Estaciones MeteorolÃ³gicas||
+LHPUPNI003|Estaciones locales (vÃ­a TNC)||
 LHPUPNI004|Ultimas Estaciones||
-LHPUPNI005|Objetos y Artículos||
-LHPUPNI006|Objetos y Artículos Propio||
+LHPUPNI005|Objetos y ArtÃ­culos||
+LHPUPNI006|Objetos y ArtÃ­culos Propio||
 LHPUPNI010| #||
 LHPUPNI011|Indicativo||
 LHPUPNI012|#Pack||
-LHPUPNI013|Ult.Posición||
+LHPUPNI013|Ult.PosiciÃ³n||
 LHPUPNI014|Ruta||
 LHPUPNI015|PHG||
 LHPUPNI016|Comentarios||
@@ -1027,39 +1027,39 @@ PULDNMAT02|Muestra mapa de alarma bajo otros mapas||
 #
 # Error/popup mensajes
 POPEM00001|Localiza Error!||
-POPEM00002|La estación %s no fue encontrada!||
+POPEM00002|La estaciÃ³n %s no fue encontrada!||
 POPEM00003|Rastreo Error!||
-POPEM00004|Interfáz Error!||
-POPEM00005|Inválido nombre de puerto AX.25 %s||
-POPEM00006|Inválido nombre de puerto AX.25 %s||
-POPEM00007|Inválido Indicativo %s||
-POPEM00008|Inválido Indicativo AX.25 destinación o digipeater||
-POPEM00009|No puedo abrir el sócalo AX.25, %s||
-POPEM00010|No puedo atar el sócalo AX.25, %s||
+POPEM00004|InterfÃ¡z Error!||
+POPEM00005|InvÃ¡lido nombre de puerto AX.25 %s||
+POPEM00006|InvÃ¡lido nombre de puerto AX.25 %s||
+POPEM00007|InvÃ¡lido Indicativo %s||
+POPEM00008|InvÃ¡lido Indicativo AX.25 destinaciÃ³n o digipeater||
+POPEM00009|No puedo abrir el sÃ³calo AX.25, %s||
+POPEM00010|No puedo atar el sÃ³calo AX.25, %s||
 POPEM00011|No puedo conectar al Indicativo AX.25, %s||
 POPEM00012|AX.25 error en la salida de UI||
 POPEM00013|AX.25 problema con el archivo axports||
-POPEM00014|AX.25 inválido nombre de puerto %s||
-POPEM00015|Error abriendo la interfáz %d, duro fallo||
-POPEM00016|Error abriendo la interfáz %d Tiempo agotado||
-POPEM00017|No hay mas interfáz disponible!||
-POPEM00018|Dato requerido - Simple Línea de Mensaje|
-POPEM00019|El Puerto de transmisión está "off" para puerto %d|
+POPEM00014|AX.25 invÃ¡lido nombre de puerto %s||
+POPEM00015|Error abriendo la interfÃ¡z %d, duro fallo||
+POPEM00016|Error abriendo la interfÃ¡z %d Tiempo agotado||
+POPEM00017|No hay mas interfÃ¡z disponible!||
+POPEM00018|Dato requerido - Simple LÃ­nea de Mensaje|
+POPEM00019|El Puerto de transmisiÃ³n estÃ¡ "off" para puerto %d|
 POPEM00020|Error banco de Datos!|
-POPEM00021|El soporte de AX.25 no está compilado en Xastir!||
+POPEM00021|El soporte de AX.25 no estÃ¡ compilado en Xastir!||
 POPEM00022|Error de entrada!|
-POPEM00023|Nombre de locación no especificada!|
-POPEM00024|Nombre de Locación especificada en uso!|
+POPEM00023|Nombre de locaciÃ³n no especificada!|
+POPEM00024|Nombre de LocaciÃ³n especificada en uso!|
 POPEM00025|No Encontrado!||
-POPEM00026|El Rastreo empezará cuando el aparezca||
-POPEM00027|Info Impropia. Algunos campos vacío?||
+POPEM00026|El Rastreo empezarÃ¡ cuando el aparezca||
+POPEM00027|Info Impropia. Algunos campos vacÃ­o?||
 POPEM00028|No se puede abrir el archivo||
 POPEM00029|Encontrado!||
-POPEM00030|Símbolo de Estación Meteorológica||
-POPEM00031|Cambiado a símbolo WX '/_', otras opciones:  '\_'  '/W'  y  '\W'||
-POPEM00032|Aviso: Usando Símbolo del National Weather Service!||
+POPEM00030|SÃ­mbolo de EstaciÃ³n MeteorolÃ³gica||
+POPEM00031|Cambiado a sÃ­mbolo WX '/_', otras opciones:  '\_'  '/W'  y  '\W'||
+POPEM00032|Aviso: Usando SÃ­mbolo del National Weather Service!||
 POPEM00033|No GPS Data!||
-POPEM00034|Disactivando TX de Mi Posición Hasta ver Data de GPS Válido!||
+POPEM00034|Disactivando TX de Mi PosiciÃ³n Hasta ver Data de GPS VÃ¡lido!||
 POPEM00035|Warning||
 POPEM00036|Notice||
 POPEM00037|HSP interface present: GPS timing has been increased||
@@ -1081,22 +1081,22 @@ POPEM00052|Callsign is EMPTY!||
 POPEM00053|Message is EMPTY!||
 POPEM00054|We're trying to talk to ourselves!||
 #
-# Salto de Locación
-JMLPO00001|Localización de Mapa||
+# Salto de LocaciÃ³n
+JMLPO00001|LocalizaciÃ³n de Mapa||
 JMLPO00002|IR!||
-JMLPO00003|Nombre de Nueva Localización:||
+JMLPO00003|Nombre de Nueva LocalizaciÃ³n:||
 #
 # Boletines 
 BULMW00001|Boletines||
-BULMW00002|Límite de Rango a (0, no hay límite)||
+BULMW00002|LÃ­mite de Rango a (0, no hay lÃ­mite)||
 BULMW00003|Cambio de Rango||
 #
-# Tráfico de todo los mensajes
-AMTMW00001|Tráfico de todos los mensajes||
-AMTMW00002|Límite de Rango a (0, no hay límite)||
+# TrÃ¡fico de todo los mensajes
+AMTMW00001|TrÃ¡fico de todos los mensajes||
+AMTMW00002|LÃ­mite de Rango a (0, no hay lÃ­mite)||
 #
 # Cadenas del Sintetizador
-SPCHSTR001|kilómetros||
+SPCHSTR001|kilÃ³metros||
 SPCHSTR002|metros||
 SPCHSTR003|millas||
 SPCHSTR004|yardas||
@@ -1106,7 +1106,7 @@ SPCHSTR007|%s, distancia es %d %s %s %s.||
 SPCHSTR008|%s, distancia es %.1f %s %s %s.||
 SPCHSTR009|Nueva Alerta de WX||
 SPCHSTR010|Nueva LLamada||
-SPCHSTR011|Oído, D X, %s, en distancia de %.1f %s||
+SPCHSTR011|OÃ­do, D X, %s, en distancia de %.1f %s||
 #
 SPCHDIRN00|norte de||
 SPCHDIRS00|sur de||
@@ -1117,34 +1117,34 @@ SPCHDIRNW0|noroeste de||
 SPCHDIRSE0|sureste de||
 SPCHDIRSW0|suroeste de||
 #
-# Diálogo de seleción de Símbolo
-SYMSEL0001|Seleccione Símbolo||
-SYMSEL0002|Tabla de Símbolo primario||
-SYMSEL0003|Tabla de Símbolo Secundario||
+# DiÃ¡logo de seleciÃ³n de SÃ­mbolo
+SYMSEL0001|Seleccione SÃ­mbolo||
+SYMSEL0002|Tabla de SÃ­mbolo primario||
+SYMSEL0003|Tabla de SÃ­mbolo Secundario||
 #
-# Diálogo de la Propiedades de Impresora
+# DiÃ¡logo de la Propiedades de Impresora
 PRINT0001|Propiedades de Impresora||
 PRINT0002|Ancho del Paper||
 PRINT0003|Auto-Rotar Imagen
-PRINT0004|Rotar Imagen 90° CCW||
+PRINT0004|Rotar Imagen 90Â° CCW||
 PRINT0005|Auto-Balancear Imagen||
 PRINT0006|Balanza:||
 PRINT0007|Forza el predefinido color de fondo a blanco||
 PRINT0008|Imprime en Blanco y Negro||
 PRINT0016|Colores Revertidos||
-PRINT0009|Resolución de Postscript:||
+PRINT0009|ResoluciÃ³n de Postscript:||
 PRINT0010|Prevista||
 PRINT0011|Imprimir al archivo||
 PRINT0012|Guardar imagen a un archivo...||
 PRINT0013|Convirtiendo a Postscript...||
-PRINT0014|Creando archivo de impresión Finalizado||
+PRINT0014|Creando archivo de impresiÃ³n Finalizado||
 PRINT0015|Estado de Impresora||
 #
-# Diálogo de la Propiedades de Impresora
+# DiÃ¡logo de la Propiedades de Impresora
 PRINT1001|Direct to:||
 PRINT1002|Via Previewer:||
 #
-# Diálogo de localizar forma
+# DiÃ¡logo de localizar forma
 FEATURE001|Nombre:||
 FEATURE002|Estado/Provincia:||
 FEATURE003|Pais:||
@@ -1158,9 +1158,9 @@ FEATURE010|Zip Code:||
 FEATURE011|Geocoding File||
 #
 # Geocoding Dialog (Nominatim)
-GEOCODE001|Buscar ubicación||
-GEOCODE002|Consulta de búsqueda:||
-GEOCODE003|Filtro de país:||
+GEOCODE001|Buscar ubicaciÃ³n||
+GEOCODE002|Consulta de bÃºsqueda:||
+GEOCODE003|Filtro de paÃ­s:||
 GEOCODE004|Buscar||
 GEOCODE005|Borrar||
 GEOCODE006|Resultados:||
@@ -1170,33 +1170,33 @@ GEOCODE009|Cerrar||
 GEOCODE010|Buscando...||
 GEOCODE011|No se encontraron resultados||
 GEOCODE012|Error: %s||
-GEOCODE013|Se encontró/encontraron %d resultado(s)||
+GEOCODE013|Se encontrÃ³/encontraron %d resultado(s)||
 GEOCODE014|Datos (C) Colaboradores de OpenStreetMap||
 GEOCODE015|Ninguno (Mundial)||
 GEOCODE023|Servicio no disponible||
-GEOCODE024|Introduzca una ubicación para buscar||
-GEOCODE025|Vaciar caché||
-GEOCODE026|Caché vaciada exitosamente||
-GEOCODE027|Error al vaciar la caché||
+GEOCODE024|Introduzca una ubicaciÃ³n para buscar||
+GEOCODE025|Vaciar cachÃ©||
+GEOCODE026|CachÃ© vaciada exitosamente||
+GEOCODE027|Error al vaciar la cachÃ©||
 GEOCODE028|Servidor Nominatim:||
-GEOCODE029|Caché habilitada:||
-GEOCODE030|Expiración de caché (días):||
-GEOCODE031|Correo electrónico del usuario:||
-GEOCODE032|País predeterminado:||
-GEOCODE033|Configuración||
+GEOCODE029|CachÃ© habilitada:||
+GEOCODE030|ExpiraciÃ³n de cachÃ© (dÃ­as):||
+GEOCODE031|Correo electrÃ³nico del usuario:||
+GEOCODE032|PaÃ­s predeterminado:||
+GEOCODE033|ConfiguraciÃ³n||
 GEOCODE034|Guardar||
 GEOCODE035|Cancelar||
 GEOCODE036|Aplicar||
-GEOCODE037|Configuración de geocodificación||
+GEOCODE037|ConfiguraciÃ³n de geocodificaciÃ³n||
 #
 # Geocoding Configuration Dialog
-GEOCFG001|Configuración de geocodificación||
+GEOCFG001|ConfiguraciÃ³n de geocodificaciÃ³n||
 GEOCFG002|URL del servidor:||
-GEOCFG003|Dirección de correo electrónico:||
+GEOCFG003|DirecciÃ³n de correo electrÃ³nico:||
 GEOCFG004|(Opcional pero recomendado)||
-GEOCFG005|País predeterminado:||
+GEOCFG005|PaÃ­s predeterminado:||
 #
-# Diálogo de Calcular Coordenada
+# DiÃ¡logo de Calcular Coordenada
 COORD001|Calcula Coordenada||
 COORD002|Calc||
 COORD003|Calcular||
@@ -1216,28 +1216,28 @@ COORD016|       Maidenhead Grid Locator:  ||
 COORD017| **       Sorry, your input was not recognized!        **||
 COORD018| **   Please use one of the following input formats:   **||
 #
-# Diálogo Baliza Inteligente
+# DiÃ¡logo Baliza Inteligente
 SMARTB001|Baliza Inteligente||
-SMARTB002|Alta Proporción (secs):||
+SMARTB002|Alta ProporciÃ³n (secs):||
 SMARTB003|Alta Velocidad (mph):||
 SMARTB004|Alta Velocidad (kph):||
-SMARTB005|Baja Proporción (mins):||
+SMARTB005|Baja ProporciÃ³n (mins):||
 SMARTB006|Baja Velocidad (mph):||
 SMARTB007|Baja Velocidad (kph):||
-SMARTB008|Mínima Vuelta (grados):||
+SMARTB008|MÃ­nima Vuelta (grados):||
 SMARTB009|Vuelta de declive:||
 SMARTB010|Tiempo de Espera (secs):||
 SMARTB011|Activar Baliza Inteligente(tm)||
 #
-# Diálogo Ajuste de Gamma
-GAMMA001|Ajuste Corrección de Gamma||
-GAMMA002|Corrección Gamma||
+# DiÃ¡logo Ajuste de Gamma
+GAMMA001|Ajuste CorrecciÃ³n de Gamma||
+GAMMA002|CorrecciÃ³n Gamma||
 #
 # Map labels font Dialog
 MAPFONT001|Change Fonts||
 MAPFONT002|Fonts||
-MAPFONT003|Map Font Minúsculo||
-MAPFONT004|Map Font Pequeño||
+MAPFONT003|Map Font MinÃºsculo||
+MAPFONT004|Map Font PequeÃ±o||
 MAPFONT005|Map Font Medio||
 MAPFONT006|Map Font Grande||
 MAPFONT007|Map Font Enorme||
@@ -1246,8 +1246,8 @@ MAPFONT009|Menu Font||
 MAPFONT010|Station Font||
 MAPFONT011|ATV ID Font||
 #
-# Distancia/Orientación en línea de estado
-PULDNDB001|Estado de Distancia/Orientación||
+# Distancia/OrientaciÃ³n en lÃ­nea de estado
+PULDNDB001|Estado de Distancia/OrientaciÃ³n||
 #
 # Transferir Operaciones de GPS
 GPS001|Transferir GPS||
@@ -1262,13 +1262,13 @@ GPS009|Azul||
 GPS010|Amarillo||
 GPS011|Violeta||
 #
-# Diálogo de Propiedades de Mapa
+# DiÃ¡logo de Propiedades de Mapa
 MAPP001|Propiedades de Mapa||
 MAPP002|Max   Min  Dibuja   Mapa  USGS  Auto||
 MAPP003|Zoom  Zoom  Capa  Llenado DRG   Mapa Sendero/NombreArchivo||
 MAPP004|Cambie Capa->||
 MAPP005|Llenado->||
-MAPP006|Sí||
+MAPP006|SÃ­||
 MAPP007|No||
 MAPP008|Automapas->||
 MAPP009|Max Zoom->||
@@ -1277,8 +1277,8 @@ MAPP011|Auto||
 MAPP012|USGS DRG->||
 #
 # Cadenas del Tiempo
-TIME001|Día||
-TIME002|Días||
+TIME001|DÃ­a||
+TIME002|DÃ­as||
 TIME003|Hora||
 TIME004|Horas||
 TIME005|Minuto||

--- a/help/help-French.dat
+++ b/help/help-French.dat
@@ -2,24 +2,24 @@ HELP-INDEX>ME LIRE EN PREMIER - License
 
                         ME LIRE EN PREMIER pour XASTIR
 
-Traduction Francaise par Google Translate.  KM5VY a essayé de les faire
-correspondre avec les traductions utilisée dans le logiciel soi-même,
-mais il y a peut-être des erreurs.  Les traductions du logiciel a été
+Traduction Francaise par Google Translate.  KM5VY a essayÃ© de les faire
+correspondre avec les traductions utilisÃ©e dans le logiciel soi-mÃªme,
+mais il y a peut-Ãªtre des erreurs.  Les traductions du logiciel a Ã©tÃ©
 initialement fait par VE2DJE, F1SJE, et F1IOL il y a longtemps.
 
 Si vous n'aimez pas cette traduction, on sera ravis d'avoir vos
 corrections!
 
-Pour obtenir les informations les plus récentes, veuillez consulter le
-fichier README.md dans le répertoire Xastir.  Consultez également les
+Pour obtenir les informations les plus rÃ©centes, veuillez consulter le
+fichier README.md dans le rÃ©pertoire Xastir.  Consultez Ã©galement les
 fichiers LICENSE et COPYING pour plus d'informations.
 
-Ce programme est destiné à la communauté des radioamateurs. Aux
-États-Unis, la FCC interdit l'émission par radiofréquence aux
+Ce programme est destinÃ© Ã  la communautÃ© des radioamateurs. Aux
+Ã‰tats-Unis, la FCC interdit l'Ã©mission par radiofrÃ©quence aux
 personnes non titulaires d'une licence de radioamateur.
 
-Les utilisateurs résidant en dehors des États-Unis sont invités à se
-renseigner sur la réglementation en vigueur dans leur pays.
+Les utilisateurs rÃ©sidant en dehors des Ã‰tats-Unis sont invitÃ©s Ã  se
+renseigner sur la rÃ©glementation en vigueur dans leur pays.
 
 LICENSE :
 
@@ -28,29 +28,29 @@ Copyright (C) 1999  Frank Giannandrea
 Copyright (C) 2000-2026 The Xastir Group
 
 Ce programme est un logiciel libre ; vous pouvez le redistribuer et/ou
-le modifier conformément aux termes de la Licence publique générale
-GNU, telle que publiée par la Free Software Foundation ; soit la
-version 2 de la Licence, soit (à votre choix) toute version
-ultérieure.
+le modifier conformÃ©ment aux termes de la Licence publique gÃ©nÃ©rale
+GNU, telle que publiÃ©e par la Free Software Foundation ; soit la
+version 2 de la Licence, soit (Ã  votre choix) toute version
+ultÃ©rieure.
 
-Ce programme est distribué SANS AUCUNE GARANTIE ; sans même la
-garantie implicite de QUALITÉ MARCHANDE ou d'ADÉQUATION À UN USAGE
-PARTICULIER. Consultez la Licence publique générale GNU pour plus de
-détails.
+Ce programme est distribuÃ© SANS AUCUNE GARANTIE ; sans mÃªme la
+garantie implicite de QUALITÃ‰ MARCHANDE ou d'ADÃ‰QUATION Ã€ UN USAGE
+PARTICULIER. Consultez la Licence publique gÃ©nÃ©rale GNU pour plus de
+dÃ©tails.
 
-Vous devriez avoir reçu une copie de la Licence publique générale GNU
-avec ce programme ; si ce n'est pas le cas, veuillez écrire à la Free
+Vous devriez avoir reÃ§u une copie de la Licence publique gÃ©nÃ©rale GNU
+avec ce programme ; si ce n'est pas le cas, veuillez Ã©crire Ã  la Free
 Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-02111-1307, États-Unis.
+02111-1307, Ã‰tats-Unis.
 
-Vous trouverez plus d'informations sur le programme à l'adresse suivante :
+Vous trouverez plus d'informations sur le programme Ã  l'adresse suivante :
 
 https://github.com/Xastir/Xastir
 https://github.com/Xastir/Xastir/wiki
 https://www.xastir.org
 
-Des listes de diffusion spécifiques à Xastir sont disponibles.
-Veuillez vous abonner à l'une ou aux deux pour obtenir les dernières
+Des listes de diffusion spÃ©cifiques Ã  Xastir sont disponibles.
+Veuillez vous abonner Ã  l'une ou aux deux pour obtenir les derniÃ¨res
 informations sur Xastir. Consultez https://www.xastir.org pour vous
 abonner.
 
@@ -66,52 +66,52 @@ XASTIR, ou X Amateur Station Tracking and Information Reporting (Suivi
 et rapport d'informations des stations radioamateurs X).
 
 Xastir est un programme APRS(tm) open source, gratuit et librement
-distribuable. Actuellement en développement, ce programme ne doit pas
-être considéré comme un produit fini ! Votre aide est précieuse pour
-l'améliorer. Si vous avez des compétences en programmation et/ou en
-rédaction de documentation, votre contribution est la bienvenue ! Nous
-avons beaucoup d'idées, mais peu de temps. Si vous pensez pouvoir
-apporter votre contribution, n'hésitez pas à nous contacter !
+distribuable. Actuellement en dÃ©veloppement, ce programme ne doit pas
+Ãªtre considÃ©rÃ© comme un produit fini ! Votre aide est prÃ©cieuse pour
+l'amÃ©liorer. Si vous avez des compÃ©tences en programmation et/ou en
+rÃ©daction de documentation, votre contribution est la bienvenue ! Nous
+avons beaucoup d'idÃ©es, mais peu de temps. Si vous pensez pouvoir
+apporter votre contribution, n'hÃ©sitez pas Ã  nous contacter !
 
-APRS(tm) a été créé par Bob Bruninga et initialement déposé comme marque
-par lui. Il s'agit actuellement d'une marque déposée de la Tucson
-Amateur Radio Packet Corporation. Après le décès de Bob Bruninga, la
-maintenance et la documentation d'APRS pour la communauté ont été
+APRS(tm) a Ã©tÃ© crÃ©Ã© par Bob Bruninga et initialement dÃ©posÃ© comme marque
+par lui. Il s'agit actuellement d'une marque dÃ©posÃ©e de la Tucson
+Amateur Radio Packet Corporation. AprÃ¨s le dÃ©cÃ¨s de Bob Bruninga, la
+maintenance et la documentation d'APRS pour la communautÃ© ont Ã©tÃ©
 reprises par la Fondation APRS, dont le site web est
-https://how.aprs.works/. C'est la meilleure source d'informations à
+https://how.aprs.works/. C'est la meilleure source d'informations Ã 
 jour sur APRS.
 
 Une copie historique du site web original d'APRS de Bob Bruninga est
-disponible à l'adresse https://aprs.org/.
+disponible Ã  l'adresse https://aprs.org/.
 
-HELP-INDEX>Nouveautés de Xastir
+HELP-INDEX>NouveautÃ©s de Xastir
 
-La section « Nouveautés » de ce fichier d'aide a été longtemps
-négligée et n'a pas été mise à jour à chaque version. À partir de la
-version 2.2.4, nous avons supprimé toutes les anciennes entrées et ne
-la mettrons plus à jour.
+La section Â« NouveautÃ©s Â» de ce fichier d'aide a Ã©tÃ© longtemps
+nÃ©gligÃ©e et n'a pas Ã©tÃ© mise Ã  jour Ã  chaque version. Ã€ partir de la
+version 2.2.4, nous avons supprimÃ© toutes les anciennes entrÃ©es et ne
+la mettrons plus Ã  jour.
 
-Pour connaître les nouveautés de chaque version de Xastir, le mieux
+Pour connaÃ®tre les nouveautÃ©s de chaque version de Xastir, le mieux
 est de consulter les notes de version que nous publions sur
-GitHub. Vous pouvez les consulter à l'adresse suivante :
+GitHub. Vous pouvez les consulter Ã  l'adresse suivante :
 https://github.com/Xastir/Xastir/releases.
 
-HELP-INDEX>Débuter
-                               Débuter
+HELP-INDEX>DÃ©buter
+                               DÃ©buter
 
-Lors du premier lancement de Xastir, il est recommandé de le démarrer
-depuis une fenêtre de terminal afin de visualiser les éventuels
-messages d'avertissement ou d'erreur. Sur la plupart des systèmes, un
-chemin d'accès est configuré pour exécuter les programmes dans
-/usr/local/bin ; il vous suffit alors de taper « xastir & » à l'invite
-de commande. Sur les systèmes où ce chemin n'est pas configuré, tapez
-« /usr/local/bin/xastir & » pour démarrer le programme. Le caractère «
-& » permet de lancer Xastir en arrière-plan, libérant ainsi la fenêtre
+Lors du premier lancement de Xastir, il est recommandÃ© de le dÃ©marrer
+depuis une fenÃªtre de terminal afin de visualiser les Ã©ventuels
+messages d'avertissement ou d'erreur. Sur la plupart des systÃ¨mes, un
+chemin d'accÃ¨s est configurÃ© pour exÃ©cuter les programmes dans
+/usr/local/bin ; il vous suffit alors de taper Â« xastir & Â» Ã  l'invite
+de commande. Sur les systÃ¨mes oÃ¹ ce chemin n'est pas configurÃ©, tapez
+Â« /usr/local/bin/xastir & Â» pour dÃ©marrer le programme. Le caractÃ¨re Â«
+& Â» permet de lancer Xastir en arriÃ¨re-plan, libÃ©rant ainsi la fenÃªtre
 du terminal pour d'autres utilisations.
 
-Vous pouvez également choisir la langue à ce moment-là. Pour définir
+Vous pouvez Ã©galement choisir la langue Ã  ce moment-lÃ . Pour dÃ©finir
 la langue ou modifier la langue actuelle, lancez Xastir avec l'option
-« -l » :
+Â« -l Â» :
 
     xastir -lEnglish
 
@@ -129,26 +129,26 @@ Options de langue disponibles :
     xastir -l PigLatin
     xastir -l PirateEnglish
 
-La langue choisie sera enregistrée dans votre fichier de configuration
-et conservée pour les lancements ultérieurs de Xastir. Lors d'une
-nouvelle installation, Xastir utilise l'anglais par défaut jusqu'à ce
-que vous modifiiez la langue à l'aide de cette option de ligne de
+La langue choisie sera enregistrÃ©e dans votre fichier de configuration
+et conservÃ©e pour les lancements ultÃ©rieurs de Xastir. Lors d'une
+nouvelle installation, Xastir utilise l'anglais par dÃ©faut jusqu'Ã  ce
+que vous modifiiez la langue Ã  l'aide de cette option de ligne de
 commande.
 
-Les menus supérieurs sont accessibles à la souris ou à l'aide de
+Les menus supÃ©rieurs sont accessibles Ã  la souris ou Ã  l'aide de
 raccourcis clavier. Les raccourcis clavier peuvent ne pas fonctionner
-correctement si le verrouillage numérique est activé.
+correctement si le verrouillage numÃ©rique est activÃ©.
 
 Vous devrez configurer les interfaces pour pouvoir utiliser Xastir. La
-configuration des interfaces est détaillée dans la rubrique d'aide «
-Configuration des interfaces » et ses sous-rubriques.
+configuration des interfaces est dÃ©taillÃ©e dans la rubrique d'aide Â«
+Configuration des interfaces Â» et ses sous-rubriques.
 
-Si vous travaillez dans un contexte où un système de coordonnées autre
-que le système par défaut DD MM.MMMM serait plus approprié, vous
-pouvez sélectionner votre système préféré en allant dans Fichier |
-Configurer | Système de coordonnées. Tous les systèmes de coordonnées
-pris en charge peuvent être utilisés en entrée grâce au calculateur de
-coordonnées.
+Si vous travaillez dans un contexte oÃ¹ un systÃ¨me de coordonnÃ©es autre
+que le systÃ¨me par dÃ©faut DD MM.MMMM serait plus appropriÃ©, vous
+pouvez sÃ©lectionner votre systÃ¨me prÃ©fÃ©rÃ© en allant dans Fichier |
+Configurer | SystÃ¨me de coordonnÃ©es. Tous les systÃ¨mes de coordonnÃ©es
+pris en charge peuvent Ãªtre utilisÃ©s en entrÃ©e grÃ¢ce au calculateur de
+coordonnÃ©es.
 
 HELP-INDEX>Configuration des informations de la station
 
@@ -159,185 +159,185 @@ Cliquez sur Fichier, puis sur Configurer, puis sur Station.
 Saisissez l'indicatif d'appel de votre station radioamateur.
 
 Saisissez la position de votre station si vous n'utilisez pas Xastir
-avec un récepteur GPS. Vous pouvez localiser votre position
+avec un rÃ©cepteur GPS. Vous pouvez localiser votre position
 approximative sur la carte avec Xastir et utiliser la position
-indiquée par le curseur sur la carte. Cette position sera visible dans
-la zone située en bas de l'écran Xastir, à la deuxième position à
+indiquÃ©e par le curseur sur la carte. Cette position sera visible dans
+la zone situÃ©e en bas de l'Ã©cran Xastir, Ã  la deuxiÃ¨me position Ã 
 partir de la gauche, lorsque la souris survole la zone de dessin. Vous
-pouvez également sélectionner « Déplacer ma station ici » dans le menu
+pouvez Ã©galement sÃ©lectionner Â« DÃ©placer ma station ici Â» dans le menu
 contextuel (clic droit) lorsque votre souris se trouve sur votre
-emplacement. Si vous possédez un GPS, vous pouvez igniter cette étape
-et configurer le GPS ultérieurement.
+emplacement. Si vous possÃ©dez un GPS, vous pouvez igniter cette Ã©tape
+et configurer le GPS ultÃ©rieurement.
 
-L'option « Transmettre positions compressées », si elle est
-sélectionnée, transmettra les données au nouveau format compressé. Ce
-format réduit la quantité de données transmises, augmentant ainsi la
-capacité du réseau APRS(tm).  La précision maximale de la position
-transmise est également supérieure.  Certains programmes plus anciens,
-y compris les versions récentes de WinAPRS, ne décodent pas encore ce
-format. Findu.com pourrait également rencontrer des difficultés avec
+L'option Â« Transmettre positions compressÃ©es Â», si elle est
+sÃ©lectionnÃ©e, transmettra les donnÃ©es au nouveau format compressÃ©. Ce
+format rÃ©duit la quantitÃ© de donnÃ©es transmises, augmentant ainsi la
+capacitÃ© du rÃ©seau APRS(tm).  La prÃ©cision maximale de la position
+transmise est Ã©galement supÃ©rieure.  Certains programmes plus anciens,
+y compris les versions rÃ©centes de WinAPRS, ne dÃ©codent pas encore ce
+format. Findu.com pourrait Ã©galement rencontrer des difficultÃ©s avec
 ce format. Nous transmettons le cap et la vitesse dans ce format, mais
 pas l'altitude. L'envoi du cap, de la vitesse ET de l'altitude
-nécessite l'ajout de neuf caractères au paquet, ce qui annule en
-partie l'intérêt d'utiliser les positions compressées.
+nÃ©cessite l'ajout de neuf caractÃ¨res au paquet, ce qui annule en
+partie l'intÃ©rÃªt d'utiliser les positions compressÃ©es.
 
-Pour sélectionner un symbole pour votre station, vous devez spécifier
-un groupe et un caractère de symbole. Vous pouvez remplir ces champs
-manuellement ou appuyer sur « Sélectionner » pour choisir un symbole
+Pour sÃ©lectionner un symbole pour votre station, vous devez spÃ©cifier
+un groupe et un caractÃ¨re de symbole. Vous pouvez remplir ces champs
+manuellement ou appuyer sur Â« SÃ©lectionner Â» pour choisir un symbole
 graphiquement. Deux groupes de symboles sont disponibles. Une
 description textuelle de chaque symbole est disponible dans l'aide,
-rubrique « Table des symboles ».
+rubrique Â« Table des symboles Â».
 
-Pour certains symboles du deuxième groupe, vous pouvez spécifier une
-superposition. Un symbole sera alors affiché avec un caractère de
-superposition supplémentaire, par exemple un symbole de voiture avec
-le chiffre 1 superposé.
+Pour certains symboles du deuxiÃ¨me groupe, vous pouvez spÃ©cifier une
+superposition. Un symbole sera alors affichÃ© avec un caractÃ¨re de
+superposition supplÃ©mentaire, par exemple un symbole de voiture avec
+le chiffre 1 superposÃ©.
 
-Pour utiliser les superpositions, vous devez sélectionner un symbole
-dans la table des symboles secondaires et saisir le caractère de
-superposition à afficher dans le champ groupe/superposition. Seuls les
-chiffres et les majuscules sont autorisés comme caractères de
-superposition. Conformément à la spécification APRS(tm), tous les
-symboles ne peuvent pas être superposés. Xastir n'applique pas cette
+Pour utiliser les superpositions, vous devez sÃ©lectionner un symbole
+dans la table des symboles secondaires et saisir le caractÃ¨re de
+superposition Ã  afficher dans le champ groupe/superposition. Seuls les
+chiffres et les majuscules sont autorisÃ©s comme caractÃ¨res de
+superposition. ConformÃ©ment Ã  la spÃ©cification APRS(tm), tous les
+symboles ne peuvent pas Ãªtre superposÃ©s. Xastir n'applique pas cette
 restriction, mais certains autres programmes peuvent le
-faire. Veuillez noter que tous les symboles n'ont pas encore été
-implémentés dans le sélecteur graphique, et certains ne sont pas
-encore conformes à la spécification APRS(tm).
+faire. Veuillez noter que tous les symboles n'ont pas encore Ã©tÃ©
+implÃ©mentÃ©s dans le sÃ©lecteur graphique, et certains ne sont pas
+encore conformes Ã  la spÃ©cification APRS(tm).
 
-Ensuite, saisissez les données relatives à la puissance, à la hauteur
+Ensuite, saisissez les donnÃ©es relatives Ã  la puissance, Ã  la hauteur
 et au gain de votre station. Ces informations sont utiles mais non
-obligatoires ; il vous suffit de sélectionner « Désactiver PHG » pour
-les désactiver. Ces options offrent une représentation détaillée de la
-portée de votre station. Sélectionnez la combinaison de valeurs la
+obligatoires ; il vous suffit de sÃ©lectionner Â« DÃ©sactiver PHG Â» pour
+les dÃ©sactiver. Ces options offrent une reprÃ©sentation dÃ©taillÃ©e de la
+portÃ©e de votre station. SÃ©lectionnez la combinaison de valeurs la
 plus proche de la description de votre station. Veuillez utiliser la
 hauteur au-dessus du terrain moyen (HAAT) pour la valeur de
 hauteur. N'utilisez PAS la hauteur moyenne au-dessus du niveau de la
-mer ni la hauteur au-dessus du sol. Toutes les valeurs doivent être
-spécifiées si vous souhaitez transmettre les informations PHG.
+mer ni la hauteur au-dessus du sol. Toutes les valeurs doivent Ãªtre
+spÃ©cifiÃ©es si vous souhaitez transmettre les informations PHG.
 
-Une autre option consiste à spécifier la portée (RNG) en miles dans le
+Une autre option consiste Ã  spÃ©cifier la portÃ©e (RNG) en miles dans le
 champ de commentaire au lieu d'utiliser le PHG. Consultez la
-spécification APRS(tm) pour plus de détails.
+spÃ©cification APRS(tm) pour plus de dÃ©tails.
 
-Pour le gain, utilisez le gain de votre antenne en dBi. (À CORRIGER :
-dBd ? La spécification n'est pas claire, je pense qu'il s'agit de dBi
-car il est indiqué que « en l'absence de données, les stations sont
-censées fonctionner avec une puissance de 10 W et une antenne
-omnidirectionnelle de 3 dB à 6 mètres de hauteur. Une antenne
-omnidirectionnelle typique n'a qu'un gain de 3 dBi... »)
+Pour le gain, utilisez le gain de votre antenne en dBi. (Ã€ CORRIGER :
+dBd ? La spÃ©cification n'est pas claire, je pense qu'il s'agit de dBi
+car il est indiquÃ© que Â« en l'absence de donnÃ©es, les stations sont
+censÃ©es fonctionner avec une puissance de 10 W et une antenne
+omnidirectionnelle de 3 dB Ã  6 mÃ¨tres de hauteur. Une antenne
+omnidirectionnelle typique n'a qu'un gain de 3 dBi... Â»)
 
-Remarque : Le réglage du gain est destiné aux antennes verticales ; le
-réglage du gain pour une antenne directionnelle doit être nettement
-inférieur au gain avant de l'antenne.  En effet, avec la directivité
-définie, le cercle PHG n'est décalé que d'un tiers de sa taille vers
-la direction spécifiée. Un réglage de gain plus élevé agrandirait le
-cercle de manière irréaliste, au lieu d'augmenter la directivité.  Il
-a été question il y a plusieurs années de modifier les spécifications
+Remarque : Le rÃ©glage du gain est destinÃ© aux antennes verticales ; le
+rÃ©glage du gain pour une antenne directionnelle doit Ãªtre nettement
+infÃ©rieur au gain avant de l'antenne.  En effet, avec la directivitÃ©
+dÃ©finie, le cercle PHG n'est dÃ©calÃ© que d'un tiers de sa taille vers
+la direction spÃ©cifiÃ©e. Un rÃ©glage de gain plus Ã©levÃ© agrandirait le
+cercle de maniÃ¨re irrÃ©aliste, au lieu d'augmenter la directivitÃ©.  Il
+a Ã©tÃ© question il y a plusieurs annÃ©es de modifier les spÃ©cifications
 pour mieux prendre en compte les antennes directionnelles, mais aucune
-modification n'a été apportée.
+modification n'a Ã©tÃ© apportÃ©e.
 
 Saisissez un commentaire (facultatif), qui apportera des informations
-supplémentaires sur votre station.  Vous pouvez par exemple indiquer
-votre adresse e-mail préférée. Elle sera transmise avec vos positions.
+supplÃ©mentaires sur votre station.  Vous pouvez par exemple indiquer
+votre adresse e-mail prÃ©fÃ©rÃ©e. Elle sera transmise avec vos positions.
 
-L'ambiguïté de position vous permet de contrôler la précision de la
-transmission de votre position. Le réglage « Aucun » permet à votre
+L'ambiguÃ¯tÃ© de position vous permet de contrÃ´ler la prÃ©cision de la
+transmission de votre position. Le rÃ©glage Â« Aucun Â» permet Ã  votre
 station de transmettre la position exacte que vous avez saisie ou
-reçue d'un GPS. Les autres options vous positionneront dans la plage
-de l'option sélectionnée. Notez que cela peut perturber certaines
-stations non conformes aux spécifications. Findu.com ne prend pas en
-charge l'ambiguïté de position.
+reÃ§ue d'un GPS. Les autres options vous positionneront dans la plage
+de l'option sÃ©lectionnÃ©e. Notez que cela peut perturber certaines
+stations non conformes aux spÃ©cifications. Findu.com ne prend pas en
+charge l'ambiguÃ¯tÃ© de position.
 
 Cliquez sur OK pour enregistrer vos modifications. Cliquez sur Annuler
-pour conserver les paramètres précédents.
+pour conserver les paramÃ¨tres prÃ©cÃ©dents.
 
-HELP-INDEX>Configuration des paramètres par défaut
+HELP-INDEX>Configuration des paramÃ¨tres par dÃ©faut
 
-Configuration des paramètres par défaut
+Configuration des paramÃ¨tres par dÃ©faut
 
-Cliquez sur Fichier, puis sur Configurer, puis sur Paramètres par défaut.
+Cliquez sur Fichier, puis sur Configurer, puis sur ParamÃ¨tres par dÃ©faut.
 
-Cette page permet de configurer certains paramètres par défaut pour le
+Cette page permet de configurer certains paramÃ¨tres par dÃ©faut pour le
 fonctionnement du programme.
 
-L'option «Option de transmission» définit le type de paquet que votre
-station utilisera pour transmettre ses données.
+L'option Â«Option de transmissionÂ» dÃ©finit le type de paquet que votre
+station utilisera pour transmettre ses donnÃ©es.
 
 Les options IGate permettent de configurer votre station comme
-passerelle Internet-RF. Cette option doit être utilisée avec prudence
-; en tant qu'opérateur radioamateur, vous êtes responsable des données
-reçues via Internet et transmises par radio. Vous devrez également
+passerelle Internet-RF. Cette option doit Ãªtre utilisÃ©e avec prudence
+; en tant qu'opÃ©rateur radioamateur, vous Ãªtes responsable des donnÃ©es
+reÃ§ues via Internet et transmises par radio. Vous devrez Ã©galement
 choisir une option IGate pour chaque interface afin que la passerelle
 IGate fonctionne.  Si vous souhaitez que votre passerelle IGate
-transmette les alertes météorologiques du NWS par radio, vous devez
-créer un fichier ~/.xastir/data/nws-stations.txt listant chaque
-indicatif ou station NWS (comme « PHISVR ») que vous souhaitez
-transmettre par radio. Cette fonctionnalité permet également de
-transmettre des indicatifs spécifiques par radio.
+transmette les alertes mÃ©tÃ©orologiques du NWS par radio, vous devez
+crÃ©er un fichier ~/.xastir/data/nws-stations.txt listant chaque
+indicatif ou station NWS (comme Â« PHISVR Â») que vous souhaitez
+transmettre par radio. Cette fonctionnalitÃ© permet Ã©galement de
+transmettre des indicatifs spÃ©cifiques par radio.
 
-L'option « Transmettre les objets/éléments compressés ? », si elle est
-sélectionnée, transmettra les objets et les éléments au format
-compressé plus récent. La précision maximale de la position transmise
-est plus élevée et la transmission est plus courte, mais certains
-programmes plus anciens ne décodent pas encore ce
+L'option Â« Transmettre les objets/Ã©lÃ©ments compressÃ©s ? Â», si elle est
+sÃ©lectionnÃ©e, transmettra les objets et les Ã©lÃ©ments au format
+compressÃ© plus rÃ©cent. La prÃ©cision maximale de la position transmise
+est plus Ã©levÃ©e et la transmission est plus courte, mais certains
+programmes plus anciens ne dÃ©codent pas encore ce
 format. Actuellement, cette option ne compresse que les
-objets/éléments « standard » avec une vitesse/direction
-optionnelle. Elle ne compressera pas les objets/éléments de zone, de
-panneau ou de radiogoniométrie, et ne représente pas actuellement
-l'altitude dans les objets/éléments « standard ».
+objets/Ã©lÃ©ments Â« standard Â» avec une vitesse/direction
+optionnelle. Elle ne compressera pas les objets/Ã©lÃ©ments de zone, de
+panneau ou de radiogoniomÃ©trie, et ne reprÃ©sente pas actuellement
+l'altitude dans les objets/Ã©lÃ©ments Â« standard Â».
 
-L'option « Afficher bulletins nouveaux », si elle est
-sélectionnée, affichera la boîte de dialogue des bulletins lorsque des
-bulletins se trouvant dans la plage configurée sont reçus. L'option «
-Afficher les bulletins à distance nulle » permet de ne pas afficher
-les bulletins sans position connue ni d'afficher de fenêtres
+L'option Â« Afficher bulletins nouveaux Â», si elle est
+sÃ©lectionnÃ©e, affichera la boÃ®te de dialogue des bulletins lorsque des
+bulletins se trouvant dans la plage configurÃ©e sont reÃ§us. L'option Â«
+Afficher les bulletins Ã  distance nulle Â» permet de ne pas afficher
+les bulletins sans position connue ni d'afficher de fenÃªtres
 contextuelles.
 
-L'option « Alerter si clés modificatrices (Verr.Num.) »
+L'option Â« Alerter si clÃ©s modificatrices (Verr.Num.) Â»
 affichera un avertissement si vous tentez d'utiliser Xastir alors que
-les touches Verr. Num, Arrêt défil. ou Verr. Maj sont
-activées. Certains utilisateurs signalent un écran noir et des
-problèmes similaires lorsqu'ils tentent d'utiliser Xastir avec l'une
-de ces touches de modification activée.
+les touches Verr. Num, ArrÃªt dÃ©fil. ou Verr. Maj sont
+activÃ©es. Certains utilisateurs signalent un Ã©cran noir et des
+problÃ¨mes similaires lorsqu'ils tentent d'utiliser Xastir avec l'une
+de ces touches de modification activÃ©e.
 
-Vous pouvez également sélectionner « Activer réseau alterne ? » et
-choisir un indicatif de réseau alternatif dans cette boîte de
-dialogue. Le réseau alternatif vous permet de disposer d'un réseau
-APRS(tm) privé entre les stations qui ont également configuré le réseau
-alternatif et qui ont saisi le même indicatif de réseau
-alternatif. L'option « Désactiver identif. de duplic. posit. »
-désactive la vérification des positions en double. Cette option ne
-doit être utilisée que si une station est susceptible de revenir
-exactement à la même position (à 60 pieds près environ pour les
-positions non compressées) et que vous souhaitez afficher les
+Vous pouvez Ã©galement sÃ©lectionner Â« Activer rÃ©seau alterne ? Â» et
+choisir un indicatif de rÃ©seau alternatif dans cette boÃ®te de
+dialogue. Le rÃ©seau alternatif vous permet de disposer d'un rÃ©seau
+APRS(tm) privÃ© entre les stations qui ont Ã©galement configurÃ© le rÃ©seau
+alternatif et qui ont saisi le mÃªme indicatif de rÃ©seau
+alternatif. L'option Â« DÃ©sactiver identif. de duplic. posit. Â»
+dÃ©sactive la vÃ©rification des positions en double. Cette option ne
+doit Ãªtre utilisÃ©e que si une station est susceptible de revenir
+exactement Ã  la mÃªme position (Ã  60 pieds prÃ¨s environ pour les
+positions non compressÃ©es) et que vous souhaitez afficher les
 positions et/ou les traces en double sur la carte. Cette option est
-rarement nécessaire en pratique, mais peut s'avérer utile pour des
-événements spéciaux tels que les opérations de recherche et de
+rarement nÃ©cessaire en pratique, mais peut s'avÃ©rer utile pour des
+Ã©vÃ©nements spÃ©ciaux tels que les opÃ©rations de recherche et de
 sauvetage.
 
-L'option « Mon parcour en une seule couleur » affiche toutes les traces
-associées à votre indicatif d'appel, mais avec des SSID différents,
-dans la même couleur. Si cette option est sélectionnée, mycall-1 et
-mycall-2 s'affichent dans la même couleur. Si elle est désactivée,
-mycall-1 et mycall-2 s'affichent dans des couleurs différentes.
+L'option Â« Mon parcour en une seule couleur Â» affiche toutes les traces
+associÃ©es Ã  votre indicatif d'appel, mais avec des SSID diffÃ©rents,
+dans la mÃªme couleur. Si cette option est sÃ©lectionnÃ©e, mycall-1 et
+mycall-2 s'affichent dans la mÃªme couleur. Si elle est dÃ©sactivÃ©e,
+mycall-1 et mycall-2 s'affichent dans des couleurs diffÃ©rentes.
 
-L'option « Charger des objets prédéfinis à partir d'un fichier » et la
-liste déroulante qui la suit vous permettent de remplacer la liste des
-objets prédéfinis accessibles depuis le menu contextuel (clic droit)
+L'option Â« Charger des objets prÃ©dÃ©finis Ã  partir d'un fichier Â» et la
+liste dÃ©roulante qui la suit vous permettent de remplacer la liste des
+objets prÃ©dÃ©finis accessibles depuis le menu contextuel (clic droit)
 par votre propre liste d'objets. Un ensemble d'objets standard pour
-les opérations de recherche et de sauvetage et un ensemble d'objets
-typiques pour les événements publics sont fournis dans les fichiers
-predefined_SAR.sys et predefined_EVENT.sys. Vous pouvez également
-utiliser ces fichiers comme modèle pour créer un fichier
+les opÃ©rations de recherche et de sauvetage et un ensemble d'objets
+typiques pour les Ã©vÃ©nements publics sont fournis dans les fichiers
+predefined_SAR.sys et predefined_EVENT.sys. Vous pouvez Ã©galement
+utiliser ces fichiers comme modÃ¨le pour crÃ©er un fichier
 predefined_USER.sys. Consultez les instructions dans les fichiers
-predefined_SAR.sys et predefined_EVENT.sys pour plus de détails sur la
-manière de définir des objets pour un menu d'objets prédéfinis
-personnalisé. Si l'option « Charger les objets prédéfinis à partir d'un
-fichier » est sélectionnée et qu'un fichier existant dans le
-répertoire xastir/config/ est sélectionné, les objets définis dans ce
-fichier s'afficheront dans le menu Objets prédéfinis. Le fichier
-predefined_SAR.sys non modifié définit les mêmes objets que le menu
-par défaut.
+predefined_SAR.sys et predefined_EVENT.sys pour plus de dÃ©tails sur la
+maniÃ¨re de dÃ©finir des objets pour un menu d'objets prÃ©dÃ©finis
+personnalisÃ©. Si l'option Â« Charger les objets prÃ©dÃ©finis Ã  partir d'un
+fichier Â» est sÃ©lectionnÃ©e et qu'un fichier existant dans le
+rÃ©pertoire xastir/config/ est sÃ©lectionnÃ©, les objets dÃ©finis dans ce
+fichier s'afficheront dans le menu Objets prÃ©dÃ©finis. Le fichier
+predefined_SAR.sys non modifiÃ© dÃ©finit les mÃªmes objets que le menu
+par dÃ©faut.
 
 HELP-INDEX>Configuration de la temporisation
 
@@ -345,70 +345,70 @@ Configuration de la temporisation
 
 Cliquez sur Fichier, puis sur Configurer, puis sur Temporisation.
 
-Intervalle transmission de position (Posit TX Interval) spécifie
-la fréquence à laquelle la position de votre station sera
-transmise. Pour les stations fixes, il est recommandé de transmettre
+Intervalle transmission de position (Posit TX Interval) spÃ©cifie
+la frÃ©quence Ã  laquelle la position de votre station sera
+transmise. Pour les stations fixes, il est recommandÃ© de transmettre
 toutes les 30 minutes, et en aucun cas moins de 10 minutes. Les
-stations mobiles peuvent souhaiter utiliser une fréquence plus
+stations mobiles peuvent souhaiter utiliser une frÃ©quence plus
 rapide. Notez que si vous utilisez SmartBeaconing, ce curseur est
-ignoré.
+ignorÃ©.
 
 Intervalle maximum de transmission des objets/articles (min) (Object/Item
-Max TX Interval) est l'intervalle maximal utilisé pour l'envoi des
+Max TX Interval) est l'intervalle maximal utilisÃ© pour l'envoi des
 objets et des articles. Essayez de maintenir ces intervalles
 raisonnables, car la transmission sur une longue distance toutes les 5
 minutes consommera beaucoup de temps d'antenne.  Un algorithme
-d'intervalle décroissant est déclenché chaque fois qu'un objet est
-créé, modifié ou supprimé. L'intervalle de transmission augmentera
-jusqu'à atteindre l'intervalle maximal indiqué par le curseur.
+d'intervalle dÃ©croissant est dÃ©clenchÃ© chaque fois qu'un objet est
+crÃ©Ã©, modifiÃ© ou supprimÃ©. L'intervalle de transmission augmentera
+jusqu'Ã  atteindre l'intervalle maximal indiquÃ© par le curseur.
 
-L'intervalle de lecture GPS (GPS Check Interval) définit
-l'intervalle de temps pendant lequel le GPS est interrogé pour de
-nouvelles données. Cette option est disponible pour les stations
-utilisant un HSP ou un câble partagé avec leur TNC.
+L'intervalle de lecture GPS (GPS Check Interval) dÃ©finit
+l'intervalle de temps pendant lequel le GPS est interrogÃ© pour de
+nouvelles donnÃ©es. Cette option est disponible pour les stations
+utilisant un HSP ou un cÃ¢ble partagÃ© avec leur TNC.
 
-Expiration de point estimé (min) (Dead-Reckoning Timeout) ajuste la
-durée pendant laquelle une position est considérée comme valide pour
+Expiration de point estimÃ© (min) (Dead-Reckoning Timeout) ajuste la
+durÃ©e pendant laquelle une position est considÃ©rÃ©e comme valide pour
 l'estimation de sa position actuelle.
 
-Délai nouvel piste (min) (New Track Time) ajuste le nombre de
-minutes qui doivent s'écouler avant qu'une nouvelle trace distincte ne
-soit démarrée. Attention : régler le temps de nouvelle trace à 0
-désactivera l'affichage de toutes les traces.
+DÃ©lai nouvel piste (min) (New Track Time) ajuste le nombre de
+minutes qui doivent s'Ã©couler avant qu'une nouvelle trace distincte ne
+soit dÃ©marrÃ©e. Attention : rÃ©gler le temps de nouvelle trace Ã  0
+dÃ©sactivera l'affichage de toutes les traces.
 
 Rino->Intervalle d'objets (min) (RINO -> Objects Interval) ajuste la
-fréquence à laquelle les points de repère sont téléchargés à partir
-d'une unité radio/GPS Garmin RINO connectée. Les objets APRS(tm) sont
-créés à partir de tous les points de repère commençant par « APRS
-». Le préfixe « APRS » est supprimé lors de la création des noms
+frÃ©quence Ã  laquelle les points de repÃ¨re sont tÃ©lÃ©chargÃ©s Ã  partir
+d'une unitÃ© radio/GPS Garmin RINO connectÃ©e. Les objets APRS(tm) sont
+crÃ©Ã©s Ã  partir de tous les points de repÃ¨re commenÃ§ant par Â« APRS
+Â». Le prÃ©fixe Â« APRS Â» est supprimÃ© lors de la crÃ©ation des noms
 d'objets.
 
-Délai d'affichage faible d'une stations (min) (Station Ghosting Time)
-spécifie l'intervalle d'affichage des stations fantômes. Les stations
-qui n'ont pas été entendues pendant la période donnée apparaîtront en
-mode fantôme à l'écran.
+DÃ©lai d'affichage faible d'une stations (min) (Station Ghosting Time)
+spÃ©cifie l'intervalle d'affichage des stations fantÃ´mes. Les stations
+qui n'ont pas Ã©tÃ© entendues pendant la pÃ©riode donnÃ©e apparaÃ®tront en
+mode fantÃ´me Ã  l'Ã©cran.
 
-Délai de suppression d'affichage d'une station (Station Clear Time) spécifie le
-moment où une station sera supprimée de l'écran.
+DÃ©lai de suppression d'affichage d'une station (Station Clear Time) spÃ©cifie le
+moment oÃ¹ une station sera supprimÃ©e de l'Ã©cran.
 
-Délai de suppression d'une station (Station Delete Time) spécifie le
-nombre de jours complets avant que les données d'une station ne soient
-entièrement supprimées de la base de données Xastir.
+DÃ©lai de suppression d'une station (Station Delete Time) spÃ©cifie le
+nombre de jours complets avant que les donnÃ©es d'une station ne soient
+entiÃ¨rement supprimÃ©es de la base de donnÃ©es Xastir.
 
-Délai inter-caractères port série (Serial Inter-Char Delay) spécifie
-un temps d'attente en millisecondes entre chaque caractère envoyé à un
-TNC connecté.
+DÃ©lai inter-caractÃ¨res port sÃ©rie (Serial Inter-Char Delay) spÃ©cifie
+un temps d'attente en millisecondes entre chaque caractÃ¨re envoyÃ© Ã  un
+TNC connectÃ©.
 
-Espace nouvelle piste (en degrés) (New Track Interval (degrees))
-spécifie la distance en degrés de latitude/longitude à laquelle un
-nouveau segment de trace est démarré. Attention : régler l'intervalle
-de nouvelle trace à 0 degrés désactivera l'affichage de toutes les
+Espace nouvelle piste (en degrÃ©s) (New Track Interval (degrees))
+spÃ©cifie la distance en degrÃ©s de latitude/longitude Ã  laquelle un
+nouveau segment de trace est dÃ©marrÃ©. Attention : rÃ©gler l'intervalle
+de nouvelle trace Ã  0 degrÃ©s dÃ©sactivera l'affichage de toutes les
 traces.
 
-L'intervalle de capture instantané (en minutes) spécifie la fréquence à
-laquelle les fichiers de capture d'écran seront enregistrés si les
-options Fichier > Activer copie d'écran PNG ou Fichier > Instantané
-KML sont sélectionnées.
+L'intervalle de capture instantanÃ© (en minutes) spÃ©cifie la frÃ©quence Ã 
+laquelle les fichiers de capture d'Ã©cran seront enregistrÃ©s si les
+options Fichier > Activer copie d'Ã©cran PNG ou Fichier > InstantanÃ©
+KML sont sÃ©lectionnÃ©es.
 
 HELP-INDEX>Configuration des alarmes sonores
 
@@ -418,456 +418,456 @@ Cliquez sur Fichier, puis sur Configurer, puis sur Alarmes sonores.
 
 Pour utiliser cette option, vous devez disposer d'une carte son et
 d'un programme capable de lire les fichiers WAV. La commande de
-lecture audio doit contenir le programme que vous souhaitez exécuter
+lecture audio doit contenir le programme que vous souhaitez exÃ©cuter
 pour lire le fichier audio (ainsi que les options de ligne de commande
-éventuelles). Cela ne fonctionne évidemment pas si la seule carte son
-du système est utilisée par un modem audio...
+Ã©ventuelles). Cela ne fonctionne Ã©videmment pas si la seule carte son
+du systÃ¨me est utilisÃ©e par un modem audio...
 
-Chaque type d'alerte possède une case à cocher pour l'activer. Les
-champs contiennent le nom du fichier à lire. Les champs situés sous
-l'option permettent de définir les paramètres de cette option.
+Chaque type d'alerte possÃ¨de une case Ã  cocher pour l'activer. Les
+champs contiennent le nom du fichier Ã  lire. Les champs situÃ©s sous
+l'option permettent de dÃ©finir les paramÃ¨tres de cette option.
 
 Les options disponibles sont les suivantes :
-Émettre un son lors de la détection d'une nouvelle station.
-Émettre un son lors de la réception d'un nouveau message.
-Émettre un son lors de la réception de données d'une station située dans la
-  plage de distance définie par vos paramètres de proximité.
-Émettre un son lors de la réception de données d'une station (via TNC) située
-  dans la plage de distance définie par vos paramètres d'ouverture de bande.
-Émettre un son lors de la réception et de l'affichage d'une nouvelle alerte
-  météo.
+Ã‰mettre un son lors de la dÃ©tection d'une nouvelle station.
+Ã‰mettre un son lors de la rÃ©ception d'un nouveau message.
+Ã‰mettre un son lors de la rÃ©ception de donnÃ©es d'une station situÃ©e dans la
+  plage de distance dÃ©finie par vos paramÃ¨tres de proximitÃ©.
+Ã‰mettre un son lors de la rÃ©ception de donnÃ©es d'une station (via TNC) situÃ©e
+  dans la plage de distance dÃ©finie par vos paramÃ¨tres d'ouverture de bande.
+Ã‰mettre un son lors de la rÃ©ception et de l'affichage d'une nouvelle alerte
+  mÃ©tÃ©o.
 
 Un ensemble de sons standard est disponible dans la plupart des
-endroits où Xastir peut être téléchargé. Veuillez consulter le fichier
+endroits oÃ¹ Xastir peut Ãªtre tÃ©lÃ©chargÃ©. Veuillez consulter le fichier
 INSTALL.md pour plus d'informations.
 
-HELP-INDEX>Configuration de la synthèse vocale
+HELP-INDEX>Configuration de la synthÃ¨se vocale
 
-           Configurer la synthèse vocale
+           Configurer la synthÃ¨se vocale
 
 Pour utiliser cette option, vous devez disposer d'une carte son et du
-logiciel de synthèse vocale « Festival » installé. Installez Festival
-et lancez-le en mode « serveur » avant de démarrer XASTIR. La commande
-habituelle est « festival_server & ». Si vous utilisez l'option «
-festival --server » (ancienne méthode), vous risquez de rencontrer des
-problèmes de connexion refusée par le serveur.
+logiciel de synthÃ¨se vocale Â« Festival Â» installÃ©. Installez Festival
+et lancez-le en mode Â« serveur Â» avant de dÃ©marrer XASTIR. La commande
+habituelle est Â« festival_server & Â». Si vous utilisez l'option Â«
+festival --server Â» (ancienne mÃ©thode), vous risquez de rencontrer des
+problÃ¨mes de connexion refusÃ©e par le serveur.
 
-Une fois Festival installé, Xastir pourra utiliser la synthèse vocale
+Une fois Festival installÃ©, Xastir pourra utiliser la synthÃ¨se vocale
 avec les options suivantes :
 
 Nouvelle station : Annonce l'indicatif d'une nouvelle station.
-Alerte nouveau message : Annonce l'arrivée d'un nouveau message.
+Alerte nouveau message : Annonce l'arrivÃ©e d'un nouveau message.
 Contenu du message : Lit le contenu d'un message.
-Alerte de proximité : Annonce la réception de données d'une station
-  située dans la plage de distance définie dans les paramètres de
-  proximité. Cette option utilise les paramètres de proximité du menu
+Alerte de proximitÃ© : Annonce la rÃ©ception de donnÃ©es d'une station
+  situÃ©e dans la plage de distance dÃ©finie dans les paramÃ¨tres de
+  proximitÃ©. Cette option utilise les paramÃ¨tres de proximitÃ© du menu
   Alarmes audio.
-Alerte de proximité de la station suivie : Annonce la réception de
-  données d'une station située dans la plage de distance définie pour la
-  station suivie. Cette option utilise les paramètres de proximité du
+Alerte de proximitÃ© de la station suivie : Annonce la rÃ©ception de
+  donnÃ©es d'une station situÃ©e dans la plage de distance dÃ©finie pour la
+  station suivie. Cette option utilise les paramÃ¨tres de proximitÃ© du
   menu Alarmes audio.
-Ouverture de bande : Annonce la réception de données d'une station
-  (via TNC) située dans la plage de distance définie dans les paramètres
-  d'ouverture de bande. Cette option utilise les paramètres de distance
+Ouverture de bande : Annonce la rÃ©ception de donnÃ©es d'une station
+  (via TNC) situÃ©e dans la plage de distance dÃ©finie dans les paramÃ¨tres
+  d'ouverture de bande. Cette option utilise les paramÃ¨tres de distance
   du menu Alarmes audio.
-Nouvelle alerte météo : Non implémenté.
+Nouvelle alerte mÃ©tÃ©o : Non implÃ©mentÃ©.
 
-Des informations sur Festival sont disponibles à l'adresse suivante :
+Des informations sur Festival sont disponibles Ã  l'adresse suivante :
 https://www.cstr.ed.ac.uk/projects/festival/
 
 HELP-INDEX>Configuration de Smart Beaconing
 
 Cliquez sur Fichier, puis sur Configurer, puis sur Smart Beaconing.
 
-L'option principale « Balise intelligente (Smart Beaconing) » permet à
-Xastir de transmettre les positions à différentes fréquences et à
-différents endroits en fonction des déplacements de la station. Elle
-génèredes tracés plus réalistes et améliore considérablement la
-précision de la navigation à l'estime. Cette option n'est utile que
-pour une station mobile équipée d'un GPS.
+L'option principale Â« Balise intelligente (Smart Beaconing) Â» permet Ã 
+Xastir de transmettre les positions Ã  diffÃ©rentes frÃ©quences et Ã 
+diffÃ©rents endroits en fonction des dÃ©placements de la station. Elle
+gÃ©nÃ¨redes tracÃ©s plus rÃ©alistes et amÃ©liore considÃ©rablement la
+prÃ©cision de la navigation Ã  l'estime. Cette option n'est utile que
+pour une station mobile Ã©quipÃ©e d'un GPS.
 
 Plusieurs options sont disponibles pour personnaliser le fonctionnement de
 SmartBeaconing :
 
 Intervalle maximal
 L'intervalle (en secondes) entre l'envoi des balises lorsque la
-vitesse est supérieure au seuil de vitesse élevée. Ce paramètre est
-également utilisé pour calculer la fréquence d'envoi des balises en
+vitesse est supÃ©rieure au seuil de vitesse Ã©levÃ©e. Ce paramÃ¨tre est
+Ã©galement utilisÃ© pour calculer la frÃ©quence d'envoi des balises en
 fonction de la vitesse lorsque celle-ci se situe entre les vitesses
-basse et élevée.
+basse et Ã©levÃ©e.
 
 Vitesse haute
-Le seuil de vitesse qui déclenche l'envoi des balises à la fréquence
-spécifiée ci-dessus.
+Le seuil de vitesse qui dÃ©clenche l'envoi des balises Ã  la frÃ©quence
+spÃ©cifiÃ©e ci-dessus.
 
 Intervalle minimal
 L'intervalle (en minutes) entre l'envoi des balises lorsque la vitesse
-est inférieure au seuil de vitesse basse. Il s'agit de la fréquence
-d'envoi des balises à l'arrêt.  Ce paramètre n'est pas utilisé lorsque
-la vitesse est supérieure au seuil de vitesse basse.
+est infÃ©rieure au seuil de vitesse basse. Il s'agit de la frÃ©quence
+d'envoi des balises Ã  l'arrÃªt.  Ce paramÃ¨tre n'est pas utilisÃ© lorsque
+la vitesse est supÃ©rieure au seuil de vitesse basse.
 
 Vitesse basse
-Le seuil de vitesse qui déclenche l'envoi des balises à la fréquence
-spécifiée ci-dessus.
+Le seuil de vitesse qui dÃ©clenche l'envoi des balises Ã  la frÃ©quence
+spÃ©cifiÃ©e ci-dessus.
 
 Virage minimum
-L'angle minimum (en degrés) à partir duquel un virage est détecté à
-vitesse élevée ou supérieure.  À des vitesses inférieures, un angle de
-virage plus important sera nécessaire pour déclencher l'envoi d'une
-position, en fonction de la valeur du paramètre « Pente de virage »
+L'angle minimum (en degrÃ©s) Ã  partir duquel un virage est dÃ©tectÃ© Ã 
+vitesse Ã©levÃ©e ou supÃ©rieure.  Ã€ des vitesses infÃ©rieures, un angle de
+virage plus important sera nÃ©cessaire pour dÃ©clencher l'envoi d'une
+position, en fonction de la valeur du paramÃ¨tre Â« Pente de virage Â»
 ci-dessous.
 
 Pente de virage
 Facteur d'ajustement permettant de rendre les virages moins sensibles
-à basse vitesse. Ce paramètre n'a pas d'unité. Son comportement est
-non linéaire sur la plage de vitesses, conformément au fonctionnement
+Ã  basse vitesse. Ce paramÃ¨tre n'a pas d'unitÃ©. Son comportement est
+non linÃ©aire sur la plage de vitesses, conformÃ©ment au fonctionnement
 de l'algorithme SmartBeaconing(tm) original.
 
 Temps d'attente
-Le temps (en secondes) entre l'envoi de deux balises consécutives lors
-d'un virage. Permet d'éviter l'envoi de plusieurs balises en
+Le temps (en secondes) entre l'envoi de deux balises consÃ©cutives lors
+d'un virage. Permet d'Ã©viter l'envoi de plusieurs balises en
 succession rapide.
 
-HELP-INDEX>Configurer les unités de mesure
+HELP-INDEX>Configurer les unitÃ©s de mesure
 
-           Configurer les unités de mesure
+           Configurer les unitÃ©s de mesure
 
-Par défaut, le système métrique est sélectionné : mm, cm, km/h,
-etc. Pour sélectionner les unités impériales (pouces, pieds, mph,
-etc.), cliquez sur Fichier, puis sur Configurer, et cochez la case «
-Active mesures anglaises ».
+Par dÃ©faut, le systÃ¨me mÃ©trique est sÃ©lectionnÃ© : mm, cm, km/h,
+etc. Pour sÃ©lectionner les unitÃ©s impÃ©riales (pouces, pieds, mph,
+etc.), cliquez sur Fichier, puis sur Configurer, et cochez la case Â«
+Active mesures anglaises Â».
 
 HELP-INDEX>Sauvegarder la configuration maintenant !
 
            Sauvegarder la configuration maintenant !
 
 Ce bouton enregistre toute la configuration actuelle dans le fichier
-de configuration.  Notez que lorsque Xastir est fermé, il enregistre
-également la configuration dans le fichier de configuration.
+de configuration.  Notez que lorsque Xastir est fermÃ©, il enregistre
+Ã©galement la configuration dans le fichier de configuration.
 
-HELP-INDEX>Barre d'état inférieure
+HELP-INDEX>Barre d'Ã©tat infÃ©rieure
 
-           Barre d'état inférieure
+           Barre d'Ã©tat infÃ©rieure
 
-Au bas de la fenêtre, divers messages d'état sont affichés :
+Au bas de la fenÃªtre, divers messages d'Ã©tat sont affichÃ©s :
 
-Dans la première case à gauche, des messages d'état généraux s'affichent
-brièvement.
+Dans la premiÃ¨re case Ã  gauche, des messages d'Ã©tat gÃ©nÃ©raux s'affichent
+briÃ¨vement.
 
-La deuxième case affiche les coordonnées latitude/longitude ou UTM,
-ainsi que la position de la souris sur la carte selon le système de
-grille Maidenhead.  Si l'option Fichier | Configurer | État
-distance/cap est sélectionnée, cette case affichera également le cap
-et la distance de cette position par rapport à votre station.
+La deuxiÃ¨me case affiche les coordonnÃ©es latitude/longitude ou UTM,
+ainsi que la position de la souris sur la carte selon le systÃ¨me de
+grille Maidenhead.  Si l'option Fichier | Configurer | Ã‰tat
+distance/cap est sÃ©lectionnÃ©e, cette case affichera Ã©galement le cap
+et la distance de cette position par rapport Ã  votre station.
 
-Une troisième case indique le nombre de stations affichées à l'écran
-et le nombre de stations présentes dans la base de données.
+Une troisiÃ¨me case indique le nombre de stations affichÃ©es Ã  l'Ã©cran
+et le nombre de stations prÃ©sentes dans la base de donnÃ©es.
 
-La quatrième case affiche le niveau de zoom actuel et affiche « Tr »
-si le suivi des stations est activé. À certains niveaux de zoom, « Tr
-» n'est pas affiché correctement en raison de la taille de la case.
+La quatriÃ¨me case affiche le niveau de zoom actuel et affiche Â« Tr Â»
+si le suivi des stations est activÃ©. Ã€ certains niveaux de zoom, Â« Tr
+Â» n'est pas affichÃ© correctement en raison de la taille de la case.
 
-La cinquième case indique si l'enregistrement est activé.
+La cinquiÃ¨me case indique si l'enregistrement est activÃ©.
 
-La dernière zone affiche l'état de chaque interface. Les interfaces
-sont affichées de gauche à droite, de 0 à 9. L'état de chaque
-interface est divisé en trois parties : type de périphérique (en
-haut), flux de données (au centre) et état de fonctionnement de
+La derniÃ¨re zone affiche l'Ã©tat de chaque interface. Les interfaces
+sont affichÃ©es de gauche Ã  droite, de 0 Ã  9. L'Ã©tat de chaque
+interface est divisÃ© en trois parties : type de pÃ©riphÃ©rique (en
+haut), flux de donnÃ©es (au centre) et Ã©tat de fonctionnement de
 l'interface (en bas).
 
-Le type de périphérique indique les interfaces configurées. La couleur
-indique le type de périphérique configuré pour l'interface. Le bleu
-correspond aux différents périphériques TNC ; le vert aux
-périphériques GPS ; le jaune aux serveurs Internet ; l'orange aux
-interfaces météo.
+Le type de pÃ©riphÃ©rique indique les interfaces configurÃ©es. La couleur
+indique le type de pÃ©riphÃ©rique configurÃ© pour l'interface. Le bleu
+correspond aux diffÃ©rents pÃ©riphÃ©riques TNC ; le vert aux
+pÃ©riphÃ©riques GPS ; le jaune aux serveurs Internet ; l'orange aux
+interfaces mÃ©tÃ©o.
 
-La partie centrale indique le flux de données entrant (flèche vers la
-gauche) ou sortant (flèche vers la droite) pour cette interface.
+La partie centrale indique le flux de donnÃ©es entrant (flÃ¨che vers la
+gauche) ou sortant (flÃ¨che vers la droite) pour cette interface.
 
-Un carré vert en bas indique si l'interface est active. Un carré rouge
-indique que l'interface est active mais en état d'erreur. Sinon, rien
-n'est affiché si l'interface n'est pas active.
+Un carrÃ© vert en bas indique si l'interface est active. Un carrÃ© rouge
+indique que l'interface est active mais en Ã©tat d'erreur. Sinon, rien
+n'est affichÃ© si l'interface n'est pas active.
 
-HELP-INDEX>Déplacement de la carte et du menu Options
+HELP-INDEX>DÃ©placement de la carte et du menu Options
 
-           Déplacement de la carte et du menu Options
+           DÃ©placement de la carte et du menu Options
 
-Le déplacement de la carte est très simple ; la fluidité et la
-rapidité des mouvements dépendent de la vitesse de votre processeur et
-de la quantité de détails chargés. Astuce : Vous pouvez désactiver
-toutes les cartes dans le menu Cartes afin de vous déplacer
-rapidement, puis les réactiver.
+Le dÃ©placement de la carte est trÃ¨s simple ; la fluiditÃ© et la
+rapiditÃ© des mouvements dÃ©pendent de la vitesse de votre processeur et
+de la quantitÃ© de dÃ©tails chargÃ©s. Astuce : Vous pouvez dÃ©sactiver
+toutes les cartes dans le menu Cartes afin de vous dÃ©placer
+rapidement, puis les rÃ©activer.
 
 Zoom :
 Le zoom s'effectue en cliquant avec le bouton droit de la souris sur
-la carte (et en maintenant le bouton enfoncé). Un menu d'options
-s'affiche, proposant de zoomer ou de dézoomer d'un niveau, ou de
-choisir l'un des niveaux de zoom prédéfinis.
+la carte (et en maintenant le bouton enfoncÃ©). Un menu d'options
+s'affiche, proposant de zoomer ou de dÃ©zoomer d'un niveau, ou de
+choisir l'un des niveaux de zoom prÃ©dÃ©finis.
 
 Toutes les fonctions de zoom du menu Options effectuent un zoom avant
-ou arrière au point où vous avez cliqué avec le bouton droit de la
-souris. Les niveaux de zoom sont organisés en menu déroulant. Les
-niveaux 1 à 64 correspondent à des zones très locales et les niveaux
-256 et supérieurs à de grandes zones. Plus le niveau est bas, plus la
+ou arriÃ¨re au point oÃ¹ vous avez cliquÃ© avec le bouton droit de la
+souris. Les niveaux de zoom sont organisÃ©s en menu dÃ©roulant. Les
+niveaux 1 Ã  64 correspondent Ã  des zones trÃ¨s locales et les niveaux
+256 et supÃ©rieurs Ã  de grandes zones. Plus le niveau est bas, plus la
 zone est locale.
 
-Une fonction de zoom avant plus rapide consiste à maintenir le bouton
-gauche de la souris enfoncé, à le faire glisser sur la zone d'intérêt
-et à le relâcher. La carte effectuera un zoom à peu près à la taille
-du carré que vous venez de dessiner avec la souris. Les cases à cocher
-« Déplacer » et « Mesurer » de la barre d'outils doivent être
-désactivées pour que cette fonction soit opérationnelle. Cliquer sur
-le bouton central effectue un zoom arrière d'un facteur 2, en centrant
-la carte sur le point où vous avez cliqué.
+Une fonction de zoom avant plus rapide consiste Ã  maintenir le bouton
+gauche de la souris enfoncÃ©, Ã  le faire glisser sur la zone d'intÃ©rÃªt
+et Ã  le relÃ¢cher. La carte effectuera un zoom Ã  peu prÃ¨s Ã  la taille
+du carrÃ© que vous venez de dessiner avec la souris. Les cases Ã  cocher
+Â« DÃ©placer Â» et Â« Mesurer Â» de la barre d'outils doivent Ãªtre
+dÃ©sactivÃ©es pour que cette fonction soit opÃ©rationnelle. Cliquer sur
+le bouton central effectue un zoom arriÃ¨re d'un facteur 2, en centrant
+la carte sur le point oÃ¹ vous avez cliquÃ©.
 
-La carte peut également être zoomée à l'aide des touches Page
-précédente/Page suivante du clavier, ou des boutons « Zoom avant » et
-« Zoom arrière » de la barre d'outils. Dans ce cas, le centre de la
-carte reste le même (pas de centrage).
+La carte peut Ã©galement Ãªtre zoomÃ©e Ã  l'aide des touches Page
+prÃ©cÃ©dente/Page suivante du clavier, ou des boutons Â« Zoom avant Â» et
+Â« Zoom arriÃ¨re Â» de la barre d'outils. Dans ce cas, le centre de la
+carte reste le mÃªme (pas de centrage).
 
-Déplacement/Centrage :
-La carte peut être centrée sur un emplacement spécifique en
-sélectionnant « Centrer » dans le menu contextuel (clic droit).
+DÃ©placement/Centrage :
+La carte peut Ãªtre centrÃ©e sur un emplacement spÃ©cifique en
+sÃ©lectionnant Â« Centrer Â» dans le menu contextuel (clic droit).
 
-Le déplacement s'effectue également à l'aide du menu Options ou des
-flèches de la barre d'outils. La position de la carte se déplace d'une
-partie de l'écran.  Suffisamment de données de l'écran précédent
-doivent être disponibles pour vous permettre de vous réorienter.
+Le dÃ©placement s'effectue Ã©galement Ã  l'aide du menu Options ou des
+flÃ¨ches de la barre d'outils. La position de la carte se dÃ©place d'une
+partie de l'Ã©cran.  Suffisamment de donnÃ©es de l'Ã©cran prÃ©cÃ©dent
+doivent Ãªtre disponibles pour vous permettre de vous rÃ©orienter.
 
-La carte peut également être déplacée à l'aide des flèches du clavier.
+La carte peut Ã©galement Ãªtre dÃ©placÃ©e Ã  l'aide des flÃ¨ches du clavier.
 
 Plus d'informations sur le menu Options :
 
 Marque-pages d'affichage de carte
-Voir la rubrique d'aide « Création et utilisation des marque-pages
-d'affichage de carte »
+Voir la rubrique d'aide Â« CrÃ©ation et utilisation des marque-pages
+d'affichage de carte Â»
 
-La sélection « Informations sur la station » dans le menu Options
-recherche la station la plus proche de l'endroit où vous avez cliqué
-avec le bouton droit de la souris. Si plusieurs stations se trouvent à
-proximité de cette position, une liste de sélection de stations
-s'affichera, vous permettant de choisir les données de la station que
-vous souhaitez consulter. Si une seule station se trouve à proximité
-du pointeur de la souris, ses données s'afficheront
-immédiatement. Pour les stations mobiles disposant de nombreuses
-données de suivi, cette opération peut prendre un certain temps sur
-les ordinateurs lents. Notez que les données des stations expirées
-sont toujours stockées dans la base de données Xastir, et si vous
+La sÃ©lection Â« Informations sur la station Â» dans le menu Options
+recherche la station la plus proche de l'endroit oÃ¹ vous avez cliquÃ©
+avec le bouton droit de la souris. Si plusieurs stations se trouvent Ã 
+proximitÃ© de cette position, une liste de sÃ©lection de stations
+s'affichera, vous permettant de choisir les donnÃ©es de la station que
+vous souhaitez consulter. Si une seule station se trouve Ã  proximitÃ©
+du pointeur de la souris, ses donnÃ©es s'afficheront
+immÃ©diatement. Pour les stations mobiles disposant de nombreuses
+donnÃ©es de suivi, cette opÃ©ration peut prendre un certain temps sur
+les ordinateurs lents. Notez que les donnÃ©es des stations expirÃ©es
+sont toujours stockÃ©es dans la base de donnÃ©es Xastir, et si vous
 connaissez l'ancien emplacement d'une station, vous pouvez toujours
-consulter ses informations de cette manière. Utilisez l'option «
-Inclure donnèes périmées » pour afficher certaines données qui
+consulter ses informations de cette maniÃ¨re. Utilisez l'option Â«
+Inclure donnÃ¨es pÃ©rimÃ©es Â» pour afficher certaines donnÃ©es qui
 disparaissent pour les stations inactives, comme la vitesse,
 l'altitude, etc.
 
-Avec « Pos/zoom précédent », vous pouvez restaurer la vue précédente
-de la carte en rétablissant les valeurs précédentes de zoom et de
+Avec Â« Pos/zoom prÃ©cÃ©dent Â», vous pouvez restaurer la vue prÃ©cÃ©dente
+de la carte en rÃ©tablissant les valeurs prÃ©cÃ©dentes de zoom et de
 centrage.
 
-Pour plus d'informations sur les objets et les éléments, veuillez
-consulter la rubrique d'aide « Objets et Articles ».
+Pour plus d'informations sur les objets et les Ã©lÃ©ments, veuillez
+consulter la rubrique d'aide Â« Objets et Articles Â».
 
-L'option « Dessiner objets CAD » vous permet de créer des
-polygones à l'écran, à des fins tactiques ou de présentation. Cette
-fonctionnalité est encore en cours de développement.
+L'option Â« Dessiner objets CAD Â» vous permet de crÃ©er des
+polygones Ã  l'Ã©cran, Ã  des fins tactiques ou de prÃ©sentation. Cette
+fonctionnalitÃ© est encore en cours de dÃ©veloppement.
 
-« Déplacer ma station ici » vous permet de déplacer votre station vers
-un emplacement spécifié sur la carte sans modifier la configuration de
+Â« DÃ©placer ma station ici Â» vous permet de dÃ©placer votre station vers
+un emplacement spÃ©cifiÃ© sur la carte sans modifier la configuration de
 la station.
 
 HELP-INDEX>Objets et articles
 
-Une station peut placer plusieurs objets différents sur la carte, leur
-position étant transmise aux autres stations. Les noms d'objets sont
+Une station peut placer plusieurs objets diffÃ©rents sur la carte, leur
+position Ã©tant transmise aux autres stations. Les noms d'objets sont
 moins restrictifs que les noms de stations habituels.
 
 Les objets et les articles sont presque identiques, mais leur
-utilisation peut différer légèrement.  Les objets sont généralement
-utilisés pour des articles mobiles ou variables tels que les orages,
-tandis que les articles sont généralement utilisés pour des articles
+utilisation peut diffÃ©rer lÃ©gÃ¨rement.  Les objets sont gÃ©nÃ©ralement
+utilisÃ©s pour des articles mobiles ou variables tels que les orages,
+tandis que les articles sont gÃ©nÃ©ralement utilisÃ©s pour des articles
 plus statiques, comme les points d'eau.  Comme les articles peuvent ne
-pas être décodés par certaines versions des programmes APRS(tm), les
-objets sont souvent également utilisés pour les articles statiques.
+pas Ãªtre dÃ©codÃ©s par certaines versions des programmes APRS(tm), les
+objets sont souvent Ã©galement utilisÃ©s pour les articles statiques.
 
-Outre les objets normaux avec un symbole à leur position, il existe
-des objets spéciaux.  Les objets de zone sont utiles pour diverses
-opérations permettant de dessiner ou de mettre en évidence une zone
-d'intérêt sur la carte. Ils peuvent également être utilisés pour
-dessiner des sentiers/routes/frontières, des zones de surveillance
-météorologique, des pistes d'atterrissage, le périmètre d'une zone de
-recherche ou d'un événement de service public, des zones endommagées,
-des zones à éviter, des bâtiments non représentés sur la carte, des
-échiquiers pour jouer sur APRS(tm). :-) Notez que les objets de zone ne
-sont pas implémentés dans toutes les versions des programmes APRS(tm), et
-certains détails de leur affichage peuvent également différer selon
+Outre les objets normaux avec un symbole Ã  leur position, il existe
+des objets spÃ©ciaux.  Les objets de zone sont utiles pour diverses
+opÃ©rations permettant de dessiner ou de mettre en Ã©vidence une zone
+d'intÃ©rÃªt sur la carte. Ils peuvent Ã©galement Ãªtre utilisÃ©s pour
+dessiner des sentiers/routes/frontiÃ¨res, des zones de surveillance
+mÃ©tÃ©orologique, des pistes d'atterrissage, le pÃ©rimÃ¨tre d'une zone de
+recherche ou d'un Ã©vÃ©nement de service public, des zones endommagÃ©es,
+des zones Ã  Ã©viter, des bÃ¢timents non reprÃ©sentÃ©s sur la carte, des
+Ã©chiquiers pour jouer sur APRS(tm). :-) Notez que les objets de zone ne
+sont pas implÃ©mentÃ©s dans toutes les versions des programmes APRS(tm), et
+certains dÃ©tails de leur affichage peuvent Ã©galement diffÃ©rer selon
 les programmes.  Pour les trois autres types d'objets (cercles de
-probabilité, panneaux et objets DF), voir ci-dessous.
+probabilitÃ©, panneaux et objets DF), voir ci-dessous.
 
-Les objets/articles sont retransmis à un rythme décroissant jusqu'à
-l'intervalle maximal spécifié dans
-Fichier|Configurer|Synchronisation. Les objets/articles « supprimés »
-sont également retransmis de cette manière jusqu'à ce qu'ils soient
-retirés de la file d'attente (actuellement 20 transmissions).  Les
-objets/articles sont conservés entre les sessions Xastir et sont
-stockés dans ~/.xastir/config/object.log.  Ce fichier peut être vidé
-en sélectionnant « Effacer histoire des objets/articles » dans le
+Les objets/articles sont retransmis Ã  un rythme dÃ©croissant jusqu'Ã 
+l'intervalle maximal spÃ©cifiÃ© dans
+Fichier|Configurer|Synchronisation. Les objets/articles Â« supprimÃ©s Â»
+sont Ã©galement retransmis de cette maniÃ¨re jusqu'Ã  ce qu'ils soient
+retirÃ©s de la file d'attente (actuellement 20 transmissions).  Les
+objets/articles sont conservÃ©s entre les sessions Xastir et sont
+stockÃ©s dans ~/.xastir/config/object.log.  Ce fichier peut Ãªtre vidÃ©
+en sÃ©lectionnant Â« Effacer histoire des objets/articles Â» dans le
 menu Stations.
 
-L'option de création d'objet/article dans le menu contextuel (clic
-droit) affiche une boîte de dialogue avec la position de votre objet
-pré-remplie en fonction de l'endroit où vous avez cliqué.  Vous pouvez
-renseigner les détails et ajouter un objet/article à partir de ce
+L'option de crÃ©ation d'objet/article dans le menu contextuel (clic
+droit) affiche une boÃ®te de dialogue avec la position de votre objet
+prÃ©-remplie en fonction de l'endroit oÃ¹ vous avez cliquÃ©.  Vous pouvez
+renseigner les dÃ©tails et ajouter un objet/article Ã  partir de ce
 menu.
 
-L'option de modification d'objet/article affiche la boîte de dialogue
-de modification d'objet. Ceci est similaire à la boîte de dialogue de
-création d'objet, à la différence que les informations actuelles de
-l'objet sont déjà renseignées et que son nom ainsi que certaines
-autres options ne peuvent pas être modifiés. Vous pouvez également
-supprimer l'objet à l'aide de cette option.
+L'option de modification d'objet/article affiche la boÃ®te de dialogue
+de modification d'objet. Ceci est similaire Ã  la boÃ®te de dialogue de
+crÃ©ation d'objet, Ã  la diffÃ©rence que les informations actuelles de
+l'objet sont dÃ©jÃ  renseignÃ©es et que son nom ainsi que certaines
+autres options ne peuvent pas Ãªtre modifiÃ©s. Vous pouvez Ã©galement
+supprimer l'objet Ã  l'aide de cette option.
 
-Les objets et les articles peuvent être déplacés à la souris si la
-case à cocher « Déplacer » de la barre d'outils est activée.
+Les objets et les articles peuvent Ãªtre dÃ©placÃ©s Ã  la souris si la
+case Ã  cocher Â« DÃ©placer Â» de la barre d'outils est activÃ©e.
 
-L'option Objets prédéfinis du menu contextuel permet de placer
+L'option Objets prÃ©dÃ©finis du menu contextuel permet de placer
 rapidement des objets standard de recherche et de sauvetage sans avoir
-à passer par la boîte de dialogue de création d'objet/article. Ces
-objets comprennent les symboles standard du système de commandement
+Ã  passer par la boÃ®te de dialogue de crÃ©ation d'objet/article. Ces
+objets comprennent les symboles standard du systÃ¨me de commandement
 des incidents pour le poste de commandement (ICP), la zone de
-rassemblement (Staging), la base et l'héliport, ainsi que les objets
+rassemblement (Staging), la base et l'hÃ©liport, ainsi que les objets
 SAR pour PLS, IPP (avec 4 cercles de zone) et LKP. Si un objet portant
-le même nom qu'un objet sélectionné dans la liste existe déjà, un
-nouvel objet sera créé avec un numéro ajouté à la fin. Par exemple, la
-première fois que vous sélectionnez Staging dans le menu Objets
-prédéfinis, un objet nommé Staging sera créé. Si vous créez ensuite un
-autre objet Staging à partir du menu Objets prédéfinis, il sera nommé
-Staging2. Les objets commençant par « Heli- » (et les objets définis
-par l'utilisateur se terminant par un « - ») seront créés sous les
-noms Heli-1, Heli-2, Heli-3, etc. Si vous avez reçu l'un de ces objets
+le mÃªme nom qu'un objet sÃ©lectionnÃ© dans la liste existe dÃ©jÃ , un
+nouvel objet sera crÃ©Ã© avec un numÃ©ro ajoutÃ© Ã  la fin. Par exemple, la
+premiÃ¨re fois que vous sÃ©lectionnez Staging dans le menu Objets
+prÃ©dÃ©finis, un objet nommÃ© Staging sera crÃ©Ã©. Si vous crÃ©ez ensuite un
+autre objet Staging Ã  partir du menu Objets prÃ©dÃ©finis, il sera nommÃ©
+Staging2. Les objets commenÃ§ant par Â« Heli- Â» (et les objets dÃ©finis
+par l'utilisateur se terminant par un Â« - Â») seront crÃ©Ã©s sous les
+noms Heli-1, Heli-2, Heli-3, etc. Si vous avez reÃ§u l'un de ces objets
 standard transmis par une autre station, votre premier objet sera
-nommé avec un numéro ajouté. Vous pouvez attribuer un indicatif
-tactique à votre objet dans ce cas (par exemple, remplacer ICP2 par un
+nommÃ© avec un numÃ©ro ajoutÃ©. Vous pouvez attribuer un indicatif
+tactique Ã  votre objet dans ce cas (par exemple, remplacer ICP2 par un
 indicatif tactique).
 
-Le menu Objets prédéfinis est personnalisable en modifiant les
+Le menu Objets prÃ©dÃ©finis est personnalisable en modifiant les
 fichiers predefined_SAR.sys, predefined_EVENT.sys et
-predefined_USER.sys, puis en sélectionnant l'un de ces fichiers via la
-boîte de dialogue Fichier/Configuration/Paramètres par défaut. Voir le
-fichier predefined_SAR.sys pour plus de détails.
+predefined_USER.sys, puis en sÃ©lectionnant l'un de ces fichiers via la
+boÃ®te de dialogue Fichier/Configuration/ParamÃ¨tres par dÃ©faut. Voir le
+fichier predefined_SAR.sys pour plus de dÃ©tails.
 
-Description des entrées dans la boîte de dialogue d'objet :
+Description des entrÃ©es dans la boÃ®te de dialogue d'objet :
 
 = Panneau =
-Ceci fait de l'objet un panneau. Ces panneaux peuvent contenir un à
-trois caractères et apparaissent actuellement dans Xastir comme un
+Ceci fait de l'objet un panneau. Ces panneaux peuvent contenir un Ã 
+trois caractÃ¨res et apparaissent actuellement dans Xastir comme un
 panneau vide. Les informations de la station affichent la valeur
 contenue sur le panneau.
 
 = Objet polygonal =
 Ceci fait de l'objet un objet de zone et active les commandes d'objet
-de zone décrites ci-dessous.
+de zone dÃ©crites ci-dessous.
 
 = Objet DF =
-Il s'agit d'un rapport de radiogoniométrie. L'activer vous permet de
-choisir un rapport omnidirectionnel ou directionnel, et de spécifier
-les paramètres pour chacun. Voir : https://www.aprs.org/dfing.html
+Il s'agit d'un rapport de radiogoniomÃ©trie. L'activer vous permet de
+choisir un rapport omnidirectionnel ou directionnel, et de spÃ©cifier
+les paramÃ¨tres pour chacun. Voir : https://www.aprs.org/dfing.html
 pour la description de Bob Bruninga sur l'utilisation de ces
-techniques.  (À FAIRE : Section séparée sur les techniques de
-radiogoniométrie ?)
+techniques.  (Ã€ FAIRE : Section sÃ©parÃ©e sur les techniques de
+radiogoniomÃ©trie ?)
 
-= Cercles de probabilité =
+= Cercles de probabilitÃ© =
 
-Cela vous permet de définir le rayon (en miles) de deux cercles
-centrés sur l'objet ou l'article. Min correspond au rayon (en miles)
-du plus petit cercle intérieur, et Max au rayon (en miles) du plus
-grand cercle extérieur.  Ces cercles sont tracés en rouge. Ils peuvent
-être utilisés pour faciliter la planification des opérations de
-recherche et de sauvetage. Pour créer plus de deux cercles, ajoutez
-des objets de cercle de probabilité supplémentaires au même
-emplacement. Les cercles de probabilité peuvent ne pas être affichés
+Cela vous permet de dÃ©finir le rayon (en miles) de deux cercles
+centrÃ©s sur l'objet ou l'article. Min correspond au rayon (en miles)
+du plus petit cercle intÃ©rieur, et Max au rayon (en miles) du plus
+grand cercle extÃ©rieur.  Ces cercles sont tracÃ©s en rouge. Ils peuvent
+Ãªtre utilisÃ©s pour faciliter la planification des opÃ©rations de
+recherche et de sauvetage. Pour crÃ©er plus de deux cercles, ajoutez
+des objets de cercle de probabilitÃ© supplÃ©mentaires au mÃªme
+emplacement. Les cercles de probabilitÃ© peuvent ne pas Ãªtre affichÃ©s
 par d'autres logiciels clients.
 
 = Nom =
-Il s'agit du nom de l'objet ou de l'article. Il peut contenir jusqu'à
-9 caractères.  Les espaces sont autorisés dans le nom. Lors de la
-modification d'un objet, ce champ ne peut pas être modifié. Pour
-renommer un objet, vous devez supprimer l'original, puis créer un
-nouvel objet. Notez que si vous sélectionnez Panneau/Objet de
-zone/Objet DF, ce champ et éventuellement d'autres sont
-effacés. Saisissez le nom APRÈS avoir sélectionné le type d'objet.
+Il s'agit du nom de l'objet ou de l'article. Il peut contenir jusqu'Ã 
+9 caractÃ¨res.  Les espaces sont autorisÃ©s dans le nom. Lors de la
+modification d'un objet, ce champ ne peut pas Ãªtre modifiÃ©. Pour
+renommer un objet, vous devez supprimer l'original, puis crÃ©er un
+nouvel objet. Notez que si vous sÃ©lectionnez Panneau/Objet de
+zone/Objet DF, ce champ et Ã©ventuellement d'autres sont
+effacÃ©s. Saisissez le nom APRÃˆS avoir sÃ©lectionnÃ© le type d'objet.
 
 = Symbole de station =
-Vous pouvez sélectionner un symbole pour l'objet. Appuyez sur
-Sélectionner pour choisir graphiquement, ou consultez la section
+Vous pouvez sÃ©lectionner un symbole pour l'objet. Appuyez sur
+SÃ©lectionner pour choisir graphiquement, ou consultez la section
 d'aide du tableau des symboles pour obtenir des descriptions de chaque
-symbole. Notez également que les objets de zone, les objets de panneau
-et les objets DF ont des symboles fixes spéciaux et ne peuvent donc
-pas être sélectionnés ici. Ces symboles particuliers sont
-automatiquement attribués lorsque vous changez de type d'objet.
+symbole. Notez Ã©galement que les objets de zone, les objets de panneau
+et les objets DF ont des symboles fixes spÃ©ciaux et ne peuvent donc
+pas Ãªtre sÃ©lectionnÃ©s ici. Ces symboles particuliers sont
+automatiquement attribuÃ©s lorsque vous changez de type d'objet.
 
 = Emplacement =
-L'emplacement de l'objet est spécifié ici. Si vous avez sélectionné «
-Créer objet/élément » dans le menu contextuel, l'emplacement sur
-lequel vous avez cliqué sera renseigné. Si vous avez déplacé un objet
+L'emplacement de l'objet est spÃ©cifiÃ© ici. Si vous avez sÃ©lectionnÃ© Â«
+CrÃ©er objet/Ã©lÃ©ment Â» dans le menu contextuel, l'emplacement sur
+lequel vous avez cliquÃ© sera renseignÃ©. Si vous avez dÃ©placÃ© un objet
 avec la souris, le nouvel emplacement s'affichera dans ces
-champs. Vous pouvez également saisir un emplacement, par exemple si
-vous placez un objet à partir d'un rapport vocal reçu par radio.
+champs. Vous pouvez Ã©galement saisir un emplacement, par exemple si
+vous placez un objet Ã  partir d'un rapport vocal reÃ§u par radio.
 
-= Options génériques =
-Vous pouvez spécifier la vitesse, la direction et l'altitude des
+= Options gÃ©nÃ©riques =
+Vous pouvez spÃ©cifier la vitesse, la direction et l'altitude des
 objets ici. Certains types d'objets ne peuvent pas avoir de vitesse ou
-de direction, auquel cas les champs sont grisés.
+de direction, auquel cas les champs sont grisÃ©s.
 
 = Texte du panneau =
-Si l'objet est un panneau, vous pouvez spécifier le numéro à 1 à 3
-chiffres qui apparaît sur le panneau ici. Notez que Xastir n'affiche
+Si l'objet est un panneau, vous pouvez spÃ©cifier le numÃ©ro Ã  1 Ã  3
+chiffres qui apparaÃ®t sur le panneau ici. Notez que Xastir n'affiche
 pas encore correctement les objets de panneau.
 
 = Objet polygonal =
 
-Les objets de zone sont utilisés pour mettre en évidence des parties
-spécifiques des cartes ou pour ajouter des détails supplémentaires aux
-cartes. Cela se fait à l'aide des entrées suivantes :
+Les objets de zone sont utilisÃ©s pour mettre en Ã©vidence des parties
+spÃ©cifiques des cartes ou pour ajouter des dÃ©tails supplÃ©mentaires aux
+cartes. Cela se fait Ã  l'aide des entrÃ©es suivantes :
 = Couleur vive =
-Utilisez la version plus claire des couleurs autorisées.
+Utilisez la version plus claire des couleurs autorisÃ©es.
 = Remplissage de couleur =
-La zone doit être remplie, et non simplement délimitée. Cela peut être
-utile pour exclure une zone d'une recherche ou d'un autre événement.
+La zone doit Ãªtre remplie, et non simplement dÃ©limitÃ©e. Cela peut Ãªtre
+utile pour exclure une zone d'une recherche ou d'un autre Ã©vÃ©nement.
 = Type d'objet =
-Choisissez parmi les formes géométriques autorisées.
+Choisissez parmi les formes gÃ©omÃ©triques autorisÃ©es.
 = Couleur de l'objet =
-Choisissez la couleur dans laquelle l'objet sera affiché. Cette option
-est également affectée par l'option « Couleur vive » ci-dessus.
-= Décalage vertical de l'objet =
-En 1/1500 de degré de latitude. Un détail regrettable de la
-spécification, et difficile à calculer facilement. Sachez simplement
+Choisissez la couleur dans laquelle l'objet sera affichÃ©. Cette option
+est Ã©galement affectÃ©e par l'option Â« Couleur vive Â» ci-dessus.
+= DÃ©calage vertical de l'objet =
+En 1/1500 de degrÃ© de latitude. Un dÃ©tail regrettable de la
+spÃ©cification, et difficile Ã  calculer facilement. Sachez simplement
 que vous pouvez modifier la taille de l'objet une fois qu'il est
-placé.
-= Décalage de l'objet vers la gauche =
-En 1/1500 de degré de longitude. Voir ci-dessus.
+placÃ©.
+= DÃ©calage de l'objet vers la gauche =
+En 1/1500 de degrÃ© de longitude. Voir ci-dessus.
 = Couloir d'objet =
-Il s'agit de la largeur d'un objet de type zone linéaire. Utile pour
-les pistes d'atterrissage, les zones de surveillance météorologique,
-la description d'une zone d'intérêt ou d'une zone d'exclusion, etc.
+Il s'agit de la largeur d'un objet de type zone linÃ©aire. Utile pour
+les pistes d'atterrissage, les zones de surveillance mÃ©tÃ©orologique,
+la description d'une zone d'intÃ©rÃªt ou d'une zone d'exclusion, etc.
 
-Supprimez toujours vos objets et éléments une fois que vous n'en avez
+Supprimez toujours vos objets et Ã©lÃ©ments une fois que vous n'en avez
 plus besoin !  Ne les laissez pas simplement expirer de votre cache,
-car ils pourraient rester affichés sur les écrans d'autres
-utilisateurs pendant une période prolongée.
+car ils pourraient rester affichÃ©s sur les Ã©crans d'autres
+utilisateurs pendant une pÃ©riode prolongÃ©e.
 
 
-Description des zones de surveillance météorologique :
+Description des zones de surveillance mÃ©tÃ©orologique :
 
-Les zones de surveillance et les « zones de préoccupation maximale »
-(AOMC) générées par le WXSVR (https://www.aprs-is.net/WX/Default.aspx)
-sont colorées comme suit :
+Les zones de surveillance et les Â« zones de prÃ©occupation maximale Â»
+(AOMC) gÃ©nÃ©rÃ©es par le WXSVR (https://www.aprs-is.net/WX/Default.aspx)
+sont colorÃ©es comme suit :
 
-Jaune pointillé = Alerte d'orage violent (ressemble à un ruban de
-                  scène de crime)
+Jaune pointillÃ© = Alerte d'orage violent (ressemble Ã  un ruban de
+                  scÃ¨ne de crime)
 Jaune uni = AOMC pour alerte d'orage violent
-Rouge pointillé = Alerte de tornade
+Rouge pointillÃ© = Alerte de tornade
 Rouge uni = AOMC pour alerte de tornade
-Vert pointillé = Zone de discussion à méso-échelle (plus grande)
-Bleu pointillé = Alerte de test
+Vert pointillÃ© = Zone de discussion Ã  mÃ©so-Ã©chelle (plus grande)
+Bleu pointillÃ© = Alerte de test
 Bleu uni = Avertissement de test
 
 HELP-INDEX>Objets CAD
@@ -875,161 +875,161 @@ HELP-INDEX>Objets CAD
            Objets CAD
 
 La prise en charge des objets CAD est actuellement en phase
-préliminaire. Les fonctionnalités et l'interface utilisateur sont
-susceptibles d'être modifiées.
+prÃ©liminaire. Les fonctionnalitÃ©s et l'interface utilisateur sont
+susceptibles d'Ãªtre modifiÃ©es.
 
 Les objets CAD sont des formes arbitraires que vous pouvez dessiner
-sur les cartes dans Xastir, mais qui ne peuvent pas être transmises
+sur les cartes dans Xastir, mais qui ne peuvent pas Ãªtre transmises
 par APRS.
 
 Les objets CAD actuellement pris en charge sont : Polygones : Zones
-fermées composées d'au moins trois points.
+fermÃ©es composÃ©es d'au moins trois points.
 
-Pour créer un objet CAD, cliquez d'abord sur le bouton radio Dessiner
+Pour crÃ©er un objet CAD, cliquez d'abord sur le bouton radio Dessiner
 dans la barre d'outils.
 
-Le curseur se transforme alors en crayon. Commencez à dessiner un
+Le curseur se transforme alors en crayon. Commencez Ã  dessiner un
 polygone en cliquant avec le bouton central de la souris (ou les deux
-boutons sur une souris à deux boutons, pour laquelle vous devrez
-activer l'émulation de souris à trois boutons). Cela place un point
-sur la carte. Déplacez ensuite le curseur à un autre endroit (les
+boutons sur une souris Ã  deux boutons, pour laquelle vous devrez
+activer l'Ã©mulation de souris Ã  trois boutons). Cela place un point
+sur la carte. DÃ©placez ensuite le curseur Ã  un autre endroit (les
 fonctions de navigation et de zoom par clic gauche/droit fonctionnent
-toujours normalement) et cliquez à nouveau sur le bouton central de la
+toujours normalement) et cliquez Ã  nouveau sur le bouton central de la
 souris. Cela trace une ligne entre les deux points
-sélectionnés. Cliquez à nouveau avec le bouton central pour tracer un
-autre segment de ligne et répétez l'opération jusqu'à ce que vous ayez
-tracé tous les segments, à l'exception du dernier. Pour fermer le
-polygone, sélectionnez Carte/Dessiner
+sÃ©lectionnÃ©s. Cliquez Ã  nouveau avec le bouton central pour tracer un
+autre segment de ligne et rÃ©pÃ©tez l'opÃ©ration jusqu'Ã  ce que vous ayez
+tracÃ© tous les segments, Ã  l'exception du dernier. Pour fermer le
+polygone, sÃ©lectionnez Carte/Dessiner
 
 Objets CAD/Fermer le polygone. Cela fermera votre polygone et
-affichera une boîte de dialogue vous permettant de saisir un nom, un
-commentaire et une probabilité pour le polygone.
+affichera une boÃ®te de dialogue vous permettant de saisir un nom, un
+commentaire et une probabilitÃ© pour le polygone.
 
-Lorsque vous avez terminé de dessiner des objets CAD, quittez le mode
-de dessin CAD en désélectionnant le bouton radio Dessiner dans la
+Lorsque vous avez terminÃ© de dessiner des objets CAD, quittez le mode
+de dessin CAD en dÃ©sÃ©lectionnant le bouton radio Dessiner dans la
 barre d'outils.
 
-Les objets CAD peuvent être modifiés à partir du menu
+Les objets CAD peuvent Ãªtre modifiÃ©s Ã  partir du menu
 Affichage/Polygones CAD et du menu
 
-Carte/Dessiner Objets CAD/Polygones CAD. Les objets CAD peuvent être
-supprimés à partir du menu Carte/Dessiner Objets CAD/Effacer les
+Carte/Dessiner Objets CAD/Polygones CAD. Les objets CAD peuvent Ãªtre
+supprimÃ©s Ã  partir du menu Carte/Dessiner Objets CAD/Effacer les
 polygones CAD.
 
 HELP-INDEX>Menu Examiner
 
            Options du menu Examiner
 
-Le menu Examiner présente différentes façons de visualiser les
-données dans Xastir.
+Le menu Examiner prÃ©sente diffÃ©rentes faÃ§ons de visualiser les
+donnÃ©es dans Xastir.
 
 Bulletins
 
-Il s'agit du tableau d'affichage APRS(tm), où sont publiées les
+Il s'agit du tableau d'affichage APRS(tm), oÃ¹ sont publiÃ©es les
 annonces importantes.
 
-Si vous êtes connecté via l'interface Internet, il est conseillé de
-définir le champ de portée à quelques centaines de kilomètres afin
-d'ignorer les messages provenant d'autres régions du monde. « 0 » dans
-le champ de portée signifie le monde entier. Cliquez sur le bouton «
-Modifier la portée » pour appliquer les modifications apportées à ce
+Si vous Ãªtes connectÃ© via l'interface Internet, il est conseillÃ© de
+dÃ©finir le champ de portÃ©e Ã  quelques centaines de kilomÃ¨tres afin
+d'ignorer les messages provenant d'autres rÃ©gions du monde. Â« 0 Â» dans
+le champ de portÃ©e signifie le monde entier. Cliquez sur le bouton Â«
+Modifier la portÃ©e Â» pour appliquer les modifications apportÃ©es Ã  ce
 champ. Xastir ne prend pas encore en charge l'envoi de bulletins. Les
-bulletins entrants ouvriront automatiquement cette boîte de dialogue
-si vous sélectionnez « Afficher les nouveaux bulletins » dans la boîte
-de dialogue Configurer | Paramètres par défaut. Le bouton « Afficher
-les bulletins sans distance » permet d'afficher les bulletins pour
-lesquels vous n'avez pas encore de portée (ils n'ont pas encore envoyé
-de position, mais vous avez reçu un bulletin de leur part). Si cette
-option est désactivée, vous devez obtenir une position d'une station,
-et la station doit se trouver dans la portée sélectionnée (ou la
-portée doit être définie sur zéro) pour que le bulletin soit affiché.
+bulletins entrants ouvriront automatiquement cette boÃ®te de dialogue
+si vous sÃ©lectionnez Â« Afficher les nouveaux bulletins Â» dans la boÃ®te
+de dialogue Configurer | ParamÃ¨tres par dÃ©faut. Le bouton Â« Afficher
+les bulletins sans distance Â» permet d'afficher les bulletins pour
+lesquels vous n'avez pas encore de portÃ©e (ils n'ont pas encore envoyÃ©
+de position, mais vous avez reÃ§u un bulletin de leur part). Si cette
+option est dÃ©sactivÃ©e, vous devez obtenir une position d'une station,
+et la station doit se trouver dans la portÃ©e sÃ©lectionnÃ©e (ou la
+portÃ©e doit Ãªtre dÃ©finie sur zÃ©ro) pour que le bulletin soit affichÃ©.
 
-Données entrantes
-Cette option affiche les données entrantes sur votre TNC ou votre
+DonnÃ©es entrantes
+Cette option affiche les donnÃ©es entrantes sur votre TNC ou votre
 interface Internet. Les boutons radio ci-dessous permettent de
-sélectionner si vous souhaitez afficher uniquement les données TNC,
-uniquement les données Internet ou les deux.
+sÃ©lectionner si vous souhaitez afficher uniquement les donnÃ©es TNC,
+uniquement les donnÃ©es Internet ou les deux.
 
 Stations mobiles
 Il s'agit d'une liste des stations en mouvement. Les stations sont
-incluses dans cette liste si elles se sont déplacées (plus d'une
-position a été reçue pour elles), le symbole de la station n'est pas
-pris en compte. Les informations affichées comprennent le cap, la
-vitesse, l'altitude, la position, le nombre de paquets reçus, le
+incluses dans cette liste si elles se sont dÃ©placÃ©es (plus d'une
+position a Ã©tÃ© reÃ§ue pour elles), le symbole de la station n'est pas
+pris en compte. Les informations affichÃ©es comprennent le cap, la
+vitesse, l'altitude, la position, le nombre de paquets reÃ§us, le
 nombre de satellites GPS visibles, le cap depuis votre station et la
-distance par rapport à votre station.
+distance par rapport Ã  votre station.
 
 Toutes les stations
-Cette option affiche un tableau de toutes les stations triées par
-ordre alphabétique. Il comprend le nombre de paquets reçus, l'heure de
-la dernière réception de la station, le chemin emprunté par le paquet
-le plus récent, le PHG et le commentaire de la station.
+Cette option affiche un tableau de toutes les stations triÃ©es par
+ordre alphabÃ©tique. Il comprend le nombre de paquets reÃ§us, l'heure de
+la derniÃ¨re rÃ©ception de la station, le chemin empruntÃ© par le paquet
+le plus rÃ©cent, le PHG et le commentaire de la station.
 
 Stations locales
-Cette option affiche uniquement les stations reçues via votre
-TNC. Elle comprend le nombre de paquets reçus, l'heure de la dernière
-réception de la station, le chemin emprunté par le paquet le plus
-récent, le PHG et le commentaire de la station.
+Cette option affiche uniquement les stations reÃ§ues via votre
+TNC. Elle comprend le nombre de paquets reÃ§us, l'heure de la derniÃ¨re
+rÃ©ception de la station, le chemin empruntÃ© par le paquet le plus
+rÃ©cent, le PHG et le commentaire de la station.
 
-Stations récentes
-Cette option affiche un tableau de toutes les stations triées de la
-plus récemment entendue à la moins récemment entendue. Il inclut le
-nombre de paquets reçus, l'heure de la dernière réception, le chemin
-emprunté par le dernier paquet, le PHG et le commentaire de la
+Stations rÃ©centes
+Cette option affiche un tableau de toutes les stations triÃ©es de la
+plus rÃ©cemment entendue Ã  la moins rÃ©cemment entendue. Il inclut le
+nombre de paquets reÃ§us, l'heure de la derniÃ¨re rÃ©ception, le chemin
+empruntÃ© par le dernier paquet, le PHG et le commentaire de la
 station.
 
 Objets et articles
 Cette option affiche uniquement les objets et les articles. Elle
-inclut le nombre de paquets reçus, l'heure de la dernière réception de
-l'objet/article, le chemin emprunté par le dernier paquet, le PHG et
+inclut le nombre de paquets reÃ§us, l'heure de la derniÃ¨re rÃ©ception de
+l'objet/article, le chemin empruntÃ© par le dernier paquet, le PHG et
 le commentaire de l'objet/article.
 
 Mes objets et articles
 Cette option affiche uniquement les objets et les articles que vous
-contrôlez (c'est-à-dire ceux pour lesquels vous avez envoyé la
-dernière mise à jour). Elle inclut le nombre de paquets reçus, l'heure
-de la dernière réception de l'objet/article, le chemin emprunté par le
-dernier paquet, le PHG et le commentaire de l'objet/article. Une icône
-grisée indique que l'objet a été supprimé.
+contrÃ´lez (c'est-Ã -dire ceux pour lesquels vous avez envoyÃ© la
+derniÃ¨re mise Ã  jour). Elle inclut le nombre de paquets reÃ§us, l'heure
+de la derniÃ¨re rÃ©ception de l'objet/article, le chemin empruntÃ© par le
+dernier paquet, le PHG et le commentaire de l'objet/article. Une icÃ´ne
+grisÃ©e indique que l'objet a Ã©tÃ© supprimÃ©.
 
-Stations météo
-Cette option affiche un tableau de toutes les stations météorologiques
-APRS(tm) et leurs données. Les données comprennent la direction du vent,
-la vitesse du vent, la vitesse des rafales, la température,
-l'humidité, la pression barométrique, les précipitations de la
-dernière heure, les précipitations depuis minuit et les précipitations
-des dernières 24 heures.
+Stations mÃ©tÃ©o
+Cette option affiche un tableau de toutes les stations mÃ©tÃ©orologiques
+APRS(tm) et leurs donnÃ©es. Les donnÃ©es comprennent la direction du vent,
+la vitesse du vent, la vitesse des rafales, la tempÃ©rature,
+l'humiditÃ©, la pression baromÃ©trique, les prÃ©cipitations de la
+derniÃ¨re heure, les prÃ©cipitations depuis minuit et les prÃ©cipitations
+des derniÃ¨res 24 heures.
 
-Mes données météo
+Mes donnÃ©es mÃ©tÃ©o
 
-Affiche vos données météorologiques si vous possédez une station
-météorologique et que vous avez configuré Xastir pour y accéder.
+Affiche vos donnÃ©es mÃ©tÃ©orologiques si vous possÃ©dez une station
+mÃ©tÃ©orologique et que vous avez configurÃ© Xastir pour y accÃ©der.
 
-Alertes météo
-Affiche les alertes météorologiques reçues, y compris les indicateurs
+Alertes mÃ©tÃ©o
+Affiche les alertes mÃ©tÃ©orologiques reÃ§ues, y compris les indicateurs
 d'alerte, la source/le type d'alerte, la destination de l'alerte,
-l'expiration, le message et le lieu concerné. Ces données sont
-utilisées pour la mise en évidence des alertes. Un double-clic sur une
-alerte permet de demander des informations supplémentaires via Finger
-auprès du serveur WXSVR en ligne. Cela ne fonctionne que si vous avez
-accès à Internet ; les versions futures pourront également accéder à
-ces données par radio.
+l'expiration, le message et le lieu concernÃ©. Ces donnÃ©es sont
+utilisÃ©es pour la mise en Ã©vidence des alertes. Un double-clic sur une
+alerte permet de demander des informations supplÃ©mentaires via Finger
+auprÃ¨s du serveur WXSVR en ligne. Cela ne fonctionne que si vous avez
+accÃ¨s Ã  Internet ; les versions futures pourront Ã©galement accÃ©der Ã 
+ces donnÃ©es par radio.
 
 Trafic des messages
-Affiche tout le trafic de messages tant que la fenêtre est ouverte. Il
+Affiche tout le trafic de messages tant que la fenÃªtre est ouverte. Il
 inclut la source, la destination, l'interface et le message. L'option
-de portée permet de limiter cet affichage aux stations proches, comme
-pour le contrôle de portée des bulletins. Une portée de 0 affiche tous
+de portÃ©e permet de limiter cet affichage aux stations proches, comme
+pour le contrÃ´le de portÃ©e des bulletins. Une portÃ©e de 0 affiche tous
 les messages.
 
-État du GPS
-Affiche l'état de votre récepteur GPS, y compris le type de
+Ã‰tat du GPS
+Affiche l'Ã©tat de votre rÃ©cepteur GPS, y compris le type de
 positionnement et le nombre de satellites acquis.
 
-Durée de fonctionnement du logiciel
-Affiche la durée écoulée depuis le démarrage de Xastir.
+DurÃ©e de fonctionnement du logiciel
+Affiche la durÃ©e Ã©coulÃ©e depuis le dÃ©marrage de Xastir.
 
-HELP-INDEX>Menu des cartes et sélecteur de cartes
+HELP-INDEX>Menu des cartes et sÃ©lecteur de cartes
 
            Menu des cartes et Choix de cartes
 
@@ -1037,270 +1037,270 @@ Menu des cartes :
 
 choix de cartes
 
-Cette option affiche une liste de répertoires et/ou de fichiers de
-cartes dans votre répertoire de cartes. L'option « Agrandir
-répertoires » permet d'afficher les fichiers de cartes individuels
-contenus dans les répertoires. La boîte de dialogue des propriétés
-offre des options de contrôle plus avancées, décrites
-ci-dessous. Cliquez sur les noms des cartes pour les sélectionner ;
-elles seront affichées lorsque vous cliquerez sur le bouton OK. Vous
-pouvez sélectionner autant de cartes que vous le souhaitez. Cliquer
-sur « Effacer » désélectionne toutes les cartes, cliquer sur « Vectorielles
-» sélectionne uniquement les cartes vectorielles. Les trois options «
-topogr. » sélectionnent automatiquement toutes les images USGS GeoTIFF de la
-taille indiquée. Cliquer sur le bouton OK affiche les cartes
-sélectionnées. Annuler annule toutes les modifications.
+Cette option affiche une liste de rÃ©pertoires et/ou de fichiers de
+cartes dans votre rÃ©pertoire de cartes. L'option Â« Agrandir
+rÃ©pertoires Â» permet d'afficher les fichiers de cartes individuels
+contenus dans les rÃ©pertoires. La boÃ®te de dialogue des propriÃ©tÃ©s
+offre des options de contrÃ´le plus avancÃ©es, dÃ©crites
+ci-dessous. Cliquez sur les noms des cartes pour les sÃ©lectionner ;
+elles seront affichÃ©es lorsque vous cliquerez sur le bouton OK. Vous
+pouvez sÃ©lectionner autant de cartes que vous le souhaitez. Cliquer
+sur Â« Effacer Â» dÃ©sÃ©lectionne toutes les cartes, cliquer sur Â« Vectorielles
+Â» sÃ©lectionne uniquement les cartes vectorielles. Les trois options Â«
+topogr. Â» sÃ©lectionnent automatiquement toutes les images USGS GeoTIFF de la
+taille indiquÃ©e. Cliquer sur le bouton OK affiche les cartes
+sÃ©lectionnÃ©es. Annuler annule toutes les modifications.
 
-Caractéristiques des cartes
-Cliquer sur le bouton Caractéristiques affiche une boîte de dialogue
-où vous pouvez spécifier la couche dans laquelle les cartes
-apparaissent et les niveaux de zoom auxquels elles sont affichées. Les
-numéros de couche supérieurs sont affichés au-dessus des numéros
-inférieurs. La plage peut être spécifiée de -99999 à 99999 ; il est
-conseillé d'espacer largement vos numéros de couche pour permettre
-l'insertion ultérieure de couches de cartes supplémentaires. À partir
-de cette boîte de dialogue, vous pouvez spécifier si une carte
-vectorielle est dessinée avec des remplissages de couleur. Cette
-option est définie par carte ; l'option de désactivation globale dans
-le menu Cartes peut la remplacer. Le paramètre « Rempli » est ignoré
-pour les cartes raster (images). Un paramètre « auto » permet à un
-fichier dbfawk de contrôler directement ce paramètre (utilisable
-uniquement si dbfawk est compilé et que la carte en question est un
-fichier Shapefile). Vous pouvez également sélectionner si une carte
-est prise en compte par la fonction « AutoCartes ».  Enfin,
-vous pouvez spécifier les niveaux de zoom minimum et maximum auxquels
-une carte est affichée. Ceci est utile pour empêcher le chargement de
-cartes locales très détaillées à des niveaux de zoom très larges, et
-inversement. Un zoom minimum de 10 signifie qu'une carte sera affichée
-à tous les niveaux de zoom égaux ou supérieurs à 10. De même, un zoom
-maximum de 256 signifie qu'une carte sera affichée à tous les niveaux
-de zoom inférieurs ou égaux à 256.
+CaractÃ©ristiques des cartes
+Cliquer sur le bouton CaractÃ©ristiques affiche une boÃ®te de dialogue
+oÃ¹ vous pouvez spÃ©cifier la couche dans laquelle les cartes
+apparaissent et les niveaux de zoom auxquels elles sont affichÃ©es. Les
+numÃ©ros de couche supÃ©rieurs sont affichÃ©s au-dessus des numÃ©ros
+infÃ©rieurs. La plage peut Ãªtre spÃ©cifiÃ©e de -99999 Ã  99999 ; il est
+conseillÃ© d'espacer largement vos numÃ©ros de couche pour permettre
+l'insertion ultÃ©rieure de couches de cartes supplÃ©mentaires. Ã€ partir
+de cette boÃ®te de dialogue, vous pouvez spÃ©cifier si une carte
+vectorielle est dessinÃ©e avec des remplissages de couleur. Cette
+option est dÃ©finie par carte ; l'option de dÃ©sactivation globale dans
+le menu Cartes peut la remplacer. Le paramÃ¨tre Â« Rempli Â» est ignorÃ©
+pour les cartes raster (images). Un paramÃ¨tre Â« auto Â» permet Ã  un
+fichier dbfawk de contrÃ´ler directement ce paramÃ¨tre (utilisable
+uniquement si dbfawk est compilÃ© et que la carte en question est un
+fichier Shapefile). Vous pouvez Ã©galement sÃ©lectionner si une carte
+est prise en compte par la fonction Â« AutoCartes Â».  Enfin,
+vous pouvez spÃ©cifier les niveaux de zoom minimum et maximum auxquels
+une carte est affichÃ©e. Ceci est utile pour empÃªcher le chargement de
+cartes locales trÃ¨s dÃ©taillÃ©es Ã  des niveaux de zoom trÃ¨s larges, et
+inversement. Un zoom minimum de 10 signifie qu'une carte sera affichÃ©e
+Ã  tous les niveaux de zoom Ã©gaux ou supÃ©rieurs Ã  10. De mÃªme, un zoom
+maximum de 256 signifie qu'une carte sera affichÃ©e Ã  tous les niveaux
+de zoom infÃ©rieurs ou Ã©gaux Ã  256.
 
 Marque-pages d'affichage de carte
-Voir la rubrique d'aide « Création et utilisation des marque-pages
-d'affichage de carte »
+Voir la rubrique d'aide Â« CrÃ©ation et utilisation des marque-pages
+d'affichage de carte Â»
 
-Localiser une entité cartographique
-Cette option affiche une boîte de dialogue de recherche permettant de
-rechercher des étiquettes dans un fichier GNIS afin de trouver un
-emplacement spécifique. La carte sera centrée sur le nouvel
-emplacement s'il est trouvé. L'entrée « Fichier GNIS : » est
-enregistrée entre les appels et entre les exécutions de Xastir. Vous
-devez placer les fichiers GNIS dans le répertoire xastir/GNIS pour
-utiliser cette fonctionnalité.
+Localiser une entitÃ© cartographique
+Cette option affiche une boÃ®te de dialogue de recherche permettant de
+rechercher des Ã©tiquettes dans un fichier GNIS afin de trouver un
+emplacement spÃ©cifique. La carte sera centrÃ©e sur le nouvel
+emplacement s'il est trouvÃ©. L'entrÃ©e Â« Fichier GNIS : Â» est
+enregistrÃ©e entre les appels et entre les exÃ©cutions de Xastir. Vous
+devez placer les fichiers GNIS dans le rÃ©pertoire xastir/GNIS pour
+utiliser cette fonctionnalitÃ©.
 
 Rechercher un emplacement
-Cette fonctionnalité nécessite généralement une connexion Internet.
+Cette fonctionnalitÃ© nÃ©cessite gÃ©nÃ©ralement une connexion Internet.
 
-Cette option affiche une boîte de dialogue de recherche où vous pouvez
+Cette option affiche une boÃ®te de dialogue de recherche oÃ¹ vous pouvez
 saisir une adresse ou le nom d'une entreprise ou d'un lieu. Elle
-générera une requête Internet vers un serveur « Nominatim » qui
-interroge les données OpenStreetMap pour trouver l'emplacement. Si des
-résultats sont trouvés, la boîte de dialogue sera remplie avec une
+gÃ©nÃ©rera une requÃªte Internet vers un serveur Â« Nominatim Â» qui
+interroge les donnÃ©es OpenStreetMap pour trouver l'emplacement. Si des
+rÃ©sultats sont trouvÃ©s, la boÃ®te de dialogue sera remplie avec une
 liste d'emplacements correspondants. Choisissez-en un en cliquant
-dessus, puis cliquez sur « Aller à » ou « Marquer ». Ces deux options
-centreront la carte sur l'emplacement choisi. Le bouton « Marquer »
-placera également une grande croix bleue « X » sur l'emplacement.
+dessus, puis cliquez sur Â« Aller Ã  Â» ou Â« Marquer Â». Ces deux options
+centreront la carte sur l'emplacement choisi. Le bouton Â« Marquer Â»
+placera Ã©galement une grande croix bleue Â« X Â» sur l'emplacement.
 
-Calculatatrice de coordonnées
+Calculatatrice de coordonnÃ©es
 Cette option ouvre une calculatrice simple permettant de convertir
-entre différents systèmes de coordonnées.  Ceci est utile pour
-convertir des positions aux différents formats utilisés par différents
-groupes d'utilisateurs. Cette même calculatrice peut être appelée par
-le bouton « Calculer » dans certaines autres boîtes de dialogue. Elle
-est utile pour saisir des coordonnées dans d'autres formats.
+entre diffÃ©rents systÃ¨mes de coordonnÃ©es.  Ceci est utile pour
+convertir des positions aux diffÃ©rents formats utilisÃ©s par diffÃ©rents
+groupes d'utilisateurs. Cette mÃªme calculatrice peut Ãªtre appelÃ©e par
+le bouton Â« Calculer Â» dans certaines autres boÃ®tes de dialogue. Elle
+est utile pour saisir des coordonnÃ©es dans d'autres formats.
 
 Menu Configurer :
-Colorer la carte sous-jaçante (XOR)
-Cette option contrôle la couleur de l'arrière-plan derrière les cartes
-affichées.  La couleur d'arrière-plan est souvent entièrement masquée
+Colorer la carte sous-jaÃ§ante (XOR)
+Cette option contrÃ´le la couleur de l'arriÃ¨re-plan derriÃ¨re les cartes
+affichÃ©es.  La couleur d'arriÃ¨re-plan est souvent entiÃ¨rement masquÃ©e
 par les cartes remplies (voir ci-dessous).
 
-Intensité de la carte
-Ceci contrôle la luminosité des graphiques utilisés comme
-cartes. Cette option n'apparaît que si vous avez compilé avec la prise
+IntensitÃ© de la carte
+Ceci contrÃ´le la luminositÃ© des graphiques utilisÃ©s comme
+cartes. Cette option n'apparaÃ®t que si vous avez compilÃ© avec la prise
 en charge de GeoTIFF.
 
 Ajuster correction de gamma
-Cela vous permet d'appliquer une correction gamma à tous les
-graphiques cartographiques chargés. Les cartes peuvent être ajustées
+Cela vous permet d'appliquer une correction gamma Ã  tous les
+graphiques cartographiques chargÃ©s. Les cartes peuvent Ãªtre ajustÃ©es
 individuellement dans leurs fichiers .geo. Voir la section sur les
-fichiers .geo dans « Fichiers cartographiques et comtés WX ». Cette
-option n'apparaît que si vous avez compilé le programme avec la prise
+fichiers .geo dans Â« Fichiers cartographiques et comtÃ©s WX Â». Cette
+option n'apparaÃ®t que si vous avez compilÃ© le programme avec la prise
 en charge de GraphicsMagick et ne s'applique pas aux cartes GeoTIFF ;
 voir l'option ci-dessus.
 
-Police des étiquettes de carte
-Permet de définir le style et la taille de la police utilisée pour les
-étiquettes des cartes.
+Police des Ã©tiquettes de carte
+Permet de dÃ©finir le style et la taille de la police utilisÃ©e pour les
+Ã©tiquettes des cartes.
 
 Style du texte des stations
-Permet de choisir la police et le style à utiliser pour le texte des
-stations et autres éléments.
+Permet de choisir la police et le style Ã  utiliser pour le texte des
+stations et autres Ã©lÃ©ments.
 
-Style du contour des icônes
-Permet de spécifier un contour autour des icônes des stations. Cela
-améliore la visibilité sur différents arrière-plans.
+Style du contour des icÃ´nes
+Permet de spÃ©cifier un contour autour des icÃ´nes des stations. Cela
+amÃ©liore la visibilitÃ© sur diffÃ©rents arriÃ¨re-plans.
 
-Désactiver toutes les cartes
-Cette option désactive le chargement de toutes les cartes. Elle est
-particulièrement utile lors des zooms ou des déplacements rapides, car
-elle évite de charger les cartes à chaque rafraîchissement de
-l'affichage. Notez que cette option n'est pas enregistrée entre les
+DÃ©sactiver toutes les cartes
+Cette option dÃ©sactive le chargement de toutes les cartes. Elle est
+particuliÃ¨rement utile lors des zooms ou des dÃ©placements rapides, car
+elle Ã©vite de charger les cartes Ã  chaque rafraÃ®chissement de
+l'affichage. Notez que cette option n'est pas enregistrÃ©e entre les
 sessions.
 
 Activer cartographie automatiques
 
-REMARQUE : La fonction « Cartographie automatiques » est obsolète et il est
-préférable de la désactiver !
+REMARQUE : La fonction Â« Cartographie automatiques Â» est obsolÃ¨te et il est
+prÃ©fÃ©rable de la dÃ©sactiver !
 
-Lorsque cette option est activée, toutes les cartes présentes dans le
-répertoire des cartes (ou dans l'un de ses sous-répertoires) seront
-affichées si elles se trouvent dans la zone d'affichage actuelle. Vous
-pouvez ajouter autant de niveaux de répertoires que vous le souhaitez
-sous le répertoire principal des cartes. La fonction de cartes
-automatiques parcourra tous les répertoires pour lesquels cette option
-est activée (dans la boîte de dialogue Caractéristiques des cartes),
-les vérifiera tous et déterminera quelle carte (ou quelle partie de
-carte) doit être affichée. Toutes les cartes seront fusionnées dans la
+Lorsque cette option est activÃ©e, toutes les cartes prÃ©sentes dans le
+rÃ©pertoire des cartes (ou dans l'un de ses sous-rÃ©pertoires) seront
+affichÃ©es si elles se trouvent dans la zone d'affichage actuelle. Vous
+pouvez ajouter autant de niveaux de rÃ©pertoires que vous le souhaitez
+sous le rÃ©pertoire principal des cartes. La fonction de cartes
+automatiques parcourra tous les rÃ©pertoires pour lesquels cette option
+est activÃ©e (dans la boÃ®te de dialogue CaractÃ©ristiques des cartes),
+les vÃ©rifiera tous et dÃ©terminera quelle carte (ou quelle partie de
+carte) doit Ãªtre affichÃ©e. Toutes les cartes seront fusionnÃ©es dans la
 zone d'affichage. Si vous avez un grand nombre de cartes, des cartes
-très détaillées ou un ordinateur lent, cette opération peut être assez
-lente. Lorsque cette option est désactivée, seules les cartes
-sélectionnées avec le choix de cartes seront affichées.
+trÃ¨s dÃ©taillÃ©es ou un ordinateur lent, cette opÃ©ration peut Ãªtre assez
+lente. Lorsque cette option est dÃ©sactivÃ©e, seules les cartes
+sÃ©lectionnÃ©es avec le choix de cartes seront affichÃ©es.
 
-Cartographie automatique - désactiver les cartes tramées
-Cette option empêche les cartes automatiques de charger les cartes
-graphiques (images).  Seules les cartes vectorielles seront affichées
+Cartographie automatique - dÃ©sactiver les cartes tramÃ©es
+Cette option empÃªche les cartes automatiques de charger les cartes
+graphiques (images).  Seules les cartes vectorielles seront affichÃ©es
 dans ce cas.
 
 Activer quadrillage
-Lorsque cette option est activée, une grille s'affiche sur la
-carte. Si le système de coordonnées est UTM, une grille UTM sera
-affichée. Si le système de coordonnées est latitude/longitude, une
-grille de latitude et de longitude sera affichée. Lorsque vous zoomez,
-la grille passe à une résolution plus fine. L'espacement de la grille
-de latitude et de longitude peut être ajusté manuellement avec les
-touches « + » et « - ».
+Lorsque cette option est activÃ©e, une grille s'affiche sur la
+carte. Si le systÃ¨me de coordonnÃ©es est UTM, une grille UTM sera
+affichÃ©e. Si le systÃ¨me de coordonnÃ©es est latitude/longitude, une
+grille de latitude et de longitude sera affichÃ©e. Lorsque vous zoomez,
+la grille passe Ã  une rÃ©solution plus fine. L'espacement de la grille
+de latitude et de longitude peut Ãªtre ajustÃ© manuellement avec les
+touches Â« + Â» et Â« - Â».
 
 Activer bordure des carte
 
 Lorsque les options Activer la grille cartographique et Activer la
-bordure de la carte sont activées, une fine bordure blanche est tracée
-autour de la carte et les lignes de la grille sont étiquetées à l'aide
-du système de coordonnées sélectionné (Fichier/Configurer/Système de
-coordonnées) et de la police de bordure sélectionnée
-(Carte/Configurer/Police des étiquettes de carte/Police de la
-bordure). Si les systèmes de coordonnées UTM ou MGRS sont
-sélectionnés, les lignes de la grille seront étiquetées avec les
-valeurs d'est et de nord uniquement aux niveaux de zoom inférieurs à
+bordure de la carte sont activÃ©es, une fine bordure blanche est tracÃ©e
+autour de la carte et les lignes de la grille sont Ã©tiquetÃ©es Ã  l'aide
+du systÃ¨me de coordonnÃ©es sÃ©lectionnÃ© (Fichier/Configurer/SystÃ¨me de
+coordonnÃ©es) et de la police de bordure sÃ©lectionnÃ©e
+(Carte/Configurer/Police des Ã©tiquettes de carte/Police de la
+bordure). Si les systÃ¨mes de coordonnÃ©es UTM ou MGRS sont
+sÃ©lectionnÃ©s, les lignes de la grille seront Ã©tiquetÃ©es avec les
+valeurs d'est et de nord uniquement aux niveaux de zoom infÃ©rieurs Ã 
 environ 2048.
 
-Niveau de cartes activé
-Lorsque cette option est activée, le programme tente de filtrer les
-données lorsque le niveau de zoom affiche de grandes zones. Cela ne
+Niveau de cartes activÃ©
+Lorsque cette option est activÃ©e, le programme tente de filtrer les
+donnÃ©es lorsque le niveau de zoom affiche de grandes zones. Cela ne
 fonctionne pas avec toutes les cartes, mais fonctionne avec les cartes
-générées à partir des cartes Tiger Line du site aprs.rutgers.edu et
-avec les cartes au format ESRI Shapefile. Cela ne réduit pas beaucoup
-les temps de chargement des cartes, mais réduit simplement
-l'encombrement de l'écran.
+gÃ©nÃ©rÃ©es Ã  partir des cartes Tiger Line du site aprs.rutgers.edu et
+avec les cartes au format ESRI Shapefile. Cela ne rÃ©duit pas beaucoup
+les temps de chargement des cartes, mais rÃ©duit simplement
+l'encombrement de l'Ã©cran.
 
 Activer annotation des cartes
-Cette option active ou désactive l'affichage des étiquettes de carte
-intégrées aux cartes aux formats DosAPRS, WinAPRS, GNIS et ESRI
+Cette option active ou dÃ©sactive l'affichage des Ã©tiquettes de carte
+intÃ©grÃ©es aux cartes aux formats DosAPRS, WinAPRS, GNIS et ESRI
 Shapefile. Activer le remplissage des zones de couleur Cette option
-contrôle le remplissage des cartes vectorielles. Dans certains cas,
-vous pourriez souhaiter désactiver le remplissage pour visualiser les
-cartes situées sous les cartes supérieures. Il s'agit d'un paramètre
-global ; le remplissage des cartes peut être activé ou désactivé
-individuellement dans la boîte de dialogue des propriétés du choix de
+contrÃ´le le remplissage des cartes vectorielles. Dans certains cas,
+vous pourriez souhaiter dÃ©sactiver le remplissage pour visualiser les
+cartes situÃ©es sous les cartes supÃ©rieures. Il s'agit d'un paramÃ¨tre
+global ; le remplissage des cartes peut Ãªtre activÃ© ou dÃ©sactivÃ©
+individuellement dans la boÃ®te de dialogue des propriÃ©tÃ©s du choix de
 cartes.
 
-Activer les alertes météorologiques par comté
+Activer les alertes mÃ©tÃ©orologiques par comtÃ©
 
 Cette option active l'affichage des cartes des zones d'alerte par
-comté pour les conditions météorologiques extrêmes. Ces cartes peuvent
-être obtenues et installées conformément aux instructions disponibles
-à l'adresse
+comtÃ© pour les conditions mÃ©tÃ©orologiques extrÃªmes. Ces cartes peuvent
+Ãªtre obtenues et installÃ©es conformÃ©ment aux instructions disponibles
+Ã  l'adresse
 https://github.com/Xastir/Xastir/wiki/Xastir-Mapping-Overview et ses
-différents liens. Elles s'affichent à l'écran lors de la réception de
-messages d'alerte météorologique et expirent après un certain temps ou
-peuvent être annulées à distance.  Le texte des alertes
-météorologiques est accessible via Affichage | Alertes
-météorologiques. Le répertoire xastir/Counties doit contenir les
-fichiers appropriés de la NOAA et la prise en charge de Shapelib doit
-être compilée dans Xastir pour activer cette fonctionnalité.
+diffÃ©rents liens. Elles s'affichent Ã  l'Ã©cran lors de la rÃ©ception de
+messages d'alerte mÃ©tÃ©orologique et expirent aprÃ¨s un certain temps ou
+peuvent Ãªtre annulÃ©es Ã  distance.  Le texte des alertes
+mÃ©tÃ©orologiques est accessible via Affichage | Alertes
+mÃ©tÃ©orologiques. Le rÃ©pertoire xastir/Counties doit contenir les
+fichiers appropriÃ©s de la NOAA et la prise en charge de Shapelib doit
+Ãªtre compilÃ©e dans Xastir pour activer cette fonctionnalitÃ©.
 
-Index: nouvelles cartes au démarrage
-Cette option contrôle la création du fichier d'index des cartes au
-démarrage. La plupart des utilisateurs devraient laisser cette option
-activée. Si l'horodatage du fichier de carte est plus récent que celui
-du fichier d'index des cartes, la carte sera indexée.
+Index: nouvelles cartes au dÃ©marrage
+Cette option contrÃ´le la crÃ©ation du fichier d'index des cartes au
+dÃ©marrage. La plupart des utilisateurs devraient laisser cette option
+activÃ©e. Si l'horodatage du fichier de carte est plus rÃ©cent que celui
+du fichier d'index des cartes, la carte sera indexÃ©e.
 
 Index : Ajouter nouvelles cartes
-Cette option ajoute les nouvelles cartes à l'index. Les mêmes règles
-que pour la fonction « Indexer les nouvelles cartes » s'appliquent,
-mais il s'agit d'une méthode d'activation manuelle.
+Cette option ajoute les nouvelles cartes Ã  l'index. Les mÃªmes rÃ¨gles
+que pour la fonction Â« Indexer les nouvelles cartes Â» s'appliquent,
+mais il s'agit d'une mÃ©thode d'activation manuelle.
 
-Index : Réindexer toutes les cartes
-Cette option réinitialise l'indexation et indexe toutes les cartes
-reconnues dans le répertoire des cartes. Cette fonction est utile si
-la fonction « Ajouter nouvelles cartes » ignore certaines cartes,
-peut-être en raison d'horodatages obsolètes sur les fichiers de
+Index : RÃ©indexer toutes les cartes
+Cette option rÃ©initialise l'indexation et indexe toutes les cartes
+reconnues dans le rÃ©pertoire des cartes. Cette fonction est utile si
+la fonction Â« Ajouter nouvelles cartes Â» ignore certaines cartes,
+peut-Ãªtre en raison d'horodatages obsolÃ¨tes sur les fichiers de
 cartes.  Cette fonction peut prendre un certain temps si vous avez
 beaucoup de cartes.
 
 Menu souris
 Cette option affiche le menu d'options normalement accessible par un
 clic droit.   Remarque concernant les cartes : La plupart des cartes
-vectorielles historiques pour les États-Unis ont été
-créées avec le système de référence NAD 1927, tandis que Xastir et
-d'autres programmes APRS(tm) utilisent le système de référence WGS
-1984. En cas de zoom sur une petite zone de la carte, le décalage de
-système de référence peut être très perceptible. Les cartes
-topographiques de l'USGS voient leur système de référence corrigé par
-Xastir lors de l'affichage ; les positions seront donc généralement
-plus précises avec ces cartes topographiques.
+vectorielles historiques pour les Ã‰tats-Unis ont Ã©tÃ©
+crÃ©Ã©es avec le systÃ¨me de rÃ©fÃ©rence NAD 1927, tandis que Xastir et
+d'autres programmes APRS(tm) utilisent le systÃ¨me de rÃ©fÃ©rence WGS
+1984. En cas de zoom sur une petite zone de la carte, le dÃ©calage de
+systÃ¨me de rÃ©fÃ©rence peut Ãªtre trÃ¨s perceptible. Les cartes
+topographiques de l'USGS voient leur systÃ¨me de rÃ©fÃ©rence corrigÃ© par
+Xastir lors de l'affichage ; les positions seront donc gÃ©nÃ©ralement
+plus prÃ©cises avec ces cartes topographiques.
 
-HELP-INDEX>Fichiers cartographiques et comtés météo
+HELP-INDEX>Fichiers cartographiques et comtÃ©s mÃ©tÃ©o
 
-Fichiers cartographiques et comtés météo
+Fichiers cartographiques et comtÃ©s mÃ©tÃ©o
 
 Types de cartes
-Xastir fonctionne avec différents types de fichiers cartographiques. Tous les fichiers cartographiques DosAPRS et Windows/Mac APRS(tm) sont pris en charge sans qu'aucune bibliothèque externe supplémentaire ne soit nécessaire.
-Xastir peut également être
-compilé pour utiliser des bibliothèques externes afin de prendre en charge les images XPixmap (XPM), les cartes topographiques GeoTIFF
-et les cartes au format Shapefile ESRI. La capacité de gestion graphique
-de Xastir peut être considérablement étendue en compilant avec la prise en charge de GraphicsMagick,
-ce qui permet de prendre en charge de nombreux formats graphiques comme cartes. Xastir prend en charge les cartes d'alertes météorologiques au format Shapefile ESRI, disponibles auprès de la NOAA. Consultez la page wiki Github
-https://github.com/Xastir/Xastir/wiki/Installing-Xastir pour plus de détails.
+Xastir fonctionne avec diffÃ©rents types de fichiers cartographiques. Tous les fichiers cartographiques DosAPRS et Windows/Mac APRS(tm) sont pris en charge sans qu'aucune bibliothÃ¨que externe supplÃ©mentaire ne soit nÃ©cessaire.
+Xastir peut Ã©galement Ãªtre
+compilÃ© pour utiliser des bibliothÃ¨ques externes afin de prendre en charge les images XPixmap (XPM), les cartes topographiques GeoTIFF
+et les cartes au format Shapefile ESRI. La capacitÃ© de gestion graphique
+de Xastir peut Ãªtre considÃ©rablement Ã©tendue en compilant avec la prise en charge de GraphicsMagick,
+ce qui permet de prendre en charge de nombreux formats graphiques comme cartes. Xastir prend en charge les cartes d'alertes mÃ©tÃ©orologiques au format Shapefile ESRI, disponibles auprÃ¨s de la NOAA. Consultez la page wiki Github
+https://github.com/Xastir/Xastir/wiki/Installing-Xastir pour plus de dÃ©tails.
 
-Des informations détaillées sur les emplacements où obtenir la plupart des types de cartes mentionnés ci-dessus se trouvent dans
+Des informations dÃ©taillÃ©es sur les emplacements oÃ¹ obtenir la plupart des types de cartes mentionnÃ©s ci-dessus se trouvent dans
 le fichier https://github.com/Xastir/Xastir/wiki/Xastir-Mapping-Overview et
 les liens ci-dessous.
 
 Emplacements des cartes
-Tout fichier cartographique doit être stocké dans le répertoire /usr/local/share/xastir/maps
-sur votre ordinateur. Cet emplacement peut être différent sur certains systèmes, selon
-la manière dont Xastir a été compilé/installé. Vous pouvez créer autant de répertoires que vous le souhaitez
-sous ce répertoire pour organiser et séparer vos données. Les cartes seront
-chargées par ordre alphanumérique, sauf si une superposition est spécifiée.
+Tout fichier cartographique doit Ãªtre stockÃ© dans le rÃ©pertoire /usr/local/share/xastir/maps
+sur votre ordinateur. Cet emplacement peut Ãªtre diffÃ©rent sur certains systÃ¨mes, selon
+la maniÃ¨re dont Xastir a Ã©tÃ© compilÃ©/installÃ©. Vous pouvez crÃ©er autant de rÃ©pertoires que vous le souhaitez
+sous ce rÃ©pertoire pour organiser et sÃ©parer vos donnÃ©es. Les cartes seront
+chargÃ©es par ordre alphanumÃ©rique, sauf si une superposition est spÃ©cifiÃ©e.
 
 Des conseils sur l'installation et l'organisation des cartes se trouvent sur le wiki Github de Xastir
-à l'adresse https://github.com/Xastir/Xastir/wiki/Xastir-Mapping-Overview.
-Les cartes au format graphique pixelisé nécessitent en réalité une combinaison de deux fichiers :
-un fichier de données avec une image bitmap (.xpm) (ou un autre format si vous avez compilé
+Ã  l'adresse https://github.com/Xastir/Xastir/wiki/Xastir-Mapping-Overview.
+Les cartes au format graphique pixelisÃ© nÃ©cessitent en rÃ©alitÃ© une combinaison de deux fichiers :
+un fichier de donnÃ©es avec une image bitmap (.xpm) (ou un autre format si vous avez compilÃ©
 avec GraphicsMagick) et un fichier de calibration (.geo). Le fichier .xpm est le
-format graphique standard, disponible sans bibliothèques supplémentaires. Si vous
-souhaitez économiser de l'espace de stockage, vous pouvez utiliser gzip pour compresser ces fichiers
-(« gzip map.xpm » créera « map.xpm.gz »). Xastir détecte cela
+format graphique standard, disponible sans bibliothÃ¨ques supplÃ©mentaires. Si vous
+souhaitez Ã©conomiser de l'espace de stockage, vous pouvez utiliser gzip pour compresser ces fichiers
+(Â« gzip map.xpm Â» crÃ©era Â« map.xpm.gz Â»). Xastir dÃ©tecte cela
 automatiquement lors du chargement des cartes. Vous pouvez utiliser XView/Gimp/GraphicsMagick et
 d'autres programmes pour convertir les images gif, jpg et tif dans ce format si
 vous ne disposez pas de la prise en charge de nombreux types d'images (GraphicsMagick). Si
-vous rencontrez des problèmes avec les cartes au format xpm, essayez de charger et d'enregistrer les
-graphiques avec Gimp au préalable, afin de convertir tous les noms de couleurs inconnus en
-représentation binaire.
+vous rencontrez des problÃ¨mes avec les cartes au format xpm, essayez de charger et d'enregistrer les
+graphiques avec Gimp au prÃ©alable, afin de convertir tous les noms de couleurs inconnus en
+reprÃ©sentation binaire.
 
-Le fichier .geo est un fichier de données texte qui associe l'image à un emplacement
+Le fichier .geo est un fichier de donnÃ©es texte qui associe l'image Ã  un emplacement
 dans le monde. Voici un exemple de fichier .geo qui couvrira le monde entier
 avec la carte world1.xpm :
 
@@ -1310,45 +1310,45 @@ TIEPOINT   0          0        -180        90
 TIEPOINT   639        319      180         -90
 IMAGESIZE  640        320
 
-Les fichiers .geo peuvent contenir plusieurs éléments :
+Les fichiers .geo peuvent contenir plusieurs Ã©lÃ©ments :
 
 FILENAME <nom_de_fichier>
-Spécifie le nom du fichier image de la carte à charger depuis le disque local.
+SpÃ©cifie le nom du fichier image de la carte Ã  charger depuis le disque local.
 
 URL <https://site_web>
-Spécifie l'URL d'une image de carte à charger depuis un site web ou FTP.
+SpÃ©cifie l'URL d'une image de carte Ã  charger depuis un site web ou FTP.
 Uniquement avec GraphicsMagick.
 
 TIEPOINT <pixel_x> <pixel_y> <longitude> <latitude>
-Deux points de liaison sont requis, et plus de deux seront ignorés.
+Deux points de liaison sont requis, et plus de deux seront ignorÃ©s.
 Ces deux lignes permettent de relier une position de pixel x,y dans l'image
-à une position de latitude et de longitude sur la Terre. Les points doivent être aussi proches que
-possible du coin supérieur gauche et du coin inférieur droit de l'image pour
-une précision optimale. La latitude/longitude est spécifiée en degrés décimaux.
+Ã  une position de latitude et de longitude sur la Terre. Les points doivent Ãªtre aussi proches que
+possible du coin supÃ©rieur gauche et du coin infÃ©rieur droit de l'image pour
+une prÃ©cision optimale. La latitude/longitude est spÃ©cifiÃ©e en degrÃ©s dÃ©cimaux.
 
 IMAGESIZE <pixels horizontalement> <pixels verticalement>
-Spécifie la taille de l'image en pixels. Si cette option n'est pas définie, l'image
-sera chargée à chaque redessin de la carte, qu'elle soit visible à l'écran ou non.
-IMAGESIZE est une option OBLIGATOIRE si une URL est spécifiée. Pour les fichiers locaux, il s'agit
-d'un paramètre facultatif (nous utilisons GraphicsMagick pour interroger la taille de l'image pour les fichiers locaux).
+SpÃ©cifie la taille de l'image en pixels. Si cette option n'est pas dÃ©finie, l'image
+sera chargÃ©e Ã  chaque redessin de la carte, qu'elle soit visible Ã  l'Ã©cran ou non.
+IMAGESIZE est une option OBLIGATOIRE si une URL est spÃ©cifiÃ©e. Pour les fichiers locaux, il s'agit
+d'un paramÃ¨tre facultatif (nous utilisons GraphicsMagick pour interroger la taille de l'image pour les fichiers locaux).
 
 DATUM <datum>
-Cette fonctionnalité n'est pas implémentée. PROJECTION <projection>
-Cette fonctionnalité n'est que partiellement implémentée. La valeur par défaut est « LatLon », l'autre
-possibilité est « TM » pour spécifier que la carte est en projection Mercator transverse.
+Cette fonctionnalitÃ© n'est pas implÃ©mentÃ©e. PROJECTION <projection>
+Cette fonctionnalitÃ© n'est que partiellement implÃ©mentÃ©e. La valeur par dÃ©faut est Â« LatLon Â», l'autre
+possibilitÃ© est Â« TM Â» pour spÃ©cifier que la carte est en projection Mercator transverse.
 
 # <anything>
-Toute ligne commençant par un « # » sera ignorée.
+Toute ligne commenÃ§ant par un Â« # Â» sera ignorÃ©e.
 
-Améliorations d'image spécifiques à GraphicsMagick :
+AmÃ©liorations d'image spÃ©cifiques Ã  GraphicsMagick :
 
 GAMMA
 Exemple : GAMMA 1.2 ou GAMMA 1.2,2.0,1.2
-Le premier modifie le gamma global de l'image, le second éclaircit le vert plus que le rouge ou le bleu.
+Le premier modifie le gamma global de l'image, le second Ã©claircit le vert plus que le rouge ou le bleu.
 
 CONTRAST
 Exemple : CONTRAST 0 ou CONTRAST 1
-Ne semble pas avoir beaucoup d'effet, les autres valeurs ne font aucune différence.
+Ne semble pas avoir beaucoup d'effet, les autres valeurs ne font aucune diffÃ©rence.
 
 NEGATE
 Exemple : NEGATE 0 ou NEGATE 1
@@ -1362,194 +1362,194 @@ Aucun argument.
 
 LEVEL <black_point, mid_point, white_point>
 Exemple : LEVEL 0,1,65535
-Ces valeurs semblent être les valeurs par défaut.
+Ces valeurs semblent Ãªtre les valeurs par dÃ©faut.
 
 MODULATE <brightness, saturation, hue>
 Exemple : MODULATE 90,150,100
-Ce sont des pourcentages, 100,100,100 est la valeur par défaut.
+Ce sont des pourcentages, 100,100,100 est la valeur par dÃ©faut.
 
 REFRESH <seconds>
 Exemple : REFRESH 900
-Cette balise est utilisée pour les URL dynamiques telles que les radars météorologiques, où vous
-souhaitez que Xastir redessine automatiquement la carte à un intervalle spécifié. En
-ajoutant cette balise aux fichiers .geos des radars météorologiques, vous pouvez observer le déplacement des
-phénomènes météorologiques sur votre écran. Xastir ne contient qu'un seul compteur d'intervalle,
-donc le plus petit intervalle REFRESH chargé prend effet pour toutes les cartes sélectionnées.
+Cette balise est utilisÃ©e pour les URL dynamiques telles que les radars mÃ©tÃ©orologiques, oÃ¹ vous
+souhaitez que Xastir redessine automatiquement la carte Ã  un intervalle spÃ©cifiÃ©. En
+ajoutant cette balise aux fichiers .geos des radars mÃ©tÃ©orologiques, vous pouvez observer le dÃ©placement des
+phÃ©nomÃ¨nes mÃ©tÃ©orologiques sur votre Ã©cran. Xastir ne contient qu'un seul compteur d'intervalle,
+donc le plus petit intervalle REFRESH chargÃ© prend effet pour toutes les cartes sÃ©lectionnÃ©es.
 
 TRANSPARENT
-Couleur à supprimer de l'image.  Utilisez un nombre, 0 = noir. Les
+Couleur Ã  supprimer de l'image.  Utilisez un nombre, 0 = noir. Les
 images avec correspondance de couleurs utilisent la valeur de la
-carte, donc le blanc est généralement 0xffffffff (32 bits de 1). Les
-valeurs doivent être en hexadécimal, et sont précédées de « 0x ». La
-valeur peut être obtenue en utilisant le niveau de débogage 16. Le
-premier des quatre nombres après « Couleur allouée est » est l'indice
+carte, donc le blanc est gÃ©nÃ©ralement 0xffffffff (32 bits de 1). Les
+valeurs doivent Ãªtre en hexadÃ©cimal, et sont prÃ©cÃ©dÃ©es de Â« 0x Â». La
+valeur peut Ãªtre obtenue en utilisant le niveau de dÃ©bogage 16. Le
+premier des quatre nombres aprÃ¨s Â« Couleur allouÃ©e est Â» est l'indice
 de la table des couleurs.
 
 CROP <gauche haut droite bas>
 Supprime les bordures (les rend transparentes). Les valeurs sont en
-pixels avec (0,0) en haut à gauche. Une bonne valeur pour les images
-radar NWS 620x620 est « CROP 35 20 616 600 »
+pixels avec (0,0) en haut Ã  gauche. Une bonne valeur pour les images
+radar NWS 620x620 est Â« CROP 35 20 616 600 Â»
 
-Fichiers .geo spéciaux/non standard :
+Fichiers .geo spÃ©ciaux/non standard :
 
 WMSSERVER
 Permet l'utilisation des services de cartes web (WMS). Plusieurs
 exemples de ce type de source de carte en ligne sont automatiquement
-installés dans le répertoire des cartes, tels que « USTigermap.geo »
-et les cartes radar météorologiques dans le répertoire « NWS ».
+installÃ©s dans le rÃ©pertoire des cartes, tels que Â« USTigermap.geo Â»
+et les cartes radar mÃ©tÃ©orologiques dans le rÃ©pertoire Â« NWS Â».
 
 OSMSTATICMAP
 OSM_TILED_MAP
 Permet l'utilisation des serveurs OpenStreetMap qui fournissent soit
 une seule image statique, soit de petites tuiles de carte. Plusieurs
-exemples dont les noms commencent par « OSM_ » sont installés dans le
-répertoire des cartes.
+exemples dont les noms commencent par Â« OSM_ Â» sont installÃ©s dans le
+rÃ©pertoire des cartes.
 
 
 Les cartes GeoTIFF sont une variante du format d'image TIFF avec des
-balises de géoréférencement supplémentaires intégrées. Celles
-utilisées aux États-Unis sont généralement fournies avec deux fichiers
+balises de gÃ©orÃ©fÃ©rencement supplÃ©mentaires intÃ©grÃ©es. Celles
+utilisÃ©es aux Ã‰tats-Unis sont gÃ©nÃ©ralement fournies avec deux fichiers
 : un fichier .tif et un fichier .fgd. Le fichier .tif contient les
-données de la carte. Le fichier .fgd est un fichier de métadonnées
-conforme à une norme fédérale, mais pour les besoins de Xastir, il ne
+donnÃ©es de la carte. Le fichier .fgd est un fichier de mÃ©tadonnÃ©es
+conforme Ã  une norme fÃ©dÃ©rale, mais pour les besoins de Xastir, il ne
 doit contenir que quatre lignes comme celles-ci (il peut cependant en
 contenir beaucoup d'autres) :
 
-1.5.1.1   COORDONNÉE OUEST :  -122.000000
-1.5.1.2   COORDONNÉE EST :  -120.000000
-1.5.1.3   COORDONNÉE NORD :  48.000000
-1.5.1.4   COORDONNÉE SUD :  47.000000
+1.5.1.1   COORDONNÃ‰E OUEST :  -122.000000
+1.5.1.2   COORDONNÃ‰E EST :  -120.000000
+1.5.1.3   COORDONNÃ‰E NORD :  48.000000
+1.5.1.4   COORDONNÃ‰E SUD :  47.000000
 
 Xastir utilise uniquement ces quatre lignes dans ses calculs pour
-déterminer les points d'angle d'une carte, afin de vérifier si la
+dÃ©terminer les points d'angle d'une carte, afin de vÃ©rifier si la
 carte s'affiche correctement dans la zone d'affichage (et ainsi
-décider de l'afficher ou non). Si vos données cartographiques
+dÃ©cider de l'afficher ou non). Si vos donnÃ©es cartographiques
 proviennent de cartes topographiques USGS, le fichier .fgd devrait
-être facilement disponible. Si ce n'est pas le cas, le script
-mapfgd.pl peut le créer pour vous. Si vous ne disposez pas de fichier
+Ãªtre facilement disponible. Si ce n'est pas le cas, le script
+mapfgd.pl peut le crÃ©er pour vous. Si vous ne disposez pas de fichier
 .fgd, la carte se chargera correctement, mais les bordures blanches ne
-seront pas recadrées et la taille et la rotation peuvent être
-légèrement incorrectes. Une fonctionnalité supplémentaire de Xastir
-est la possibilité d'effectuer des translations de datum du NAD 1927
+seront pas recadrÃ©es et la taille et la rotation peuvent Ãªtre
+lÃ©gÃ¨rement incorrectes. Une fonctionnalitÃ© supplÃ©mentaire de Xastir
+est la possibilitÃ© d'effectuer des translations de datum du NAD 1927
 au WGS 84, ce qui rend les cartes topographiques USGS beaucoup plus
-précises sur l'écran de Xastir.
+prÃ©cises sur l'Ã©cran de Xastir.
 
 Xastir peut utiliser les cartes topographiques GeoTIFF USGS
 directement depuis le lecteur CD.  Montez manuellement le disque ou
-utilisez un outil de montage automatique, et assurez-vous d'avoir créé
-un lien symbolique dans votre répertoire de cartes pointant vers
+utilisez un outil de montage automatique, et assurez-vous d'avoir crÃ©Ã©
+un lien symbolique dans votre rÃ©pertoire de cartes pointant vers
 l'emplacement de votre lecteur CD-ROM. C'est tout !
 
-Les cartes au format ESRI Shapefile sont également une combinaison de
+Les cartes au format ESRI Shapefile sont Ã©galement une combinaison de
 plusieurs fichiers : un fichier .shp, un fichier .dbf et un fichier
-.shx. Il vous suffit de sélectionner le fichier .shp pour charger la
-carte, mais les autres fichiers doivent être présents pour que la
-carte se charge correctement.  De plus, à moins que votre ensemble de
-fichiers Shapefile corresponde à ceux pour lesquels Xastir dispose
-déjà de règles de rendu, vous devrez créer un fichier « dbfawk » pour
-que Xastir puisse les afficher correctement. Cartes du comté WX
+.shx. Il vous suffit de sÃ©lectionner le fichier .shp pour charger la
+carte, mais les autres fichiers doivent Ãªtre prÃ©sents pour que la
+carte se charge correctement.  De plus, Ã  moins que votre ensemble de
+fichiers Shapefile corresponde Ã  ceux pour lesquels Xastir dispose
+dÃ©jÃ  de rÃ¨gles de rendu, vous devrez crÃ©er un fichier Â« dbfawk Â» pour
+que Xastir puisse les afficher correctement. Cartes du comtÃ© WX
 
-Toutes les cartes du comté WX doivent être stockées dans le répertoire
+Toutes les cartes du comtÃ© WX doivent Ãªtre stockÃ©es dans le rÃ©pertoire
 /usr/local/share/xastir/Counties. Xastir prend uniquement en charge le
-format ESRI Shapefile pour ces cartes. L'installation est expliquée
+format ESRI Shapefile pour ces cartes. L'installation est expliquÃ©e
 sur
 https://github.com/Xastir/Xastir/wiki/Xastir-Mapping-Overview. Vous
-devez avoir compilé Shapelib.
+devez avoir compilÃ© Shapelib.
 
-À la réception des messages du NWS, différentes zones sont colorées
-pour indiquer les zones concernées. Ces couleurs correspondent aux
-différents types d'alertes : cyan pour les avis, jaune pour les
-veilles, rouge pour les alertes, orange pour les alertes annulées,
+Ã€ la rÃ©ception des messages du NWS, diffÃ©rentes zones sont colorÃ©es
+pour indiquer les zones concernÃ©es. Ces couleurs correspondent aux
+diffÃ©rents types d'alertes : cyan pour les avis, jaune pour les
+veilles, rouge pour les alertes, orange pour les alertes annulÃ©es,
 bleu roi pour les tests et vert pour les niveaux d'alerte
-indéterminés. La coloration est réalisée à l'aide d'un motif de pixmap
-qui affiche le type d'alerte, si celui-ci peut être déterminé. Ces
-modifications ont été apportées afin que les cartes sous-jacentes
-restent visibles sous les zones d'alerte météorologique et que le type
+indÃ©terminÃ©s. La coloration est rÃ©alisÃ©e Ã  l'aide d'un motif de pixmap
+qui affiche le type d'alerte, si celui-ci peut Ãªtre dÃ©terminÃ©. Ces
+modifications ont Ã©tÃ© apportÃ©es afin que les cartes sous-jacentes
+restent visibles sous les zones d'alerte mÃ©tÃ©orologique et que le type
 d'alerte soit plus facilement identifiable, car il est parfois
-difficile de faire correspondre les alertes affichées à l'écran et
-celles du dialogue des alertes météorologiques. L'affichage des
-alertes météorologiques peut être activé ou désactivé via le menu
+difficile de faire correspondre les alertes affichÃ©es Ã  l'Ã©cran et
+celles du dialogue des alertes mÃ©tÃ©orologiques. L'affichage des
+alertes mÃ©tÃ©orologiques peut Ãªtre activÃ© ou dÃ©sactivÃ© via le menu
 Carte.
 
 HELP-INDEX>Menu Stations
 
                           Menu Stations
 
-Ces options vous permettent de contrôler les données affichées autour
-des stations sur la carte. Elles vous permettent également de suivre
+Ces options vous permettent de contrÃ´ler les donnÃ©es affichÃ©es autour
+des stations sur la carte. Elles vous permettent Ã©galement de suivre
 et de localiser des stations, ainsi que d'effacer des stations et des
-traces dans la base de données et sur la carte.
+traces dans la base de donnÃ©es et sur la carte.
 
 Localiser une station
-Consultez la rubrique d'aide « Localisation d'une station ».
+Consultez la rubrique d'aide Â« Localisation d'une station Â».
 
 Suivre une station
-Consultez la rubrique d'aide « Suivi d'une station ».
+Consultez la rubrique d'aide Â« Suivi d'une station Â».
 
-Récupérer piste Findu
-Télécharge les données de trace historiques depuis findu.com. Les
-curseurs permettent de contrôler le point de départ et la durée des
-données téléchargées. Par exemple, si vous souhaitez afficher la trace
-d'il y a deux jours, sur toute la journée, vous pouvez régler le
-premier curseur sur 48 heures (heure de début il y a deux jours) et le
-second sur 24 heures pour obtenir exactement les données d'une
-journée, du début jusqu'à 24 heures plus tard.
+RÃ©cupÃ©rer piste Findu
+TÃ©lÃ©charge les donnÃ©es de trace historiques depuis findu.com. Les
+curseurs permettent de contrÃ´ler le point de dÃ©part et la durÃ©e des
+donnÃ©es tÃ©lÃ©chargÃ©es. Par exemple, si vous souhaitez afficher la trace
+d'il y a deux jours, sur toute la journÃ©e, vous pouvez rÃ©gler le
+premier curseur sur 48 heures (heure de dÃ©but il y a deux jours) et le
+second sur 24 heures pour obtenir exactement les donnÃ©es d'une
+journÃ©e, du dÃ©but jusqu'Ã  24 heures plus tard.
 
 
 Exporter tout
-Ce sous-menu permet d'enregistrer les données de toutes les stations
-dans des fichiers [ou des bases de données].
+Ce sous-menu permet d'enregistrer les donnÃ©es de toutes les stations
+dans des fichiers [ou des bases de donnÃ©es].
 
    Exporter vers fichier KML
      Enregistre toutes les stations et leurs traces dans un fichier
      Keyhole Markup Language dans ~/.xastir/tracklogs. Le nom du
      fichier sera la date et l'heure actuelles avec l'extension .kml,
      par exemple 20080125-033045.kml Des fichiers KML peuvent
-     également être créés régulièrement à l'aide des instantanés KML
+     Ã©galement Ãªtre crÃ©Ã©s rÃ©guliÃ¨rement Ã  l'aide des instantanÃ©s KML
      du menu Fichier.
 
-   Base de données par réseau [Non encore implémenté]
-      [L'enregistrement dans les interfaces de base de données n'est
-      actuellement implémenté que via les boîtes de dialogue
-      d'interface de base de données SQL individuelles]
+   Base de donnÃ©es par rÃ©seau [Non encore implÃ©mentÃ©]
+      [L'enregistrement dans les interfaces de base de donnÃ©es n'est
+      actuellement implÃ©mentÃ© que via les boÃ®tes de dialogue
+      d'interface de base de donnÃ©es SQL individuelles]
 
-   Pour enregistrer un instantané PNG de la carte actuelle, utilisez
-   Fichier->Activer copie d'écran PNG
+   Pour enregistrer un instantanÃ© PNG de la carte actuelle, utilisez
+   Fichier->Activer copie d'Ã©cran PNG
 
-Filtrer les données
-Ce sous-menu permet de filtrer les symboles affichés :
+Filtrer les donnÃ©es
+Ce sous-menu permet de filtrer les symboles affichÃ©s :
 
   Ne rien afficher
-    Détermine si les symboles doivent être affichés sur la carte. Les
-    autres options dépendent de l'activation de cette option.
+    DÃ©termine si les symboles doivent Ãªtre affichÃ©s sur la carte. Les
+    autres options dÃ©pendent de l'activation de cette option.
 
   Ma station
-    Détermine si votre propre station est affichée sur la carte.
+    DÃ©termine si votre propre station est affichÃ©e sur la carte.
 
   Choisir TNC
-    Activation/désactivation globale de l'affichage des données reçues
-    via un TNC, mais peut être affinée :
+    Activation/dÃ©sactivation globale de l'affichage des donnÃ©es reÃ§ues
+    via un TNC, mais peut Ãªtre affinÃ©e :
 
    Stations en direct
      Cette option affiche uniquement les stations entendues
-     directement (non relayées).
+     directement (non relayÃ©es).
 
    Stations via Digi
      Cette option affiche les stations entendues indirectement via un
-     répéteur.
+     rÃ©pÃ©teur.
 
   Stations via le net
-    Cette option affiche les stations dont les données ont été reçues
+    Cette option affiche les stations dont les donnÃ©es ont Ã©tÃ© reÃ§ues
     via Internet.
 
-  Inclure données périmées
-    Permet à Xastir de continuer à afficher les données de station qui
-    disparaissent normalement lorsque le symbole est masqué. Le délai
-    d'expiration peut être ajusté dans le menu
-    Fichier|Configurer|Paramètres par défaut.
+  Inclure donnÃ©es pÃ©rimÃ©es
+    Permet Ã  Xastir de continuer Ã  afficher les donnÃ©es de station qui
+    disparaissent normalement lorsque le symbole est masquÃ©. Le dÃ©lai
+    d'expiration peut Ãªtre ajustÃ© dans le menu
+    Fichier|Configurer|ParamÃ¨tres par dÃ©faut.
 
   Afficher les stations
-    Activation globale de l'affichage des stations, mais peut être affinée:
+    Activation globale de l'affichage des stations, mais peut Ãªtre affinÃ©e:
 
     Stations fixes
       Cette option affiche les stations fixes.
@@ -1558,307 +1558,307 @@ Ce sous-menu permet de filtrer les symboles affichés :
       Cette option affiche les stations avec plusieurs positions ou
       une vitesse non nulle.
 
-    Stations météo
-      Cette option affiche les stations météorologiques.
+    Stations mÃ©tÃ©o
+      Cette option affiche les stations mÃ©tÃ©orologiques.
 
-        Stations météo CWOP
-        Cette option inclut l'affichage des données météorologiques
+        Stations mÃ©tÃ©o CWOP
+        Cette option inclut l'affichage des donnÃ©es mÃ©tÃ©orologiques
         des stations citoyennes (non radioamateurs).  Actuellement,
-        Xastir reconnaît comme stations CWOP toute station commençant
-        par les lettres C à G, dont la deuxième lettre est « W », et
+        Xastir reconnaÃ®t comme stations CWOP toute station commenÃ§ant
+        par les lettres C Ã  G, dont la deuxiÃ¨me lettre est Â« W Â», et
         suivie de quatre chiffres.
 
     objets/articles
     Activation globale de l'affichage des objets/articles, mais peut
-    être affinée :
+    Ãªtre affinÃ©e :
 
-    Objets/articles météo
+    Objets/articles mÃ©tÃ©o
       Cette option affiche les objets et articles
-      météorologiques. Cela inclut les tempêtes tropicales et les
-      stations météorologiques distantes.
+      mÃ©tÃ©orologiques. Cela inclut les tempÃªtes tropicales et les
+      stations mÃ©tÃ©orologiques distantes.
 
     Objets/articles indicateurs d'eau
-      Cette option active ou désactive l'affichage des objets de jauge
+      Cette option active ou dÃ©sactive l'affichage des objets de jauge
       d'eau (/w).
 
     Autres objets/articles
-      Cette option active ou désactive l'affichage des objets autres
-      que ceux énumérés ci-dessus.
+      Cette option active ou dÃ©sactive l'affichage des objets autres
+      que ceux Ã©numÃ©rÃ©s ci-dessus.
 
 
 Filtrer affichage
-Ce sous-menu permet de filtrer les données affichées :
+Ce sous-menu permet de filtrer les donnÃ©es affichÃ©es :
 
   Afficher indicatif
-  Détermine si l'indicatif d'appel est affiché.
+  DÃ©termine si l'indicatif d'appel est affichÃ©.
 
     Annoter les points de piste
     Cette option inclut les indicatifs d'appel le long des traces,
-    pour aider à identifier quels points appartiennent à quelles stations.
+    pour aider Ã  identifier quels points appartiennent Ã  quelles stations.
 
   Afficher symbole
-  Détermine si le symbole est affiché à gauche de l'indicatif d'appel.
+  DÃ©termine si le symbole est affichÃ© Ã  gauche de l'indicatif d'appel.
 
     pivoter symbole
     Certains symboles changent d'orientation pour indiquer la
-    direction dans laquelle ils se déplacent.
+    direction dans laquelle ils se dÃ©placent.
 
   Afficher piste
-  Lorsqu'elle est activée, toute station mobile affiche une ligne
-  colorée. Nous affichons désormais autant de positions que nous en
-  avons dans notre base de données (l'ancienne limite était de
-  100). Les segments de trace longs (plus de 2 degrés de latitude ou 2
-  degrés de longitude), ou les segments avec un délai de réception de
-  plus de 45 minutes entre les points ne seront pas affichés.  Les
-  points en double sont également éliminés de la trace (équipe de
-  recherche et de sauvetage revenant à la base : le dernier segment
-  peut ne pas être affiché car le point de départ apparaît deux fois
+  Lorsqu'elle est activÃ©e, toute station mobile affiche une ligne
+  colorÃ©e. Nous affichons dÃ©sormais autant de positions que nous en
+  avons dans notre base de donnÃ©es (l'ancienne limite Ã©tait de
+  100). Les segments de trace longs (plus de 2 degrÃ©s de latitude ou 2
+  degrÃ©s de longitude), ou les segments avec un dÃ©lai de rÃ©ception de
+  plus de 45 minutes entre les points ne seront pas affichÃ©s.  Les
+  points en double sont Ã©galement Ã©liminÃ©s de la trace (Ã©quipe de
+  recherche et de sauvetage revenant Ã  la base : le dernier segment
+  peut ne pas Ãªtre affichÃ© car le point de dÃ©part apparaÃ®t deux fois
   dans la liste des traces).
 
   Afficher cap
-  Lorsqu'elle est activée, un texte vert apparaît sous l'indicatif
-  d'appel. Il affiche le dernier cap connu (en degrés) de la
+  Lorsqu'elle est activÃ©e, un texte vert apparaÃ®t sous l'indicatif
+  d'appel. Il affiche le dernier cap connu (en degrÃ©s) de la
   station.
 
   Afficher vitesse
-  Lorsque cette option est activée, un texte rouge s'affiche sous
-  l'indicatif d'appel (ou le cap). Il indique la dernière vitesse
+  Lorsque cette option est activÃ©e, un texte rouge s'affiche sous
+  l'indicatif d'appel (ou le cap). Il indique la derniÃ¨re vitesse
   connue de la station.
 
-    Afficher vitesse abrégée
-    Cette option supprime l'affichage des unités de mesure de la vitesse.
+    Afficher vitesse abrÃ©gÃ©e
+    Cette option supprime l'affichage des unitÃ©s de mesure de la vitesse.
 
   Afficher altitude
-  Lorsque cette option est activée, un texte bleu s'affiche au-dessus
-  de l'indicatif d'appel. Il indique la dernière altitude connue de la
+  Lorsque cette option est activÃ©e, un texte bleu s'affiche au-dessus
+  de l'indicatif d'appel. Il indique la derniÃ¨re altitude connue de la
   station.
 
 
-  Affichage info météo
-  Option globale pour l'affichage des informations météorologiques,
-  qui peut être affinée :
+  Affichage info mÃ©tÃ©o
+  Option globale pour l'affichage des informations mÃ©tÃ©orologiques,
+  qui peut Ãªtre affinÃ©e :
 
-    Afficher texte météo
-    Lorsque cette option est activée, les dernières données
-    météorologiques (température, vitesse/direction/rafales du
-    vent, humidité) sont affichées. Ce paramètre peut être ajusté
+    Afficher texte mÃ©tÃ©o
+    Lorsque cette option est activÃ©e, les derniÃ¨res donnÃ©es
+    mÃ©tÃ©orologiques (tempÃ©rature, vitesse/direction/rafales du
+    vent, humiditÃ©) sont affichÃ©es. Ce paramÃ¨tre peut Ãªtre ajustÃ©
     avec l'option suivante :
 
-      Seulement la température
-      Affiche uniquement les données de température pour la station.
+      Seulement la tempÃ©rature
+      Affiche uniquement les donnÃ©es de tempÃ©rature pour la station.
 
     Indicateur de vent
-    Lorsque cette option est activée, une flèche de vent indiquant la
-    direction et la vitesse du vent est dessinée pour toutes les
-    stations affichées qui transmettent ces informations.
+    Lorsque cette option est activÃ©e, une flÃ¨che de vent indiquant la
+    direction et la vitesse du vent est dessinÃ©e pour toutes les
+    stations affichÃ©es qui transmettent ces informations.
 
-  Afficher ambiguïté de position
-  Lorsque cette option est activée, la zone dans laquelle la station
-  utilisant l'incertitude de position peut se trouver est ombrée,
-  avec la station concernée au centre.
+  Afficher ambiguÃ¯tÃ© de position
+  Lorsque cette option est activÃ©e, la zone dans laquelle la station
+  utilisant l'incertitude de position peut se trouver est ombrÃ©e,
+  avec la station concernÃ©e au centre.
 
   Afficher puissance/gain
-  Lorsque cette option est activée, les cercles de puissance/gain
-  seront affichés. Les cercles qui se chevauchent indiquent que les
-  stations sont théoriquement à portée simplex l'une de l'autre. Cette
-  indication n'est qu'approximative, surtout dans les zones à relief
+  Lorsque cette option est activÃ©e, les cercles de puissance/gain
+  seront affichÃ©s. Les cercles qui se chevauchent indiquent que les
+  stations sont thÃ©oriquement Ã  portÃ©e simplex l'une de l'autre. Cette
+  indication n'est qu'approximative, surtout dans les zones Ã  relief
   variable.
 
-    Activer puissance/gain défaut Active un réglage de
-    puissance/gain par défaut tel que spécifié dans la norme APRS(tm).
+    Activer puissance/gain dÃ©faut Active un rÃ©glage de
+    puissance/gain par dÃ©faut tel que spÃ©cifiÃ© dans la norme APRS(tm).
 
     Activer puissance/gain mobile Active les cercles de puissance/gain
     pour les stations mobiles. 
 
 
   Afficher attributs DF
-  Lorsque cette option est activée, tous les cercles/lignes DF seront
-  affichés à l'écran.
+  Lorsque cette option est activÃ©e, tous les cercles/lignes DF seront
+  affichÃ©s Ã  l'Ã©cran.
 
-  Activer point estimé Lorsque cette option est activée,
-  les positions des stations sont estimées en fonction de leur
-  trajectoire et de leur vitesse passées. Le taux de recalcul doit
-  être raisonnable, mais peut être ajusté dans le fichier de
+  Activer point estimÃ© Lorsque cette option est activÃ©e,
+  les positions des stations sont estimÃ©es en fonction de leur
+  trajectoire et de leur vitesse passÃ©es. Le taux de recalcul doit
+  Ãªtre raisonnable, mais peut Ãªtre ajustÃ© dans le fichier de
   configuration.
 
     Afficher arc Affiche un arc en expansion indiquant la distance
-    de déplacement maximale attendue, la position et la trajectoire,
-    compte tenu de la trajectoire et de la vitesse passées. L'arc se
-    transforme progressivement en cercle à mesure que le rapport de
+    de dÃ©placement maximale attendue, la position et la trajectoire,
+    compte tenu de la trajectoire et de la vitesse passÃ©es. L'arc se
+    transforme progressivement en cercle Ã  mesure que le rapport de
     position vieillit.
 
     Afficher cap Affiche la trajectoire et la distance
     parcourue attendues par la station, en supposant que la
-    trajectoire n'a pas changé.
+    trajectoire n'a pas changÃ©.
 
-    Afficher symbole Affiche une version estompée du symbole de
-    la station à la position attendue, en supposant que la station a
-    continué à sa trajectoire et à sa vitesse actuelles.
+    Afficher symbole Affiche une version estompÃ©e du symbole de
+    la station Ã  la position attendue, en supposant que la station a
+    continuÃ© Ã  sa trajectoire et Ã  sa vitesse actuelles.
 
 
-  Afficher distance/relèvement Lorsque cette option est activée,
-  deux lignes de texte seront affichées sur le côté gauche de l'icône
-  de la station. La ligne supérieure indiquera la distance entre votre
-  station et cette station. La ligne inférieure indiquera le
-  relèvement de votre station à cette station.
+  Afficher distance/relÃ¨vement Lorsque cette option est activÃ©e,
+  deux lignes de texte seront affichÃ©es sur le cÃ´tÃ© gauche de l'icÃ´ne
+  de la station. La ligne supÃ©rieure indiquera la distance entre votre
+  station et cette station. La ligne infÃ©rieure indiquera le
+  relÃ¨vement de votre station Ã  cette station.
 
-  Afficher âge du dernier rapport Affiche le temps écoulé depuis le
+  Afficher Ã¢ge du dernier rapport Affiche le temps Ã©coulÃ© depuis le
   dernier contact avec la station.
 
 Recharger histoire des objets/articles Cette option recharge le
-fichier ~/.xastir/config/objects.log utilisé pour la persistance des
-objets et des éléments.  Cette opération est nécessaire si vous
-modifiez le fichier pendant que Xastir est en cours d'exécution.
+fichier ~/.xastir/config/objects.log utilisÃ© pour la persistance des
+objets et des Ã©lÃ©ments.  Cette opÃ©ration est nÃ©cessaire si vous
+modifiez le fichier pendant que Xastir est en cours d'exÃ©cution.
 
 Effacer histoire des objets/articles : Cette option effacera le
-fichier ~/.xastir/config/objects.log utilisé pour la persistance des
-objets et des éléments. Il est recommandé de sélectionner et de
-supprimer manuellement tous les objets et éléments que vous possédez
-avant d'effectuer cette opération, sinon ils risquent de rester
-affichés sur les écrans des autres utilisateurs APRS(tm).
+fichier ~/.xastir/config/objects.log utilisÃ© pour la persistance des
+objets et des Ã©lÃ©ments. Il est recommandÃ© de sÃ©lectionner et de
+supprimer manuellement tous les objets et Ã©lÃ©ments que vous possÃ©dez
+avant d'effectuer cette opÃ©ration, sinon ils risquent de rester
+affichÃ©s sur les Ã©crans des autres utilisateurs APRS(tm).
 
 Effacer indicatifs tactiques : Cette option efface tous les
-indicatifs tactiques attribués. La modification prendra effet lors du
-prochain rafraîchissement de l'écran. Notez que cela n'effacera PAS
-les indicatifs tactiques sur les écrans des autres utilisateurs si
-vous les avez publiés via un message à « TACTICAL » (voir l'aide pour
-« Envoyer un message »).
+indicatifs tactiques attribuÃ©s. La modification prendra effet lors du
+prochain rafraÃ®chissement de l'Ã©cran. Notez que cela n'effacera PAS
+les indicatifs tactiques sur les Ã©crans des autres utilisateurs si
+vous les avez publiÃ©s via un message Ã  Â« TACTICAL Â» (voir l'aide pour
+Â« Envoyer un message Â»).
 
 Effacer historique des indicatifs tactiques : Cette option supprime
 le fichier d'historique des indicatifs tactiques, ce qui signifie que
-les indicatifs tactiques attribués ne seront pas conservés entre les
-redémarrages de Xastir. Notez que cela n'effacera PAS les indicatifs
-tactiques sur les écrans des autres utilisateurs si vous les avez
-publiés via un message à « TACTICAL » (voir l'aide pour « Envoyer un
-message »).
+les indicatifs tactiques attribuÃ©s ne seront pas conservÃ©s entre les
+redÃ©marrages de Xastir. Notez que cela n'effacera PAS les indicatifs
+tactiques sur les Ã©crans des autres utilisateurs si vous les avez
+publiÃ©s via un message Ã  Â« TACTICAL Â» (voir l'aide pour Â« Envoyer un
+message Â»).
 
-Effacer toutes pistes : Cette option effacera toutes les données
-de suivi des lignes de la base de données des stations et rafraîchira
-l'écran. Cette option peut être utile si vous manquez de mémoire ou si
-vous souhaitez simplement un écran plus clair. Vous pouvez également
-effacer les traces des stations individuelles à partir de la boîte de
+Effacer toutes pistes : Cette option effacera toutes les donnÃ©es
+de suivi des lignes de la base de donnÃ©es des stations et rafraÃ®chira
+l'Ã©cran. Cette option peut Ãªtre utile si vous manquez de mÃ©moire ou si
+vous souhaitez simplement un Ã©cran plus clair. Vous pouvez Ã©galement
+effacer les traces des stations individuelles Ã  partir de la boÃ®te de
 dialogue Informations sur la station.
 
-Effacer toutes stations : Cette option effacera toutes les données
-de la base de données des stations, à l'exception des vôtres. Cette
-option peut être utile si vous manquez de mémoire ou si vous souhaitez
-simplement désencombrer votre écran.
+Effacer toutes stations : Cette option effacera toutes les donnÃ©es
+de la base de donnÃ©es des stations, Ã  l'exception des vÃ´tres. Cette
+option peut Ãªtre utile si vous manquez de mÃ©moire ou si vous souhaitez
+simplement dÃ©sencombrer votre Ã©cran.
 
 
 HELP-INDEX>Messages et menu Messages
 
            Messages et menu Messages
 
-Envoyer un message à et Ouvrir les messages de groupe
+Envoyer un message Ã  et Ouvrir les messages de groupe
 
-Ces deux fonctions sont très similaires. « Composer un message à »
-permet d'envoyer vos messages à une seule station et de ne recevoir
-des données que de cette station. Les messages de groupe sont plus
-généraux : vous pouvez recevoir tous les messages destinés au groupe
-et envoyer vos messages à ce groupe. Le code des messages de groupe
-n'est pas encore entièrement implémenté et divers problèmes restent à
-résoudre. Le fichier « groups » est recherché dans
-~/.xastir/config. C'est là que sont stockés les groupes dont vous êtes
-membre. Comme mentionné précédemment, la fonctionnalité « groupes »
-n'est peut-être pas encore complète.
+Ces deux fonctions sont trÃ¨s similaires. Â« Composer un message Ã  Â»
+permet d'envoyer vos messages Ã  une seule station et de ne recevoir
+des donnÃ©es que de cette station. Les messages de groupe sont plus
+gÃ©nÃ©raux : vous pouvez recevoir tous les messages destinÃ©s au groupe
+et envoyer vos messages Ã  ce groupe. Le code des messages de groupe
+n'est pas encore entiÃ¨rement implÃ©mentÃ© et divers problÃ¨mes restent Ã 
+rÃ©soudre. Le fichier Â« groups Â» est recherchÃ© dans
+~/.xastir/config. C'est lÃ  que sont stockÃ©s les groupes dont vous Ãªtes
+membre. Comme mentionnÃ© prÃ©cÃ©demment, la fonctionnalitÃ© Â« groupes Â»
+n'est peut-Ãªtre pas encore complÃ¨te.
 
-Dans un avenir proche, l'envoi de bulletins devrait également être
-ajouté à ce menu. Cette fonctionnalité n'est pas encore codée.
+Dans un avenir proche, l'envoi de bulletins devrait Ã©galement Ãªtre
+ajoutÃ© Ã  ce menu. Cette fonctionnalitÃ© n'est pas encore codÃ©e.
 
-Chacun de ces deux écrans contient une zone de message, une ligne
+Chacun de ces deux Ã©crans contient une zone de message, une ligne
 d'appel, une ligne de message et divers boutons. Vous devez d'abord
 saisir l'indicatif du groupe ou de la station que vous souhaitez
-contacter. Une fois cela fait, tout nouveau message reçu de cette
+contacter. Une fois cela fait, tout nouveau message reÃ§u de cette
 station s'affichera. Si la station vous envoie des informations et
-qu'aucune fenêtre de message n'est ouverte, une nouvelle fenêtre
-s'ouvrira automatiquement (jusqu'à 10) avec l'indicatif de cette
-station déjà renseigné. Vous pouvez alors saisir un message dans la
-ligne de message. Le message peut être plus long que la ligne de
-message et sa longueur maximale est d'environ 250 caractères. Une fois
-votre message saisi, cliquez sur le bouton « Transmettre maintenant ! »
-pour l'envoyer. Le bouton « Transmettre maintenant ! » sera grisé jusqu'à
-ce que votre message soit entièrement confirmé. Tous les messages que
-vous recevez sont triés par numéro de ligne et affichés dans la
-fenêtre de message. En mode groupe, chaque ligne affiche l'indicatif
-de la station émettrice, suivi du message. Actuellement, les messages
-de groupe sont triés par indicatif, puis par numéro de ligne. Lorsque
-vous avez terminé d'envoyer des messages, cliquez sur le bouton de
-sortie pour fermer la fenêtre. D'autres boutons sont également
-disponibles : le bouton « Nouvel/Refresh indicatif » vous permet de
+qu'aucune fenÃªtre de message n'est ouverte, une nouvelle fenÃªtre
+s'ouvrira automatiquement (jusqu'Ã  10) avec l'indicatif de cette
+station dÃ©jÃ  renseignÃ©. Vous pouvez alors saisir un message dans la
+ligne de message. Le message peut Ãªtre plus long que la ligne de
+message et sa longueur maximale est d'environ 250 caractÃ¨res. Une fois
+votre message saisi, cliquez sur le bouton Â« Transmettre maintenant ! Â»
+pour l'envoyer. Le bouton Â« Transmettre maintenant ! Â» sera grisÃ© jusqu'Ã 
+ce que votre message soit entiÃ¨rement confirmÃ©. Tous les messages que
+vous recevez sont triÃ©s par numÃ©ro de ligne et affichÃ©s dans la
+fenÃªtre de message. En mode groupe, chaque ligne affiche l'indicatif
+de la station Ã©mettrice, suivi du message. Actuellement, les messages
+de groupe sont triÃ©s par indicatif, puis par numÃ©ro de ligne. Lorsque
+vous avez terminÃ© d'envoyer des messages, cliquez sur le bouton de
+sortie pour fermer la fenÃªtre. D'autres boutons sont Ã©galement
+disponibles : le bouton Â« Nouvel/Refresh indicatif Â» vous permet de
 consulter les 
-anciennes données envoyées par une station. Saisissez l'indicatif et
+anciennes donnÃ©es envoyÃ©es par une station. Saisissez l'indicatif et
 cliquez sur ce bouton ; les anciennes informations s'afficheront. Vous
-pouvez également utiliser ce bouton pour modifier l'indicatif de la
+pouvez Ã©galement utiliser ce bouton pour modifier l'indicatif de la
 station avec laquelle vous communiquez. Saisissez le nouvel appel et
-cliquez sur le bouton. Le bouton « Effacer histoire de messages »
-effacera tous les messages affichés dans la fenêtre des messages. Le
-bouton « Annuler messages en suspens » annulera tous les messages
-en file d'attente de transmission qui n'ont pas encore été confirmés
-par la station distante. Après avoir annulé les messages en attente ou
-reçu un accusé de réception de la station distante, vous pouvez
-envoyer de nouveaux messages à cette station. Xastir vous permet de
-saisir du texte à l'avance ; vous pouvez donc continuer à taper sans
-attendre les accusés de réception.
+cliquez sur le bouton. Le bouton Â« Effacer histoire de messages Â»
+effacera tous les messages affichÃ©s dans la fenÃªtre des messages. Le
+bouton Â« Annuler messages en suspens Â» annulera tous les messages
+en file d'attente de transmission qui n'ont pas encore Ã©tÃ© confirmÃ©s
+par la station distante. AprÃ¨s avoir annulÃ© les messages en attente ou
+reÃ§u un accusÃ© de rÃ©ception de la station distante, vous pouvez
+envoyer de nouveaux messages Ã  cette station. Xastir vous permet de
+saisir du texte Ã  l'avance ; vous pouvez donc continuer Ã  taper sans
+attendre les accusÃ©s de rÃ©ception.
 
-Les messages en réponse à des messages précédents tenteront d'utiliser
-le chemin du message reçu afin d'éviter de saturer le système avec des
-messages diffusés. Vous pouvez modifier le chemin dans la boîte de
-dialogue d'envoi de message, ou les chemins par défaut définis dans
-les paramètres de l'interface seront utilisés si vous laissez ce champ
-vide. Le chemin peut être défini pour chaque message envoyé, mais une
-fois le message envoyé, le chemin reste fixe pour ce message.
+Les messages en rÃ©ponse Ã  des messages prÃ©cÃ©dents tenteront d'utiliser
+le chemin du message reÃ§u afin d'Ã©viter de saturer le systÃ¨me avec des
+messages diffusÃ©s. Vous pouvez modifier le chemin dans la boÃ®te de
+dialogue d'envoi de message, ou les chemins par dÃ©faut dÃ©finis dans
+les paramÃ¨tres de l'interface seront utilisÃ©s si vous laissez ce champ
+vide. Le chemin peut Ãªtre dÃ©fini pour chaque message envoyÃ©, mais une
+fois le message envoyÃ©, le chemin reste fixe pour ce message.
 
-Chaque message sortant reste mis en évidence jusqu'à ce qu'il soit
-confirmé par la station distante. S'il expire ou si vous annulez les
-messages en attente, ces messages resteront mis en évidence, sauf si
+Chaque message sortant reste mis en Ã©vidence jusqu'Ã  ce qu'il soit
+confirmÃ© par la station distante. S'il expire ou si vous annulez les
+messages en attente, ces messages resteront mis en Ã©vidence, sauf si
 vous effacez l'historique des messages.
 
 Pour publier des indicatifs tactiques vers d'autres stations Xastir et
-APRS+SA, et les attribuer localement : Envoyez un message à « TACTICAL
-» dont le corps contient des lignes similaires à :
+APRS+SA, et les attribuer localement : Envoyez un message Ã  Â« TACTICAL
+Â» dont le corps contient des lignes similaires Ã  :
 
 indicatif-1=TAC1;indicatif-2=TAC2;indicatif-3=TAC3
 
-Pour supprimer ultérieurement ces indicatifs tactiques des écrans
+Pour supprimer ultÃ©rieurement ces indicatifs tactiques des Ã©crans
 locaux ET distants, assurez-vous que le(s) message(s) d'origine les
-ayant attribués a/ont expiré ou a/ont été annulé(s), puis envoyez un
-message comme celui-ci et laissez-le se répéter jusqu'à expiration (ce
+ayant attribuÃ©s a/ont expirÃ© ou a/ont Ã©tÃ© annulÃ©(s), puis envoyez un
+message comme celui-ci et laissez-le se rÃ©pÃ©ter jusqu'Ã  expiration (ce
 qui attribue des indicatifs tactiques vides aux indicatifs d'origine,
 supprimant ainsi l'attribution) :
 
 indicatif-1=;indicatif-2=;indicatif-3=
 
-Effacer tout message à expédier
-Cela effacera tous les messages non acquittés que vous avez envoyés.
+Effacer tout message Ã  expÃ©dier
+Cela effacera tous les messages non acquittÃ©s que vous avez envoyÃ©s.
 
-Intérroger toutes les stations
-Ceci envoie un paquet « ?APRS? », ce qui devrait inciter toutes les
-stations locales à signaler leur position et/ou leur statut. La
-plupart des logiciels ignorent cette requête, car y répondre
-provoquerait un flux de données massif.
+IntÃ©rroger toutes les stations
+Ceci envoie un paquet Â« ?APRS? Â», ce qui devrait inciter toutes les
+stations locales Ã  signaler leur position et/ou leur statut. La
+plupart des logiciels ignorent cette requÃªte, car y rÃ©pondre
+provoquerait un flux de donnÃ©es massif.
 
-Intérroger les statsion IGate
-Ceci envoie un paquet « ?IGATE? », ce qui devrait inciter toutes les
-stations IGate locales à répondre avec leurs capacités.
+IntÃ©rroger les statsion IGate
+Ceci envoie un paquet Â« ?IGATE? Â», ce qui devrait inciter toutes les
+stations IGate locales Ã  rÃ©pondre avec leurs capacitÃ©s.
 
-Intérroger les station météo
-Ceci envoie un paquet « ?WX? », ce qui devrait inciter toutes les
-stations météorologiques locales à signaler leur position et les
-conditions météorologiques.
+IntÃ©rroger les station mÃ©tÃ©o
+Ceci envoie un paquet Â« ?WX? Â», ce qui devrait inciter toutes les
+stations mÃ©tÃ©orologiques locales Ã  signaler leur position et les
+conditions mÃ©tÃ©orologiques.
 
-Configurer la réponse automatique
-Cela définit le message envoyé en réponse automatique.
+Configurer la rÃ©ponse automatique
+Cela dÃ©finit le message envoyÃ© en rÃ©ponse automatique.
 
-Activer la réponse automatique
-Cela active la réponse automatique lorsqu'un message entrant est reçu.
+Activer la rÃ©ponse automatique
+Cela active la rÃ©ponse automatique lorsqu'un message entrant est reÃ§u.
 
 Mode "Satellite Ack"
-Ce mode désactive l'envoi de messages d'accusé de réception en réponse
-aux messages reçus. Les messages sont toujours acquittés à l'aide du
-système de réponse-accusé de réception. Lors d'une communication par
-satellite, il est évident que votre message a bien été transmis, car
-vous l'entendrez répété. L'envoi d'un accusé de réception indépendant
-par la station réceptrice ne fait qu'ajouter des interférences.
+Ce mode dÃ©sactive l'envoi de messages d'accusÃ© de rÃ©ception en rÃ©ponse
+aux messages reÃ§us. Les messages sont toujours acquittÃ©s Ã  l'aide du
+systÃ¨me de rÃ©ponse-accusÃ© de rÃ©ception. Lors d'une communication par
+satellite, il est Ã©vident que votre message a bien Ã©tÃ© transmis, car
+vous l'entendrez rÃ©pÃ©tÃ©. L'envoi d'un accusÃ© de rÃ©ception indÃ©pendant
+par la station rÃ©ceptrice ne fait qu'ajouter des interfÃ©rences.
 
 HELP-INDEX>Menu Interfaces
 
@@ -1866,126 +1866,126 @@ HELP-INDEX>Menu Interfaces
 
 Ce menu contient les options relatives aux interfaces.
 
-Contrôle de l'interface
-Cette option affiche une fenêtre permettant d'activer et de désactiver vos
-interfaces configurées, ainsi que d'ajouter, de supprimer ou de configurer des
-interfaces. Consultez la rubrique d'aide « Configurer les interfaces ».
+ContrÃ´le de l'interface
+Cette option affiche une fenÃªtre permettant d'activer et de dÃ©sactiver vos
+interfaces configurÃ©es, ainsi que d'ajouter, de supprimer ou de configurer des
+interfaces. Consultez la rubrique d'aide Â« Configurer les interfaces Â».
 
-Options de désactivation de la transmission
-Ces options désactivent la transmission de toutes les données, de
+Options de dÃ©sactivation de la transmission
+Ces options dÃ©sactivent la transmission de toutes les donnÃ©es, de
 votre position ou de vos objets. Ce sont des options globales qui
 affectent toutes les interfaces. La plupart des interfaces disposent
-également d'une option permettant de désactiver la transmission sur
-cette interface spécifique dans leurs menus de configuration.
+Ã©galement d'une option permettant de dÃ©sactiver la transmission sur
+cette interface spÃ©cifique dans leurs menus de configuration.
 
 Activer le port serveur
-Cette option active/désactive les sockets d'écoute TCP et UDP sur le
+Cette option active/dÃ©sactive les sockets d'Ã©coute TCP et UDP sur le
 port 2023. Vous pouvez connecter d'autres clients APRS(tm) au port TCP
-afin d'envoyer/recevoir des données APRS(tm). Une fois authentifiés,
-ils pourront envoyer des données à Xastir. Sans authentification, ils
-pourront recevoir toutes les données TNC et INET que Xastir
-reçoit. Notez que TOUT utilisateur disposant des identifiants
-appropriés peut se connecter aux ports TCP ou UDP s'ils sont
-activés. Actuellement, seul le port serveur UDP peut transmettre des
-données par radiofréquence. Le port TCP ne le peut pas.
+afin d'envoyer/recevoir des donnÃ©es APRS(tm). Une fois authentifiÃ©s,
+ils pourront envoyer des donnÃ©es Ã  Xastir. Sans authentification, ils
+pourront recevoir toutes les donnÃ©es TNC et INET que Xastir
+reÃ§oit. Notez que TOUT utilisateur disposant des identifiants
+appropriÃ©s peut se connecter aux ports TCP ou UDP s'ils sont
+activÃ©s. Actuellement, seul le port serveur UDP peut transmettre des
+donnÃ©es par radiofrÃ©quence. Le port TCP ne le peut pas.
 
-« user WE7U-13 pass XXXX vers XASTIR 1.3.3 »
+Â« user WE7U-13 pass XXXX vers XASTIR 1.3.3 Â»
 
-Connectez un autre client APRS(tm) à ce port ; il devrait s'authentifier et
-pouvoir envoyer des données à tous les serveurs auxquels Xastir est connecté,
+Connectez un autre client APRS(tm) Ã  ce port ; il devrait s'authentifier et
+pouvoir envoyer des donnÃ©es Ã  tous les serveurs auxquels Xastir est connectÃ©,
 ainsi que recevoir des paquets de tous les ports/serveurs auxquels Xastir est
-connecté.
+connectÃ©.
 
-Vous devriez également disposer d'un exécutable appelé «
-xastir_udp_client » qui peut envoyer des paquets au port d'écoute
-UDP. Exécutez-le comme suit:
+Vous devriez Ã©galement disposer d'un exÃ©cutable appelÃ© Â«
+xastir_udp_client Â» qui peut envoyer des paquets au port d'Ã©coute
+UDP. ExÃ©cutez-le comme suit:
 
      xastir_udp_client localhost 2023 <indicatif> <mot de passe> "Paquet APRS ici"
 
-Actuellement, cela injectera le paquet dans les routines de décodage
-de Xastir et l'enverra à tous les clients connectés en TCP. Il
-l'enverra également à l'INET si la fonction d'envoi à l'INET est
-activée. Il enverra le paquet via les ports RF en tant que paquet
-tiers uniquement si vous ajoutez l'option « -to_rf » après le mot de
+Actuellement, cela injectera le paquet dans les routines de dÃ©codage
+de Xastir et l'enverra Ã  tous les clients connectÃ©s en TCP. Il
+l'enverra Ã©galement Ã  l'INET si la fonction d'envoi Ã  l'INET est
+activÃ©e. Il enverra le paquet via les ports RF en tant que paquet
+tiers uniquement si vous ajoutez l'option Â« -to_rf Â» aprÃ¨s le mot de
 passe, comme ceci :
 
      xastir_udp_client localhost 2023 <indicatif> <mot de passe> -to_rf "Paquet APRS"
 
-Le client UDP est utile pour générer et injecter des paquets APRS à
-partir de scripts externes. Il peut également être utilisé pour
-récupérer l'indicatif du serveur Xastir distant en utilisant l'option
-« -identify » :
+Le client UDP est utile pour gÃ©nÃ©rer et injecter des paquets APRS Ã 
+partir de scripts externes. Il peut Ã©galement Ãªtre utilisÃ© pour
+rÃ©cupÃ©rer l'indicatif du serveur Xastir distant en utilisant l'option
+Â« -identify Â» :
 
      xastir_udp_client localhost 2023 <indicatif> <mot de passe> -identify
 
 Transmettre maintenant!
-Cette option permet à toutes les interfaces pour lesquelles la
-transmission est activée (voir Configuration | Interfaces) d'envoyer
-un paquet de position. Elle sera grisée si l'option « Désactiver la
-transmission : TOUT » est sélectionnée.
+Cette option permet Ã  toutes les interfaces pour lesquelles la
+transmission est activÃ©e (voir Configuration | Interfaces) d'envoyer
+un paquet de position. Elle sera grisÃ©e si l'option Â« DÃ©sactiver la
+transmission : TOUT Â» est sÃ©lectionnÃ©e.
 
-Si GPSMan est installé, les options de menu supplémentaires suivantes
+Si GPSMan est installÃ©, les options de menu supplÃ©mentaires suivantes
 s'affichent:
 
 Extraire piste GPS
-Télécharger un ensemble de points de trace depuis un GPS connecté.
+TÃ©lÃ©charger un ensemble de points de trace depuis un GPS connectÃ©.
 
 Extraire routes GPS
-Télécharger un ensemble d'itinéraires depuis un GPS connecté.
+TÃ©lÃ©charger un ensemble d'itinÃ©raires depuis un GPS connectÃ©.
 
 Extraire points de cheminement GPS
-Télécharger un ensemble de points de repère depuis un GPS connecté.
+TÃ©lÃ©charger un ensemble de points de repÃ¨re depuis un GPS connectÃ©.
 
 Extraire points de cheminement Garmin RINO
-Récupérer les points de repère d'un Garmin RINO connecté et créer des
-objets APRS(tm) à partir de tous les points de repère commençant par «
-APRS ».
+RÃ©cupÃ©rer les points de repÃ¨re d'un Garmin RINO connectÃ© et crÃ©er des
+objets APRS(tm) Ã  partir de tous les points de repÃ¨re commenÃ§ant par Â«
+APRS Â».
 
-HELP-INDEX>Boîte d'informations de station - Recherche FCC et RAC
+HELP-INDEX>BoÃ®te d'informations de station - Recherche FCC et RAC
 
-           Boîte d'informations de station - Recherche FCC et RAC
+           BoÃ®te d'informations de station - Recherche FCC et RAC
 
-Les informations de station affichent les données décodées par Xastir.
+Les informations de station affichent les donnÃ©es dÃ©codÃ©es par Xastir.
 
 Vous pouvez attribuer des indicatifs tactiques (locaux uniquement) aux
-stations à partir d'ici en cliquant sur le bouton « Assigner un
-indicatif tactique ». La station s'affichera alors à l'écran avec son
+stations Ã  partir d'ici en cliquant sur le bouton Â« Assigner un
+indicatif tactique Â». La station s'affichera alors Ã  l'Ã©cran avec son
 indicatif tactique au lieu de son indicatif d'appel. Attribuer un
-indicatif tactique vide désactive cette fonction, qui peut également
-être désactivée pour toutes les stations dans le menu Stations. Cette
-fonction attribue des indicatifs tactiques uniquement à la station
+indicatif tactique vide dÃ©sactive cette fonction, qui peut Ã©galement
+Ãªtre dÃ©sactivÃ©e pour toutes les stations dans le menu Stations. Cette
+fonction attribue des indicatifs tactiques uniquement Ã  la station
 Xastir locale, mais consultez la section ci-dessous pour les partager
 avec d'autres stations.
 
 Pour partager les indicatifs tactiques par radio avec d'autres
 stations Xastir et APRS+SA (en plus de les attribuer localement),
-consultez la section d'aide « Composer un message ».
+consultez la section d'aide Â« Composer un message Â».
 
-L'option « Activer actualisation automatiques » actualise
-régulièrement la fenêtre avec les dernières informations.
+L'option Â« Activer actualisation automatiques Â» actualise
+rÃ©guliÃ¨rement la fenÃªtre avec les derniÃ¨res informations.
 
 Les informations disponibles peuvent inclure : le nombre de paquets
-reçus, l'heure de la dernière réception, l'appareil d'origine du
+reÃ§us, l'heure de la derniÃ¨re rÃ©ception, l'appareil d'origine du
 paquet, les commentaires de la station, la puissance/hauteur/gain de
-la station, le cap/la distance par rapport à votre station, les
-informations météorologiques et les positions actuelles et
-précédentes.
+la station, le cap/la distance par rapport Ã  votre station, les
+informations mÃ©tÃ©orologiques et les positions actuelles et
+prÃ©cÃ©dentes.
 
 Pour les stations mobiles, un journal de suivi s'affiche avec les
-entrées les plus récentes en haut. Un « + » indique le début d'une
+entrÃ©es les plus rÃ©centes en haut. Un Â« + Â» indique le dÃ©but d'une
 nouvelle trace (en cas d'intervalle important dans le temps ou la
-position). Une étoile à la fin d'une ligne indique que cette station a
-pu être entendue directement (sans répéteur) à cette position. Les
-positions sont suivies du carré de grille Maidenhead à 6 chiffres où
-se trouvait la station à ce moment-là.
+position). Une Ã©toile Ã  la fin d'une ligne indique que cette station a
+pu Ãªtre entendue directement (sans rÃ©pÃ©teur) Ã  cette position. Les
+positions sont suivies du carrÃ© de grille Maidenhead Ã  6 chiffres oÃ¹
+se trouvait la station Ã  ce moment-lÃ .
 
-Pour votre propre station, un champ « Echo de » affiche les six
-derniers répéteurs qui vous ont entendu directement. Ceci est utile
-pour définir des trajets non génériques.
+Pour votre propre station, un champ Â« Echo de Â» affiche les six
+derniers rÃ©pÃ©teurs qui vous ont entendu directement. Ceci est utile
+pour dÃ©finir des trajets non gÃ©nÃ©riques.
 
-Actuellement, deux rangées de quatre boutons apparaissent dans la
-fenêtre d'informations de la station. Certains libellés des boutons
-changent en fonction du type de station concernée.
+Actuellement, deux rangÃ©es de quatre boutons apparaissent dans la
+fenÃªtre d'informations de la station. Certains libellÃ©s des boutons
+changent en fonction du type de station concernÃ©e.
 
 Pour les objets/articles :
 
@@ -1995,7 +1995,7 @@ piste   objet/
 
 Info      Informations    Messages  Info
 Station   suivi           non       station
-Version                   confirmés en direct
+Version                   confirmÃ©s en direct
 
 Pour les autres stations :
 
@@ -2005,903 +2005,903 @@ Piste   un message   dans la base
 
 Info      Informations    Messages  Info
 Station   suivi           non       station
-Version                   confirmés en direct
+Version                   confirmÃ©s en direct
 
-« Info station version » devient « Effacer la piste » pour les
-stations mobiles. Le bouton « Effacer la piste » supprime tout tracé de
-ligne pour cette station, qu'il soit actuellement stocké ou affiché
+Â« Info station version Â» devient Â« Effacer la piste Â» pour les
+stations mobiles. Le bouton Â« Effacer la piste Â» supprime tout tracÃ© de
+ligne pour cette station, qu'il soit actuellement stockÃ© ou affichÃ©
 sur la carte.
 
-« Sauver piste » enregistre le tracé de la station dans un fichier sur
-le disque. Le format est similaire à celui utilisé par les récepteurs
-GPS, mais ses spécifications pourraient être modifiées (améliorées)
+Â« Sauver piste Â» enregistre le tracÃ© de la station dans un fichier sur
+le disque. Le format est similaire Ã  celui utilisÃ© par les rÃ©cepteurs
+GPS, mais ses spÃ©cifications pourraient Ãªtre modifiÃ©es (amÃ©liorÃ©es)
 dans les versions futures. Il n'est actuellement pas possible de
-relire ces données de tracé, mais cette fonctionnalité est prévue.
-L'objectif est également de lire et d'afficher les journaux de suivi
-GPS de manière similaire. Ces fichiers de journal de suivi seront
-placés dans le répertoire ~/.xastir/tracklogs avec un nom
-correspondant à l'indicatif d'appel de la station et l'extension «
-.trk ».
+relire ces donnÃ©es de tracÃ©, mais cette fonctionnalitÃ© est prÃ©vue.
+L'objectif est Ã©galement de lire et d'afficher les journaux de suivi
+GPS de maniÃ¨re similaire. Ces fichiers de journal de suivi seront
+placÃ©s dans le rÃ©pertoire ~/.xastir/tracklogs avec un nom
+correspondant Ã  l'indicatif d'appel de la station et l'extension Â«
+.trk Â».
 
-« Sauver piste » enregistre simultanément le tracé de la station sous
+Â« Sauver piste Â» enregistre simultanÃ©ment le tracÃ© de la station sous
 forme de fichier Keyhole Markup Language (.kml) avec un nom de fichier
-correspondant à l'indicatif d'appel de la station, la date et l'heure
-actuelles et l'extension « .kml ». Si la prise en charge des fichiers
-de formes est activée, le tracé de la station sera également
-enregistré sous forme d'un ensemble de quatre fichiers (.dbf, .prj,
-.shp, .shx). Les pressions successives sur « Sauver piste » pour
-la même station ajouteront des lignes supplémentaires au fichier .trk
-et créeront de nouveaux fichiers .kml (et fichiers de formes) (chacun
-contenant toutes les positions du tracé de la station).
+correspondant Ã  l'indicatif d'appel de la station, la date et l'heure
+actuelles et l'extension Â« .kml Â». Si la prise en charge des fichiers
+de formes est activÃ©e, le tracÃ© de la station sera Ã©galement
+enregistrÃ© sous forme d'un ensemble de quatre fichiers (.dbf, .prj,
+.shp, .shx). Les pressions successives sur Â« Sauver piste Â» pour
+la mÃªme station ajouteront des lignes supplÃ©mentaires au fichier .trk
+et crÃ©eront de nouveaux fichiers .kml (et fichiers de formes) (chacun
+contenant toutes les positions du tracÃ© de la station).
 
-« Modifier objet/article » affiche la fenêtre de modification d'objet.
+Â« Modifier objet/article Â» affiche la fenÃªtre de modification d'objet.
 
-« Composer un message » ouvre la fenêtre de message et vous permet
-d'envoyer un message à cette station. L'indicatif d'appel sera
-automatiquement renseigné.
+Â« Composer un message Â» ouvre la fenÃªtre de message et vous permet
+d'envoyer un message Ã  cette station. L'indicatif d'appel sera
+automatiquement renseignÃ©.
 
-Si la base de données de la FCC (Commission fédérale des
-communications des États-Unis) ou de la RAC (Radio Amateurs du Canada)
-est installée et que l'indicatif d'appel semble être un indicatif
-canadien ou américain, le bouton « Chercher dans la base FCC/RAC »
+Si la base de donnÃ©es de la FCC (Commission fÃ©dÃ©rale des
+communications des Ã‰tats-Unis) ou de la RAC (Radio Amateurs du Canada)
+est installÃ©e et que l'indicatif d'appel semble Ãªtre un indicatif
+canadien ou amÃ©ricain, le bouton Â« Chercher dans la base FCC/RAC Â»
 devient actif ; sinon, il reste inactif. Les fichiers FCC et 
-RAC doivent être placés dans le répertoire
+RAC doivent Ãªtre placÃ©s dans le rÃ©pertoire
 /usr/local/share/xastir/fcc, et la casse est importante ! Cliquer sur
-ce bouton ajoute le nom et l'adresse de la station dans le champ «
-Informations sur la station ». Les instructions d'installation de ces
-bases de données se trouvent sur la page « Scripts d'aide » du wiki : 
+ce bouton ajoute le nom et l'adresse de la station dans le champ Â«
+Informations sur la station Â». Les instructions d'installation de ces
+bases de donnÃ©es se trouvent sur la page Â« Scripts d'aide Â» du wiki : 
 https://github.com/Xastir/Xastir/wiki/Helper-Scripts
 
-Xastir crée des fichiers d'index pour chaque fichier de base de
-données au démarrage. Si un fichier d'indicatifs d'appel plus récent
-est placé dans ce répertoire pendant que Xastir est en cours
-d'exécution, l'index sera créé ou mis à jour lors de la prochaine
-recherche. Les préfixes spéciaux ne sont PAS pris en charge.
+Xastir crÃ©e des fichiers d'index pour chaque fichier de base de
+donnÃ©es au dÃ©marrage. Si un fichier d'indicatifs d'appel plus rÃ©cent
+est placÃ© dans ce rÃ©pertoire pendant que Xastir est en cours
+d'exÃ©cution, l'index sera crÃ©Ã© ou mis Ã  jour lors de la prochaine
+recherche. Les prÃ©fixes spÃ©ciaux ne sont PAS pris en charge.
 
-HELP-INDEX>Création d'un journal
-           Création d'un journal
+HELP-INDEX>CrÃ©ation d'un journal
+           CrÃ©ation d'un journal
 
-Xastir peut enregistrer les données provenant d'Internet ou d'un TNC
-pour une lecture ultérieure ou à des fins de débogage. ATTENTION :
-L'enregistrement des données peut saturer votre disque dur ; utilisez
-cette fonction avec précaution ou configurez la rotation automatique
+Xastir peut enregistrer les donnÃ©es provenant d'Internet ou d'un TNC
+pour une lecture ultÃ©rieure ou Ã  des fins de dÃ©bogage. ATTENTION :
+L'enregistrement des donnÃ©es peut saturer votre disque dur ; utilisez
+cette fonction avec prÃ©caution ou configurez la rotation automatique
 des fichiers journaux via cron. Une indication s'affichera dans la
-barre d'état lorsque l'enregistrement est activé. 
+barre d'Ã©tat lorsque l'enregistrement est activÃ©. 
 
 Toutes ces options sont accessibles via le menu Fichier :
 
 Activer archivage TNC
-Enregistre toutes les données TNC reçues et transmises. Ces journaux
-peuvent être lus à l'aide de la fonction « Ouvrir le fichier journal
-».
+Enregistre toutes les donnÃ©es TNC reÃ§ues et transmises. Ces journaux
+peuvent Ãªtre lus Ã  l'aide de la fonction Â« Ouvrir le fichier journal
+Â».
 
-Activer archivage réseau
-Enregistre toutes les données Internet reçues et transmises. Ces
-journaux peuvent être lus à l'aide de la fonction « Ouvrir le fichier
-journal ». Si aucune interface n'est démarrée mais que vous souhaitez
-tout de même enregistrer vos positions et objets localement, cette
-option est également disponible.
+Activer archivage rÃ©seau
+Enregistre toutes les donnÃ©es Internet reÃ§ues et transmises. Ces
+journaux peuvent Ãªtre lus Ã  l'aide de la fonction Â« Ouvrir le fichier
+journal Â». Si aucune interface n'est dÃ©marrÃ©e mais que vous souhaitez
+tout de mÃªme enregistrer vos positions et objets localement, cette
+option est Ã©galement disponible.
 
 Activer archivage IGate
-Enregistre toutes les données transmises dans les deux sens, ainsi que
-les transmissions rejetées avec les raisons du rejet. Inclut les
-messages NWS transmis par radiofréquence.
+Enregistre toutes les donnÃ©es transmises dans les deux sens, ainsi que
+les transmissions rejetÃ©es avec les raisons du rejet. Inclut les
+messages NWS transmis par radiofrÃ©quence.
 
-Activer archivage météo
-Enregistre toutes les données météorologiques reçues de votre station
-météo.
+Activer archivage mÃ©tÃ©o
+Enregistre toutes les donnÃ©es mÃ©tÃ©orologiques reÃ§ues de votre station
+mÃ©tÃ©o.
 
 HELP-INDEX>Relecture d'un journal
 
            Relecture d'un journal
 
-Cliquez sur « Fichier », puis sur « Ouvrir le journal ». Une fenêtre
-de sélection de fichier s'affichera.
+Cliquez sur Â« Fichier Â», puis sur Â« Ouvrir le journal Â». Une fenÃªtre
+de sÃ©lection de fichier s'affichera.
 
-Vous pouvez l'utiliser pour parcourir votre disque dur et sélectionner
-n'importe quel fichier contenant des données TNC brutes, comme ceux
-créés par les options d'enregistrement TNC et réseau. Votre station
-continuera de fonctionner normalement, en réception et en
-transmission. Si vous enregistriez des données, l'emplacement habituel
+Vous pouvez l'utiliser pour parcourir votre disque dur et sÃ©lectionner
+n'importe quel fichier contenant des donnÃ©es TNC brutes, comme ceux
+crÃ©Ã©s par les options d'enregistrement TNC et rÃ©seau. Votre station
+continuera de fonctionner normalement, en rÃ©ception et en
+transmission. Si vous enregistriez des donnÃ©es, l'emplacement habituel
 de ces fichiers est ~/.xastir/logs/
 
 REMARQUE : Cette fonction ne lit pas les journaux de suivi de station
-enregistrés.
+enregistrÃ©s.
 
 HELP-INDEX>Localisation d'une station
 
            Localisation d'une station
 
-Cliquez sur « Stations », puis sur « Localiser une station ». Une
-fenêtre s'ouvrira. Vous pouvez maintenant saisir un indicatif ou une
-partie d'indicatif. Par défaut, la recherche s'effectue sur une
+Cliquez sur Â« Stations Â», puis sur Â« Localiser une station Â». Une
+fenÃªtre s'ouvrira. Vous pouvez maintenant saisir un indicatif ou une
+partie d'indicatif. Par dÃ©faut, la recherche s'effectue sur une
 correspondance exacte (indicatif complet, et non partiel) et n'est pas
-sensible à la casse. Si vous recherchez une correspondance partielle,
-l'option « Correspondance exacte » ne doit pas être sélectionnée.
+sensible Ã  la casse. Si vous recherchez une correspondance partielle,
+l'option Â« Correspondance exacte Â» ne doit pas Ãªtre sÃ©lectionnÃ©e.
 
 Pour les objets pouvant contenir des minuscules, vous devez cocher
-« Casse exacte » ! Contrairement à ce que son nom indique, sans
-l'option « Casse exacte », le texte de recherche sera converti
+Â« Casse exacte Â» ! Contrairement Ã  ce que son nom indique, sans
+l'option Â« Casse exacte Â», le texte de recherche sera converti
 en majuscules.
 
-Cliquer sur le bouton « Localiser maintenant ! » centrera la première
-station trouvée au centre de votre écran, au niveau de zoom actuel.
+Cliquer sur le bouton Â« Localiser maintenant ! Â» centrera la premiÃ¨re
+station trouvÃ©e au centre de votre Ã©cran, au niveau de zoom actuel.
 
-Cliquer sur « Recherche indicatif FCC/RAC » affichera les informations
-de l'utilisateur si les bases de données FCC ou RAC sont installées.
+Cliquer sur Â« Recherche indicatif FCC/RAC Â» affichera les informations
+de l'utilisateur si les bases de donnÃ©es FCC ou RAC sont installÃ©es.
 
-Cliquer sur « Annuler » fermera la fenêtre.
+Cliquer sur Â« Annuler Â» fermera la fenÃªtre.
 
-Cette boîte de dialogue s'affiche lorsqu'une station envoie un paquet
-Mic-e « Urgence ! », afin d'encourager les utilisateurs à localiser et
-éventuellement à aider la station concernée.
+Cette boÃ®te de dialogue s'affiche lorsqu'une station envoie un paquet
+Mic-e Â« Urgence ! Â», afin d'encourager les utilisateurs Ã  localiser et
+Ã©ventuellement Ã  aider la station concernÃ©e.
 
-HELP-INDEX>Création et utilisation des signets d'affichage de carte
+HELP-INDEX>CrÃ©ation et utilisation des signets d'affichage de carte
 
-           Création et utilisation des signets d'affichage de carte
+           CrÃ©ation et utilisation des signets d'affichage de carte
 
-Cliquez sur « Cartes », puis sur « Aller à ». Une
-fenêtre s'ouvrira.
+Cliquez sur Â« Cartes Â», puis sur Â« Aller Ã  Â». Une
+fenÃªtre s'ouvrira.
 
-Si c'est la première fois que vous utilisez cette fonction, la liste
+Si c'est la premiÃ¨re fois que vous utilisez cette fonction, la liste
 sera vide. Pour ajouter un signet : positionnez la carte principale
-sur la zone et le niveau de zoom souhaités. Saisissez un nom unique
-dans le champ « Nouveau nom de lieu », puis cliquez sur « Ajouter ». Votre
-signet sera ajouté à la liste (par ordre alphabétique). Vous pouvez
+sur la zone et le niveau de zoom souhaitÃ©s. Saisissez un nom unique
+dans le champ Â« Nouveau nom de lieu Â», puis cliquez sur Â« Ajouter Â». Votre
+signet sera ajoutÃ© Ã  la liste (par ordre alphabÃ©tique). Vous pouvez
 ajouter autant de signets d'affichage de carte que vous le
-souhaitez. Pour utiliser un signet, sélectionnez son nom et cliquez
-sur « Aller ! ». La carte principale affichera alors la zone et le
-niveau de zoom enregistrés.
+souhaitez. Pour utiliser un signet, sÃ©lectionnez son nom et cliquez
+sur Â« Aller ! Â». La carte principale affichera alors la zone et le
+niveau de zoom enregistrÃ©s.
 
-Vous pouvez également supprimer un signet en cliquant sur son nom,
-puis sur le bouton « Supprimer ».
+Vous pouvez Ã©galement supprimer un signet en cliquant sur son nom,
+puis sur le bouton Â« Supprimer Â».
 
-« Cartes > Localiser élément cartographique » est une autre méthode
-pour accéder à un emplacement, si vous connaissez le nom de
-l'emplacement et que les fichiers GNIS sont installés.
+Â« Cartes > Localiser Ã©lÃ©ment cartographique Â» est une autre mÃ©thode
+pour accÃ©der Ã  un emplacement, si vous connaissez le nom de
+l'emplacement et que les fichiers GNIS sont installÃ©s.
 
 HELP-INDEX>Suivi d'une station
 
            Suivi d'une station
 
-Cliquez sur « Stations », puis sur « Suivre station ». Saisissez
-l'indicatif d'appel de la station à suivre (en entier ou en partie),
-puis cliquez sur le bouton « Suivre maintenant ! ». La station restera
-visible dans la fenêtre principale de la carte pendant son
-déplacement. Lorsque la station s'approche du bord de la fenêtre,
+Cliquez sur Â« Stations Â», puis sur Â« Suivre station Â». Saisissez
+l'indicatif d'appel de la station Ã  suivre (en entier ou en partie),
+puis cliquez sur le bouton Â« Suivre maintenant ! Â». La station restera
+visible dans la fenÃªtre principale de la carte pendant son
+dÃ©placement. Lorsque la station s'approche du bord de la fenÃªtre,
 celle-ci se recentre automatiquement afin que l'objet reste toujours
-visible. Pour arrêter le suivi de cette station, cliquez sur le bouton
-« Annuler suivi ». Pendant le suivi, la mention « Tr » s'affiche
-dans la barre d'état, à côté du niveau de zoom. Si la station n'est
-pas encore visible sur la carte, le suivi commencera dès son
+visible. Pour arrÃªter le suivi de cette station, cliquez sur le bouton
+Â« Annuler suivi Â». Pendant le suivi, la mention Â« Tr Â» s'affiche
+dans la barre d'Ã©tat, Ã  cÃ´tÃ© du niveau de zoom. Si la station n'est
+pas encore visible sur la carte, le suivi commencera dÃ¨s son
 apparition.
 
 HELP-INDEX>Impression
 
-           Impression de l'écran de la carte
+           Impression de l'Ã©cran de la carte
 
-Remarque : L'impression n'est pas configurée sous Windows/Cygwin. Ces
-instructions sont destinées aux systèmes d'exploitation Unix et
+Remarque : L'impression n'est pas configurÃ©e sous Windows/Cygwin. Ces
+instructions sont destinÃ©es aux systÃ¨mes d'exploitation Unix et
 similaires.
 
 Xastir peut imprimer la zone de dessin en noir et blanc ou en couleur.
 Pour ce faire, il enregistre d'abord l'image dans un fichier XPixmap
 sur le disque, puis utilise des outils externes pour la convertir au
 format PostScript, la redimensionner, la faire pivoter, l'afficher en
-aperçu, puis l'imprimer. Votre système d'impression  oit être
-configuré pour gérer le format PostScript (cela nécessite généralement
+aperÃ§u, puis l'imprimer. Votre systÃ¨me d'impression  oit Ãªtre
+configurÃ© pour gÃ©rer le format PostScript (cela nÃ©cessite gÃ©nÃ©ralement
 l'installation de Ghostscript et d'un filtre d'impression, ainsi que
-des gestionnaires d'impression lp ou lpr). Vous devez également
+des gestionnaires d'impression lp ou lpr). Vous devez Ã©galement
 installer les outils suivants : les outils GraphicsMagick (en
-particulier « convert »), Ghostscript, les polices Ghostscript et « gv
-». Une fois tous ces paquets installés et fonctionnels, une fenêtre «
-gv » devrait s'afficher peu après que vous ayez demandé à Xastir de
-créer un fichier d'impression. Vous pourrez alors visualiser l'image
-imprimée et, si elle vous convient, demander à « gv » de
-l'imprimer. Notez qu'il est parfois recommandé de choisir un fond
-blanc par défaut pour les cartes, selon les cartes affichées. Cela
-permet de réaliser d'importantes économies d'encre.
+particulier Â« convert Â»), Ghostscript, les polices Ghostscript et Â« gv
+Â». Une fois tous ces paquets installÃ©s et fonctionnels, une fenÃªtre Â«
+gv Â» devrait s'afficher peu aprÃ¨s que vous ayez demandÃ© Ã  Xastir de
+crÃ©er un fichier d'impression. Vous pourrez alors visualiser l'image
+imprimÃ©e et, si elle vous convient, demander Ã  Â« gv Â» de
+l'imprimer. Notez qu'il est parfois recommandÃ© de choisir un fond
+blanc par dÃ©faut pour les cartes, selon les cartes affichÃ©es. Cela
+permet de rÃ©aliser d'importantes Ã©conomies d'encre.
 
-HELP-INDEX>Création d'instantanés
+HELP-INDEX>CrÃ©ation d'instantanÃ©s
 
-          Création d'instantanés automatiques
+          CrÃ©ation d'instantanÃ©s automatiques
 
-Xastir peut créer automatiquement des instantanés de l'écran de la
-carte à intervalles réguliers. La période par défaut est de cinq
-minutes. Si vous avez installé l'outil « convert » de GraphicsMagick,
-Xastir créera un fichier au format XPM dans ~/.xastir/tmp/, puis le
+Xastir peut crÃ©er automatiquement des instantanÃ©s de l'Ã©cran de la
+carte Ã  intervalles rÃ©guliers. La pÃ©riode par dÃ©faut est de cinq
+minutes. Si vous avez installÃ© l'outil Â« convert Â» de GraphicsMagick,
+Xastir crÃ©era un fichier au format XPM dans ~/.xastir/tmp/, puis le
 convertira en fichier PNG ~/.xastir/tmp/snapshot.png. Ce fichier est
-utile pour afficher une image « en direct » de votre écran Xastir sur
-une page web. Activez cette fonctionnalité via le bouton bascule «
-Fichier->Active copie d'écran PNG ». La fréquence est d'une fois toutes les
-cinq minutes (configurable dans la boîte de dialogue Configuration des
-temporisations, accessible via « Fichier->Configurer->Temporisations
-»), ou à chaque activation du bouton. Un fichier .geo est créé pour
-vous permettre d'utiliser l'instantané comme carte. Un fichier .kml
-est également généré pour vous permettre d'utiliser l'instantané comme
+utile pour afficher une image Â« en direct Â» de votre Ã©cran Xastir sur
+une page web. Activez cette fonctionnalitÃ© via le bouton bascule Â«
+Fichier->Active copie d'Ã©cran PNG Â». La frÃ©quence est d'une fois toutes les
+cinq minutes (configurable dans la boÃ®te de dialogue Configuration des
+temporisations, accessible via Â« Fichier->Configurer->Temporisations
+Â»), ou Ã  chaque activation du bouton. Un fichier .geo est crÃ©Ã© pour
+vous permettre d'utiliser l'instantanÃ© comme carte. Un fichier .kml
+est Ã©galement gÃ©nÃ©rÃ© pour vous permettre d'utiliser l'instantanÃ© comme
 superposition graphique sur le terrain dans les applications
 compatibles KML. Consultez les fichiers kml_snapshot_to_web.sh et
-kml_snapshot_feed.kml dans le répertoire des scripts pour plus
+kml_snapshot_feed.kml dans le rÃ©pertoire des scripts pour plus
 d'informations sur l'utilisation des fichiers snapshot.png et
-snapshot.kml afin de produire un flux KML à partir des instantanés.
+snapshot.kml afin de produire un flux KML Ã  partir des instantanÃ©s.
 
-Création d'instantanés KML automatiques
+CrÃ©ation d'instantanÃ©s KML automatiques
 
 Xastir peut enregistrer toutes les stations et traces actuelles dans
-un fichier KML à intervalles réguliers. Activez cette fonctionnalité
-via le bouton bascule « Fichier->Instantanés KML ». La fréquence de
-génération de ces instantanés est la même que celle des instantanés
-PNG, configurée dans « Fichier->Configurer->Temporisations » en
-définissant l'intervalle de temps des instantanés. Chaque instantané
-est enregistré dans un fichier .kml dans ~/.xastir/tracklogs, avec un
-nom de fichier basé sur la date et l'heure de l'instantané, par
-exemple 20080206-000720.kml. Ce comportement pourrait être modifié
-pour que les instantanés KML soient enregistrés dans un seul fichier,
-comme les instantanés PNG.
+un fichier KML Ã  intervalles rÃ©guliers. Activez cette fonctionnalitÃ©
+via le bouton bascule Â« Fichier->InstantanÃ©s KML Â». La frÃ©quence de
+gÃ©nÃ©ration de ces instantanÃ©s est la mÃªme que celle des instantanÃ©s
+PNG, configurÃ©e dans Â« Fichier->Configurer->Temporisations Â» en
+dÃ©finissant l'intervalle de temps des instantanÃ©s. Chaque instantanÃ©
+est enregistrÃ© dans un fichier .kml dans ~/.xastir/tracklogs, avec un
+nom de fichier basÃ© sur la date et l'heure de l'instantanÃ©, par
+exemple 20080206-000720.kml. Ce comportement pourrait Ãªtre modifiÃ©
+pour que les instantanÃ©s KML soient enregistrÃ©s dans un seul fichier,
+comme les instantanÃ©s PNG.
 
 HELP-INDEX>Scripts inclus
 
             Scripts inclus
 
 Xastir inclut plusieurs scripts Perl et un script shell qui peuvent
-être utiles : 
+Ãªtre utiles : 
 
 get-fcc-rac.pl
-Ce script shell automatise la récupération et l'installation des bases
-de données d'indicatifs d'appel de la FCC et du RAC. Notez que ces
-bases de données sont très volumineuses !
+Ce script shell automatise la rÃ©cupÃ©ration et l'installation des bases
+de donnÃ©es d'indicatifs d'appel de la FCC et du RAC. Notez que ces
+bases de donnÃ©es sont trÃ¨s volumineuses !
 
 icontable.pl
-Ce script génère une image bitmap xpm de tous les symboles primaires
-et secondaires de Xastir à partir du fichier symbols.dat. Les
-superpositions et les symboles spéciaux sont ignorés. La sortie est
-envoyée vers STDOUT ; un appel typique serait donc « icontable.pl >
-symbols.xpm ».
+Ce script gÃ©nÃ¨re une image bitmap xpm de tous les symboles primaires
+et secondaires de Xastir Ã  partir du fichier symbols.dat. Les
+superpositions et les symboles spÃ©ciaux sont ignorÃ©s. La sortie est
+envoyÃ©e vers STDOUT ; un appel typique serait donc Â« icontable.pl >
+symbols.xpm Â».
 
 inf2geo.pl
-Ce script crée des fichiers .geo à partir de fichiers .inf de
-UI-View. Pour créer un fichier map.geo à partir d'un fichier map.inf,
-l'utilisation typique serait « inf2geo.pl map ».
+Ce script crÃ©e des fichiers .geo Ã  partir de fichiers .inf de
+UI-View. Pour crÃ©er un fichier map.geo Ã  partir d'un fichier map.inf,
+l'utilisation typique serait Â« inf2geo.pl map Â».
 
 kiss-off.pl
-Ce script envoie les commandes nécessaires pour désactiver le mode
+Ce script envoie les commandes nÃ©cessaires pour dÃ©sactiver le mode
 KISS d'un TNC.
 
 mapfgd.pl
-Ce script crée des fichiers .fgd minimaux pour les images GeoTIFF qui
-en sont dépourvues, en se basant sur les informations trouvées dans le
-fichier GeoTIFF. Les fichiers créés permettent à Xastir de recadrer
+Ce script crÃ©e des fichiers .fgd minimaux pour les images GeoTIFF qui
+en sont dÃ©pourvues, en se basant sur les informations trouvÃ©es dans le
+fichier GeoTIFF. Les fichiers crÃ©Ã©s permettent Ã  Xastir de recadrer
 les bordures blanches et de faire pivoter/redimensionner la carte
-correctement. L'utilisation typique serait « mapfgd.pl mapdir » où
-mapdir est le répertoire contenant les images GeoTIFF.
+correctement. L'utilisation typique serait Â« mapfgd.pl mapdir Â» oÃ¹
+mapdir est le rÃ©pertoire contenant les images GeoTIFF.
 
 overlay.pl
-Ce script crée des fichiers au format .log à partir de fichiers de
-superposition séparés par des virgules. Consultez les commentaires du
-script pour obtenir des informations complètes sur son utilisation.
+Ce script crÃ©e des fichiers au format .log Ã  partir de fichiers de
+superposition sÃ©parÃ©s par des virgules. Consultez les commentaires du
+script pour obtenir des informations complÃ¨tes sur son utilisation.
 
 ozi2geo.pl
-Ce script crée des fichiers .geo à partir de fichiers .map d'OziExplorer.
+Ce script crÃ©e des fichiers .geo Ã  partir de fichiers .map d'OziExplorer.
 
 permutations.pl
-Ce script convertit différents formats de
+Ce script convertit diffÃ©rents formats de
 latitude/longitude. Consultez les commentaires du script pour plus de
-détails.
+dÃ©tails.
 
 test_coord.pl
 Tests pour le module Perl Coordinate.pm.
 
 track-get.pl
-Ce script télécharge le journal de suivi d'un objet spécifié à partir
-d'un GPS Garmin. Il nécessite le module GPS::Garmin. Il demande le nom
-de l'objet et écrit le journal de suivi dans le répertoire
+Ce script tÃ©lÃ©charge le journal de suivi d'un objet spÃ©cifiÃ© Ã  partir
+d'un GPS Garmin. Il nÃ©cessite le module GPS::Garmin. Il demande le nom
+de l'objet et Ã©crit le journal de suivi dans le rÃ©pertoire
 ~/.xastir/logs.
 
 update_langfile.pl
-Ce script est destiné aux développeurs. Il reconstruit un fichier de
-langue spécifié pour qu'il contienne toutes les chaînes d'un autre
-fichier. Il est généralement utilisé pour régénérer les fichiers de
+Ce script est destinÃ© aux dÃ©veloppeurs. Il reconstruit un fichier de
+langue spÃ©cifiÃ© pour qu'il contienne toutes les chaÃ®nes d'un autre
+fichier. Il est gÃ©nÃ©ralement utilisÃ© pour rÃ©gÃ©nÃ©rer les fichiers de
 langue autres que l'anglais lorsque des modifications importantes ont
-été apportées au fichier anglais. Lorsque le fichier de la deuxième
-langue ne contient pas une chaîne présente dans le fichier principal,
-la chaîne non traduite est insérée. L'utilisation typique serait «
-update_langfile.pl language-German.sys ». Le fichier de langue
-principal est codé en dur, mais facilement modifiable.
+Ã©tÃ© apportÃ©es au fichier anglais. Lorsque le fichier de la deuxiÃ¨me
+langue ne contient pas une chaÃ®ne prÃ©sente dans le fichier principal,
+la chaÃ®ne non traduite est insÃ©rÃ©e. L'utilisation typique serait Â«
+update_langfile.pl language-German.sys Â». Le fichier de langue
+principal est codÃ© en dur, mais facilement modifiable.
 
 waypoint-get.pl
-Ce script similaire télécharge les points de passage d'un GPS Garmin et crée un
-fichier journal dans le répertoire ~/.xastir/logs contenant les points
-de passage sous forme d'objets. Il nécessite également le module GPS::Garmin.
+Ce script similaire tÃ©lÃ©charge les points de passage d'un GPS Garmin et crÃ©e un
+fichier journal dans le rÃ©pertoire ~/.xastir/logs contenant les points
+de passage sous forme d'objets. Il nÃ©cessite Ã©galement le module GPS::Garmin.
 
 db_gis_mysql.sql  db_gis_postgis.sql
-Ces fichiers créent des tables pour stocker les données des stations
-dans une base de données MySQL ou PostgreSQL/ PostGIS. La prise en
-charge des bases de données SQL Server est expérimentale. Voir la
-section « OPTIONNEL : Expérimental. Ajouter la prise en charge des
-bases de données SIG » dans le fichier INSTALL.md.
+Ces fichiers crÃ©ent des tables pour stocker les donnÃ©es des stations
+dans une base de donnÃ©es MySQL ou PostgreSQL/ PostGIS. La prise en
+charge des bases de donnÃ©es SQL Server est expÃ©rimentale. Voir la
+section Â« OPTIONNEL : ExpÃ©rimental. Ajouter la prise en charge des
+bases de donnÃ©es SIG Â» dans le fichier INSTALL.md.
 
 HELP-INDEX>Configuration des interfaces
 
            Configuration des interfaces
 
-Cliquez sur Interfaces, puis sur Contrôle de l'interface.
+Cliquez sur Interfaces, puis sur ContrÃ´le de l'interface.
 
-Une fenêtre « Interfaces installées » devrait apparaître. Cette
-fenêtre vous permettra d'ajouter, de supprimer et de modifier les
-propriétés des différents périphériques que vous souhaitez utiliser
+Une fenÃªtre Â« Interfaces installÃ©es Â» devrait apparaÃ®tre. Cette
+fenÃªtre vous permettra d'ajouter, de supprimer et de modifier les
+propriÃ©tÃ©s des diffÃ©rents pÃ©riphÃ©riques que vous souhaitez utiliser
 avec Xastir.
 
 Types d'interfaces pris en charge :
-TNC port série
-TNC série + GPS sur câble HSP
-GPS port série
-Méteo port série
+TNC port sÃ©rie
+TNC sÃ©rie + GPS sur cÃ¢ble HSP
+GPS port sÃ©rie
+MÃ©teo port sÃ©rie
 Serveur Internet
 TNC AX25
-GPS réseau (par gpsd)
-Météo par réseau
-TNC série + GPS sur câble AUX
-TNC KISS série
-Base de données par réseau (non encore implémenté)
-AGWPE par réseau
-TNC Multi-Port KISS série
-Bases de données SQL (expérimental)
+GPS rÃ©seau (par gpsd)
+MÃ©tÃ©o par rÃ©seau
+TNC sÃ©rie + GPS sur cÃ¢ble AUX
+TNC KISS sÃ©rie
+Base de donnÃ©es par rÃ©seau (non encore implÃ©mentÃ©)
+AGWPE par rÃ©seau
+TNC Multi-Port KISS sÃ©rie
+Bases de donnÃ©es SQL (expÃ©rimental)
 
-Pour ajouter un périphérique, cliquez sur le bouton Ajouter. Une
-fenêtre « Choisir du type d'interface » apparaîtra. Cliquez sur le
-type de périphérique que vous souhaitez ajouter. Cliquez ensuite sur
-le bouton Ajouter dans la fenêtre « Choisir du type d'interface ». Les
-propriétés de ce périphérique s'afficheront.
-Remplissez les informations demandées et cliquez sur OK.
+Pour ajouter un pÃ©riphÃ©rique, cliquez sur le bouton Ajouter. Une
+fenÃªtre Â« Choisir du type d'interface Â» apparaÃ®tra. Cliquez sur le
+type de pÃ©riphÃ©rique que vous souhaitez ajouter. Cliquez ensuite sur
+le bouton Ajouter dans la fenÃªtre Â« Choisir du type d'interface Â». Les
+propriÃ©tÃ©s de ce pÃ©riphÃ©rique s'afficheront.
+Remplissez les informations demandÃ©es et cliquez sur OK.
 
-Pour supprimer un périphérique, cliquez sur le périphérique que vous
+Pour supprimer un pÃ©riphÃ©rique, cliquez sur le pÃ©riphÃ©rique que vous
 souhaitez supprimer, puis cliquez sur le bouton Supprimer.
 
-Pour modifier les propriétés d'un périphérique, cliquez sur le
-périphérique que vous souhaitez modifier, puis cliquez sur le bouton
-Propriétés. Les propriétés de ce périphérique s'afficheront. Modifiez
-les informations souhaitées et cliquez sur OK.
+Pour modifier les propriÃ©tÃ©s d'un pÃ©riphÃ©rique, cliquez sur le
+pÃ©riphÃ©rique que vous souhaitez modifier, puis cliquez sur le bouton
+PropriÃ©tÃ©s. Les propriÃ©tÃ©s de ce pÃ©riphÃ©rique s'afficheront. Modifiez
+les informations souhaitÃ©es et cliquez sur OK.
 
-Une aide plus détaillée est disponible dans les rubriques d'aide de
+Une aide plus dÃ©taillÃ©e est disponible dans les rubriques d'aide de
 chaque type d'interface.
 
-Les bases de données SQL n'apparaîtront comme option que si vous avez compilé
+Les bases de donnÃ©es SQL n'apparaÃ®tront comme option que si vous avez compilÃ©
 le support MySQL ou Postgis.
 
-HELP-INDEX>Configuration des périphériques TNC série
+HELP-INDEX>Configuration des pÃ©riphÃ©riques TNC sÃ©rie
 
-           Configuration des périphériques TNC série
+           Configuration des pÃ©riphÃ©riques TNC sÃ©rie
 
-Cette section décrit l'ajout ou la modification des TNC série ou des
-TNC série avec GPS sur un câble HSP.
+Cette section dÃ©crit l'ajout ou la modification des TNC sÃ©rie ou des
+TNC sÃ©rie avec GPS sur un cÃ¢ble HSP.
 
-Si vous disposez d'un câble HSP, qui vous permet de partager le port
-TNC avec une unité GPS, vous pouvez choisir un TNC avec GPS (câble
-HSP). Il s'agit d'un câble spécial qui peut ne pas fonctionner avec
+Si vous disposez d'un cÃ¢ble HSP, qui vous permet de partager le port
+TNC avec une unitÃ© GPS, vous pouvez choisir un TNC avec GPS (cÃ¢ble
+HSP). Il s'agit d'un cÃ¢ble spÃ©cial qui peut ne pas fonctionner avec
 toutes les combinaisons d'ordinateurs/GPS/TNC. Si vous utilisez ce
-périphérique, le TNC et le GPS doivent être configurés avec les mêmes
-paramètres de communication. Généralement 4800 bps, 8 bits de données,
-pas de parité et 1 bit d'arrêt.
+pÃ©riphÃ©rique, le TNC et le GPS doivent Ãªtre configurÃ©s avec les mÃªmes
+paramÃ¨tres de communication. GÃ©nÃ©ralement 4800 bps, 8 bits de donnÃ©es,
+pas de paritÃ© et 1 bit d'arrÃªt.
 
 Options du port TNC :
-Sélectionner « Activer au démarrage » indique à Xastir de rechercher
-ce périphérique et d'établir la communication avec celui-ci au premier
-démarrage du programme.
+SÃ©lectionner Â« Activer au dÃ©marrage Â» indique Ã  Xastir de rechercher
+ce pÃ©riphÃ©rique et d'Ã©tablir la communication avec celui-ci au premier
+dÃ©marrage du programme.
 
-Sélectionner « Permettre transmission » indique à Xastir que toutes
-les données RF sortantes peuvent être envoyées à ce périphérique pour
+SÃ©lectionner Â« Permettre transmission Â» indique Ã  Xastir que toutes
+les donnÃ©es RF sortantes peuvent Ãªtre envoyÃ©es Ã  ce pÃ©riphÃ©rique pour
 diffusion.
 
-Sélectionner « Ajouter un délai » indique à Xastir d'insérer un délai
-d'une seconde entre l'envoi de la commande de passage en mode «
-Conversation » et l'envoi effectif des données. Cette option est
-uniquement destinée à gérer le TNC Kantronics KAM, qui ne parvient
-souvent pas à passer en mode conversation s'il reçoit des données
-immédiatement après l'envoi de la commande de conversation. Si vous
-possédez un KAM, cochez cette case ; sinon, laissez-la décochée.
+SÃ©lectionner Â« Ajouter un dÃ©lai Â» indique Ã  Xastir d'insÃ©rer un dÃ©lai
+d'une seconde entre l'envoi de la commande de passage en mode Â«
+Conversation Â» et l'envoi effectif des donnÃ©es. Cette option est
+uniquement destinÃ©e Ã  gÃ©rer le TNC Kantronics KAM, qui ne parvient
+souvent pas Ã  passer en mode conversation s'il reÃ§oit des donnÃ©es
+immÃ©diatement aprÃ¨s l'envoi de la commande de conversation. Si vous
+possÃ©dez un KAM, cochez cette case ; sinon, laissez-la dÃ©cochÃ©e.
 
-Le port TNC est le périphérique Unix auquel le TNC (ou le TNC et le
-GPS) est connecté. Normalement, vous pouvez utiliser /dev/ttyS0
+Le port TNC est le pÃ©riphÃ©rique Unix auquel le TNC (ou le TNC et le
+GPS) est connectÃ©. Normalement, vous pouvez utiliser /dev/ttyS0
 (com1), /dev/ttyS1 (com2), etc.
 
-Le champ Commentaire vous permet de définir un nom convivial ou un
+Le champ Commentaire vous permet de dÃ©finir un nom convivial ou un
 commentaire pour le port.
 
-Définissez maintenant le débit en bps dans les paramètres du port, et
-les paramètres dans le style du port. Le paramètre Style du port 8N1
-est utilisé pour 8 bits de données, pas de parité et 1 bit
-d'arrêt. 7E1 est utilisé pour 7 bits de données, parité paire et 1 bit
-d'arrêt. 7O1 est utilisé pour 7 bits de données, parité impaire et 1
-bit d'arrêt. Ces paramètres doivent correspondre à ceux de votre TNC
+DÃ©finissez maintenant le dÃ©bit en bps dans les paramÃ¨tres du port, et
+les paramÃ¨tres dans le style du port. Le paramÃ¨tre Style du port 8N1
+est utilisÃ© pour 8 bits de donnÃ©es, pas de paritÃ© et 1 bit
+d'arrÃªt. 7E1 est utilisÃ© pour 7 bits de donnÃ©es, paritÃ© paire et 1 bit
+d'arrÃªt. 7O1 est utilisÃ© pour 7 bits de donnÃ©es, paritÃ© impaire et 1
+bit d'arrÃªt. Ces paramÃ¨tres doivent correspondre Ã  ceux de votre TNC
 et de votre GPS.
 
-Choisissez le mode de fonctionnement IGate approprié pour ce
-périphérique. Vous pouvez avoir plusieurs périphériques TNC, et cette
-option peut être différente pour chaque périphérique. Si vous
-n'utilisez pas d'iGate, laissez l'option par défaut « Désactiver ».
+Choisissez le mode de fonctionnement IGate appropriÃ© pour ce
+pÃ©riphÃ©rique. Vous pouvez avoir plusieurs pÃ©riphÃ©riques TNC, et cette
+option peut Ãªtre diffÃ©rente pour chaque pÃ©riphÃ©rique. Si vous
+n'utilisez pas d'iGate, laissez l'option par dÃ©faut Â« DÃ©sactiver Â».
 
-Saisissez jusqu'à trois chemins UNPROTO. Xastir ajoutera
+Saisissez jusqu'Ã  trois chemins UNPROTO. Xastir ajoutera
 automatiquement la partie XX VIA du chemin UNPROTO. Trois chemins sont
-autorisés afin que votre signal soit reçu même dans de mauvaises
-conditions. Xastir utilisera successivement chaque chemin renseigné,
-un par transmission. Si vous êtes proche d'un digipeater, WIDE2-2 peut
-être un bon choix. Si vous utilisez une faible puissance et/ou êtes
-éloigné d'un digipeater, WIDE1-1, WIDE2-2 peut être plus efficace. Si
+autorisÃ©s afin que votre signal soit reÃ§u mÃªme dans de mauvaises
+conditions. Xastir utilisera successivement chaque chemin renseignÃ©,
+un par transmission. Si vous Ãªtes proche d'un digipeater, WIDE2-2 peut
+Ãªtre un bon choix. Si vous utilisez une faible puissance et/ou Ãªtes
+Ã©loignÃ© d'un digipeater, WIDE1-1, WIDE2-2 peut Ãªtre plus efficace. Si
 vous connaissez l'indicatif de votre digipeater le plus proche, vous
 pouvez utiliser XXXCALL, WIDE2-2. La plupart d'entre vous n'auront
-besoin que d'un seul chemin. Si vous êtes dans une zone isolée et que
-votre signal a du mal à être reçu, vous pourriez en avoir besoin de
-plusieurs. Renseignez-vous auprès d'un groupe local pour savoir quel
-chemin est le plus adapté à votre région. Si aucun chemin n'est saisi,
-WIDE2-2 sera utilisé par défaut.
+besoin que d'un seul chemin. Si vous Ãªtes dans une zone isolÃ©e et que
+votre signal a du mal Ã  Ãªtre reÃ§u, vous pourriez en avoir besoin de
+plusieurs. Renseignez-vous auprÃ¨s d'un groupe local pour savoir quel
+chemin est le plus adaptÃ© Ã  votre rÃ©gion. Si aucun chemin n'est saisi,
+WIDE2-2 sera utilisÃ© par dÃ©faut.
 
-Si vous utilisez une passerelle iGate vers la radiofréquence (RF),
-vous pouvez saisir un chemin spécifique pour les paquets que vous
+Si vous utilisez une passerelle iGate vers la radiofrÃ©quence (RF),
+vous pouvez saisir un chemin spÃ©cifique pour les paquets que vous
 envoyez en RF. Si vous laissez ce champ vide, les chemins UNPROTO
-ci-dessus seront utilisés. Si les chemins UNPROTO sont vides, WIDE2-2
-sera utilisé.
+ci-dessus seront utilisÃ©s. Si les chemins UNPROTO sont vides, WIDE2-2
+sera utilisÃ©.
 
-Nom du fichier de démarrage et d'arrêt du TNC. Ces champs spécifient un nom
-de fichier situé dans le répertoire
+Nom du fichier de dÃ©marrage et d'arrÃªt du TNC. Ces champs spÃ©cifient un nom
+de fichier situÃ© dans le rÃ©pertoire
 /usr/local/share/xastir/config. Chaque fichier est un fichier texte
-standard contenant les commandes que vous souhaitez envoyer à votre
-TNC lors de l'activation (fichier de démarrage) ou de l'arrêt
+standard contenant les commandes que vous souhaitez envoyer Ã  votre
+TNC lors de l'activation (fichier de dÃ©marrage) ou de l'arrÃªt
 de l'appareil.
 
-HELP-INDEX>Configurer le TNC série avec GPS sur câble HSP ou port AUX
+HELP-INDEX>Configurer le TNC sÃ©rie avec GPS sur cÃ¢ble HSP ou port AUX
 
-           Configurer le TNC série avec GPS sur câble HSP ou port AUX
+           Configurer le TNC sÃ©rie avec GPS sur cÃ¢ble HSP ou port AUX
 
-Ces types d'interface hybrides combinent les fonctionnalités des TNC
-série et des GPS. Veuillez consulter l'aide à la configuration des TNC
-série et des GPS série pour plus d'informations sur la configuration
+Ces types d'interface hybrides combinent les fonctionnalitÃ©s des TNC
+sÃ©rie et des GPS. Veuillez consulter l'aide Ã  la configuration des TNC
+sÃ©rie et des GPS sÃ©rie pour plus d'informations sur la configuration
 de ces appareils.
 
-« Envoyer Ctrl+E pour obtenir les données GPS? »
+Â« Envoyer Ctrl+E pour obtenir les donnÃ©es GPS? Â»
 
-Cette case à cocher détermine si Xastir envoie un caractère Ctrl+E au
-TNC chaque fois qu'il a besoin des données GPS.
+Cette case Ã  cocher dÃ©termine si Xastir envoie un caractÃ¨re Ctrl+E au
+TNC chaque fois qu'il a besoin des donnÃ©es GPS.
 
 Certains TNC prenant en charge un GPS sur un port auxiliaire
-nécessitent que Xastir envoie un caractère Ctrl+E au TNC pour obtenir
-les données GPS à chaque fois que cela est nécessaire. Parmi ces
+nÃ©cessitent que Xastir envoie un caractÃ¨re Ctrl+E au TNC pour obtenir
+les donnÃ©es GPS Ã  chaque fois que cela est nÃ©cessaire. Parmi ces
 appareils, on trouve le Kantronics KPC-3+.
 
 Certains appareils, comme les radios APRS Kenwood (D700, etc.), ne
-nécessitent PAS cette manipulation, et l'envoi du caractère Ctrl+E
-peut même perturber leur bon fonctionnement.
+nÃ©cessitent PAS cette manipulation, et l'envoi du caractÃ¨re Ctrl+E
+peut mÃªme perturber leur bon fonctionnement.
 
-Comme l'envoi de Ctrl+E était requis par la plupart des TNC courants
-disposant d'un port auxiliaire pour le GPS au moment de la création de
-ce type d'interface, il s'agit du comportement par défaut de
+Comme l'envoi de Ctrl+E Ã©tait requis par la plupart des TNC courants
+disposant d'un port auxiliaire pour le GPS au moment de la crÃ©ation de
+ce type d'interface, il s'agit du comportement par dÃ©faut de
 Xastir. Si vous utilisez une radio Kenwood dans ce mode, vous devez
-DÉSÉLECTIONNER la case à cocher « Envoyer Ctrl+E pour obtenir les
-données GPS ? » dans la boîte de dialogue de configuration de ce type
+DÃ‰SÃ‰LECTIONNER la case Ã  cocher Â« Envoyer Ctrl+E pour obtenir les
+donnÃ©es GPS ? Â» dans la boÃ®te de dialogue de configuration de ce type
 d'interface.
 
-HELP-INDEX>Configuration du TNC série KISS
+HELP-INDEX>Configuration du TNC sÃ©rie KISS
 
-           Configuration du TNC série KISS
+           Configuration du TNC sÃ©rie KISS
 
-Cette section traite de l'ajout ou de la modification des TNC série
-KISS. Le mode KISS est également pris en charge par la plupart des TNC
-standard et élimine la nécessité de configurer les options
-spécifiquement dans les fichiers de démarrage, au prix d'une légère
-augmentation de l'utilisation du processeur. Cela permet bien sûr
-d'utiliser des TNC purement KISS, comme celui décrit dans le numéro de
-novembre 2000 de QST, sans programme ni module noyau séparé.
+Cette section traite de l'ajout ou de la modification des TNC sÃ©rie
+KISS. Le mode KISS est Ã©galement pris en charge par la plupart des TNC
+standard et Ã©limine la nÃ©cessitÃ© de configurer les options
+spÃ©cifiquement dans les fichiers de dÃ©marrage, au prix d'une lÃ©gÃ¨re
+augmentation de l'utilisation du processeur. Cela permet bien sÃ»r
+d'utiliser des TNC purement KISS, comme celui dÃ©crit dans le numÃ©ro de
+novembre 2000 de QST, sans programme ni module noyau sÃ©parÃ©.
 
 Options
-Sélectionner « Activer au démarrage » indique à Xastir de rechercher
-ce périphérique et d'établir la communication avec lui au démarrage du
+SÃ©lectionner Â« Activer au dÃ©marrage Â» indique Ã  Xastir de rechercher
+ce pÃ©riphÃ©rique et d'Ã©tablir la communication avec lui au dÃ©marrage du
 programme.
 
-Sélectionner « Permettre transmission » indique à Xastir que toutes
-les données RF sortantes peuvent être envoyées à ce périphérique pour
+SÃ©lectionner Â« Permettre transmission Â» indique Ã  Xastir que toutes
+les donnÃ©es RF sortantes peuvent Ãªtre envoyÃ©es Ã  ce pÃ©riphÃ©rique pour
 diffusion.
 
-Sélectionner « Digipeat ? » indique à Xastir de répéter le
-trafic. Il le fera si l'indicatif du premier répéteur non utilisé dans
-le chemin correspond à votre indicatif ou à un indicatif répertorié
-dans votre fichier de configuration Xastir (ligne «
-RELAY_DIGIPEAT_CALLS », par défaut « WIDE1-1 »). Cette option est
-recommandée uniquement pour les stations de base dans les régions où
-il y a peu d'autres répéteurs de remplissage. Consultez un groupe
-local pour connaître le meilleur réglage pour votre région. Vous
+SÃ©lectionner Â« Digipeat ? Â» indique Ã  Xastir de rÃ©pÃ©ter le
+trafic. Il le fera si l'indicatif du premier rÃ©pÃ©teur non utilisÃ© dans
+le chemin correspond Ã  votre indicatif ou Ã  un indicatif rÃ©pertoriÃ©
+dans votre fichier de configuration Xastir (ligne Â«
+RELAY_DIGIPEAT_CALLS Â», par dÃ©faut Â« WIDE1-1 Â»). Cette option est
+recommandÃ©e uniquement pour les stations de base dans les rÃ©gions oÃ¹
+il y a peu d'autres rÃ©pÃ©teurs de remplissage. Consultez un groupe
+local pour connaÃ®tre le meilleur rÃ©glage pour votre rÃ©gion. Vous
 pouvez modifier manuellement le fichier de configuration Xastir
-lorsque Xastir n'est pas en cours d'exécution afin de modifier cette
-chaîne pour qu'elle corresponde aux recommandations locales. Aux
-États-Unis, « WIDE1-1 » est le paramètre recommandé.
+lorsque Xastir n'est pas en cours d'exÃ©cution afin de modifier cette
+chaÃ®ne pour qu'elle corresponde aux recommandations locales. Aux
+Ã‰tats-Unis, Â« WIDE1-1 Â» est le paramÃ¨tre recommandÃ©.
 
-Le port TNC est le périphérique série Unix auquel le TNC est connecté.
+Le port TNC est le pÃ©riphÃ©rique sÃ©rie Unix auquel le TNC est connectÃ©.
 Normalement, vous pouvez utiliser /dev/ttyS0 (com1), /dev/ttyS1
 (com2), etc.
 
-Le champ Commentaire vous permet de définir un nom convivial ou un
+Le champ Commentaire vous permet de dÃ©finir un nom convivial ou un
 commentaire pour le port.
 
-Définissez maintenant le débit en bps dans les paramètres du port.
+DÃ©finissez maintenant le dÃ©bit en bps dans les paramÃ¨tres du port.
 
-Choisissez le mode de fonctionnement IGate approprié pour ce
-périphérique. Vous pouvez avoir plusieurs périphériques TNC, et cette
-option peut être différente pour chaque périphérique. Si vous
-n'utilisez pas d'IGate, laissez l'option par défaut « Désactiver ».
+Choisissez le mode de fonctionnement IGate appropriÃ© pour ce
+pÃ©riphÃ©rique. Vous pouvez avoir plusieurs pÃ©riphÃ©riques TNC, et cette
+option peut Ãªtre diffÃ©rente pour chaque pÃ©riphÃ©rique. Si vous
+n'utilisez pas d'IGate, laissez l'option par dÃ©faut Â« DÃ©sactiver Â».
 
-Saisissez jusqu'à trois chemins UNPROTO. Xastir prendra en compte la
-partie XX VIA du chemin UNPROTO. Trois chemins sont autorisés pour que
-votre signal soit entendu même dans de mauvaises conditions. Xastir
-alternera entre chaque chemin configuré, à raison d'un par
-transmission. Si vous êtes proche d'un digipeater, un simple WIDE2-2
-peut être un bon choix. Si vous utilisez une faible puissance et/ou
-êtes éloigné d'un digipeater, WIDE1-1,WIDE2-2 peut être plus
+Saisissez jusqu'Ã  trois chemins UNPROTO. Xastir prendra en compte la
+partie XX VIA du chemin UNPROTO. Trois chemins sont autorisÃ©s pour que
+votre signal soit entendu mÃªme dans de mauvaises conditions. Xastir
+alternera entre chaque chemin configurÃ©, Ã  raison d'un par
+transmission. Si vous Ãªtes proche d'un digipeater, un simple WIDE2-2
+peut Ãªtre un bon choix. Si vous utilisez une faible puissance et/ou
+Ãªtes Ã©loignÃ© d'un digipeater, WIDE1-1,WIDE2-2 peut Ãªtre plus
 efficace. Ou si vous connaissez l'indicatif de votre digipeater le
 plus proche, vous pouvez utiliser XXXCALL,WIDE2-2. La plupart d'entre
-vous n'auront besoin que d'un seul chemin. Si vous êtes dans une zone
-isolée et que votre signal a du mal à passer, vous pourriez en avoir
-besoin de plus. Renseignez-vous auprès d'un groupe local et demandez
-quel chemin est le plus adapté à votre région. Si aucun chemin n'est
-configuré, la valeur par défaut sera WIDE2-2.
+vous n'auront besoin que d'un seul chemin. Si vous Ãªtes dans une zone
+isolÃ©e et que votre signal a du mal Ã  passer, vous pourriez en avoir
+besoin de plus. Renseignez-vous auprÃ¨s d'un groupe local et demandez
+quel chemin est le plus adaptÃ© Ã  votre rÃ©gion. Si aucun chemin n'est
+configurÃ©, la valeur par dÃ©faut sera WIDE2-2.
 
-Si vous utilisez l'iGate vers la radiofréquence, vous pouvez spécifier
+Si vous utilisez l'iGate vers la radiofrÃ©quence, vous pouvez spÃ©cifier
 un chemin particulier pour les paquets que vous envoyez en
-radiofréquence. Si vous laissez ce champ vide, les chemins UNPROTO
-ci-dessus seront utilisés.  Si les chemins UNPROTO sont vides, WIDE2-2
-sera utilisé.
+radiofrÃ©quence. Si vous laissez ce champ vide, les chemins UNPROTO
+ci-dessus seront utilisÃ©s.  Si les chemins UNPROTO sont vides, WIDE2-2
+sera utilisÃ©.
 
-Configurez ensuite les paramètres KISS : TXdelay correspond au temps
-(en unités de 10 ms) nécessaire entre l'activation de l'émetteur et le
-moment où il est prêt à envoyer des données. La persistance et le
-temps d'accès au canal sont les paramètres d'accès au canal : le temps
-d'accès au canal indique la fréquence d'exécution de l'algorithme
-d'accès au canal et doit généralement être réglé sur 10.  La
-persistance indique la fréquence à laquelle votre station tente
-d'accéder au canal lorsqu'il est libre et doit idéalement être réglée
-sur 255 divisé par le nombre de stations présentes sur le canal. Le
-mode duplex intégral permet de commencer la transmission même si des
-paquets sont reçus sur le canal ; cette option doit être désactivée
-dans la plupart des cas (réglée sur « 0 »).
+Configurez ensuite les paramÃ¨tres KISS : TXdelay correspond au temps
+(en unitÃ©s de 10 ms) nÃ©cessaire entre l'activation de l'Ã©metteur et le
+moment oÃ¹ il est prÃªt Ã  envoyer des donnÃ©es. La persistance et le
+temps d'accÃ¨s au canal sont les paramÃ¨tres d'accÃ¨s au canal : le temps
+d'accÃ¨s au canal indique la frÃ©quence d'exÃ©cution de l'algorithme
+d'accÃ¨s au canal et doit gÃ©nÃ©ralement Ãªtre rÃ©glÃ© sur 10.  La
+persistance indique la frÃ©quence Ã  laquelle votre station tente
+d'accÃ©der au canal lorsqu'il est libre et doit idÃ©alement Ãªtre rÃ©glÃ©e
+sur 255 divisÃ© par le nombre de stations prÃ©sentes sur le canal. Le
+mode duplex intÃ©gral permet de commencer la transmission mÃªme si des
+paquets sont reÃ§us sur le canal ; cette option doit Ãªtre dÃ©sactivÃ©e
+dans la plupart des cas (rÃ©glÃ©e sur Â« 0 Â»).
 
-HELP-INDEX>Configuration des périphériques TNC AX.25
+HELP-INDEX>Configuration des pÃ©riphÃ©riques TNC AX.25
 
-            Configuration des périphériques TNC AX.25
+            Configuration des pÃ©riphÃ©riques TNC AX.25
 
-Cette section décrit l'ajout ou la modification des périphériques TNC
-AX.25. Les périphériques AX.25 peuvent être n'importe quel
-périphérique utilisant les pilotes Linux AX.25. Il s'agit d'un pilote
-de niveau noyau, et des périphériques tels qu'un Baycom ou un modem
-audio peuvent être utilisés comme TNC.  Ces périphériques doivent être
-configurés et opérationnels avant que Xastir puisse les utiliser.
+Cette section dÃ©crit l'ajout ou la modification des pÃ©riphÃ©riques TNC
+AX.25. Les pÃ©riphÃ©riques AX.25 peuvent Ãªtre n'importe quel
+pÃ©riphÃ©rique utilisant les pilotes Linux AX.25. Il s'agit d'un pilote
+de niveau noyau, et des pÃ©riphÃ©riques tels qu'un Baycom ou un modem
+audio peuvent Ãªtre utilisÃ©s comme TNC.  Ces pÃ©riphÃ©riques doivent Ãªtre
+configurÃ©s et opÃ©rationnels avant que Xastir puisse les utiliser.
 
-Sélectionner « Activer au démarrage » indiquera à Xastir de rechercher
-ce périphérique et d'établir la communication avec lui au démarrage du
+SÃ©lectionner Â« Activer au dÃ©marrage Â» indiquera Ã  Xastir de rechercher
+ce pÃ©riphÃ©rique et d'Ã©tablir la communication avec lui au dÃ©marrage du
 programme.
 
-Sélectionner « Permettre transmission » indiquera à Xastir que
-toutes les données RF sortantes peuvent être envoyées à ce
-périphérique pour diffusion.
+SÃ©lectionner Â« Permettre transmission Â» indiquera Ã  Xastir que
+toutes les donnÃ©es RF sortantes peuvent Ãªtre envoyÃ©es Ã  ce
+pÃ©riphÃ©rique pour diffusion.
 
-Sélectionner « Digipeat ? » indiquera à Xastir de relayer le
-trafic. Il le fera si l'indicatif du premier répéteur numérique
-inutilisé sur le chemin correspond à votre indicatif ou à un indicatif
-répertorié dans votre fichier de configuration Xastir (ligne «
-RELAY_DIGIPEAT_CALLS », la valeur par défaut est « WIDE1-1 »). Cette
-option est recommandée uniquement pour les stations de base dans les
-régions où il y a peu d'autres stations de répéteurs numériques.
-Consultez un groupe local pour connaître le meilleur réglage pour
-votre région. Cette option est nécessaire uniquement si vous
+SÃ©lectionner Â« Digipeat ? Â» indiquera Ã  Xastir de relayer le
+trafic. Il le fera si l'indicatif du premier rÃ©pÃ©teur numÃ©rique
+inutilisÃ© sur le chemin correspond Ã  votre indicatif ou Ã  un indicatif
+rÃ©pertoriÃ© dans votre fichier de configuration Xastir (ligne Â«
+RELAY_DIGIPEAT_CALLS Â», la valeur par dÃ©faut est Â« WIDE1-1 Â»). Cette
+option est recommandÃ©e uniquement pour les stations de base dans les
+rÃ©gions oÃ¹ il y a peu d'autres stations de rÃ©pÃ©teurs numÃ©riques.
+Consultez un groupe local pour connaÃ®tre le meilleur rÃ©glage pour
+votre rÃ©gion. Cette option est nÃ©cessaire uniquement si vous
 n'utilisez pas d'autre logiciel effectuant cette fonction, tel que
 aprsdigi ou DIGI_NED. Vous pouvez modifier manuellement le fichier de
-configuration Xastir lorsque Xastir n'est pas en cours d'exécution
-afin de modifier cette chaîne pour qu'elle corresponde à vos
-recommandations locales. Aux États-Unis, « WIDE1-1 » est le paramètre
-recommandé.
+configuration Xastir lorsque Xastir n'est pas en cours d'exÃ©cution
+afin de modifier cette chaÃ®ne pour qu'elle corresponde Ã  vos
+recommandations locales. Aux Ã‰tats-Unis, Â« WIDE1-1 Â» est le paramÃ¨tre
+recommandÃ©.
 
-Saisissez le nom du périphérique AX.25 que vous avez spécifié dans le
-fichier axports pour ce périphérique.
+Saisissez le nom du pÃ©riphÃ©rique AX.25 que vous avez spÃ©cifiÃ© dans le
+fichier axports pour ce pÃ©riphÃ©rique.
 
-Le champ Commentaire vous permet de définir un nom convivial ou un
+Le champ Commentaire vous permet de dÃ©finir un nom convivial ou un
 commentaire pour le port.
 
-Choisissez le mode de fonctionnement IGate approprié pour ce
-périphérique. Vous pouvez avoir plusieurs périphériques TNC et cette
-option peut être différente pour chaque périphérique. Si vous
-n'utilisez pas d'IGate, laissez l'option par défaut « Désactiver ».
+Choisissez le mode de fonctionnement IGate appropriÃ© pour ce
+pÃ©riphÃ©rique. Vous pouvez avoir plusieurs pÃ©riphÃ©riques TNC et cette
+option peut Ãªtre diffÃ©rente pour chaque pÃ©riphÃ©rique. Si vous
+n'utilisez pas d'IGate, laissez l'option par dÃ©faut Â« DÃ©sactiver Â».
 
-Saisissez jusqu'à trois chemins UNPROTO. Xastir prendra en compte la
-partie XX VIA du chemin UNPROTO. Trois chemins sont autorisés afin que
-votre signal soit entendu même dans de mauvaises conditions. Xastir
-parcourra successivement chaque chemin configuré, à raison d'un par
-transmission. Si vous êtes proche d'un relais numérique (digipeater),
-un simple WIDE2-2 peut être un bon choix. Si vous utilisez une faible
-puissance d'émission et/ou êtes éloigné d'un relais numérique,
-WIDE1-1,WIDE2-2 peut être plus efficace. Si vous connaissez
-l'indicatif de votre relais numérique le plus proche, vous pouvez
+Saisissez jusqu'Ã  trois chemins UNPROTO. Xastir prendra en compte la
+partie XX VIA du chemin UNPROTO. Trois chemins sont autorisÃ©s afin que
+votre signal soit entendu mÃªme dans de mauvaises conditions. Xastir
+parcourra successivement chaque chemin configurÃ©, Ã  raison d'un par
+transmission. Si vous Ãªtes proche d'un relais numÃ©rique (digipeater),
+un simple WIDE2-2 peut Ãªtre un bon choix. Si vous utilisez une faible
+puissance d'Ã©mission et/ou Ãªtes Ã©loignÃ© d'un relais numÃ©rique,
+WIDE1-1,WIDE2-2 peut Ãªtre plus efficace. Si vous connaissez
+l'indicatif de votre relais numÃ©rique le plus proche, vous pouvez
 utiliser XXXCALL,WIDE2-2. La plupart d'entre vous n'auront besoin que
-d'un seul chemin. Si vous êtes dans une zone isolée et que votre
-signal a du mal à passer, vous pourriez en avoir besoin de
-plusieurs. Renseignez-vous auprès d'un groupe local pour savoir quel
-chemin est le plus adapté à votre région. Si aucun chemin n'est
-configuré, le chemin par défaut sera WIDE2-2.
+d'un seul chemin. Si vous Ãªtes dans une zone isolÃ©e et que votre
+signal a du mal Ã  passer, vous pourriez en avoir besoin de
+plusieurs. Renseignez-vous auprÃ¨s d'un groupe local pour savoir quel
+chemin est le plus adaptÃ© Ã  votre rÃ©gion. Si aucun chemin n'est
+configurÃ©, le chemin par dÃ©faut sera WIDE2-2.
 
-Si vous utilisez la fonction IGate vers la radiofréquence (RF), vous
-pouvez spécifier un chemin particulier pour les paquets que vous
+Si vous utilisez la fonction IGate vers la radiofrÃ©quence (RF), vous
+pouvez spÃ©cifier un chemin particulier pour les paquets que vous
 envoyez en RF. Si vous laissez ce champ vide, les chemins UNPROTO
-mentionnés ci-dessus seront utilisés. Si les chemins UNPROTO sont
-également vides, WIDE2-2 sera utilisé.
+mentionnÃ©s ci-dessus seront utilisÃ©s. Si les chemins UNPROTO sont
+Ã©galement vides, WIDE2-2 sera utilisÃ©.
 
-REMARQUE : Pour utiliser les périphériques AX.25 avec Xastir, vous
-devez exécuter le programme en tant que « root ». Si vous souhaitez
-exécuter Xastir avec un autre utilisateur, vous pouvez définir le bit
-SUID sur le fichier exécutable de Xastir. Veuillez consulter le
+REMARQUE : Pour utiliser les pÃ©riphÃ©riques AX.25 avec Xastir, vous
+devez exÃ©cuter le programme en tant que Â« root Â». Si vous souhaitez
+exÃ©cuter Xastir avec un autre utilisateur, vous pouvez dÃ©finir le bit
+SUID sur le fichier exÃ©cutable de Xastir. Veuillez consulter le
 fichier INSTALL pour plus d'informations ; la version actuelle de
-Xastir abandonne les privilèges supplémentaires, mais n'a pas fait
-l'objet d'un audit de sécurité. L'utilisation de cette manière dans un
-environnement multi-utilisateur se fait à vos propres risques !
+Xastir abandonne les privilÃ¨ges supplÃ©mentaires, mais n'a pas fait
+l'objet d'un audit de sÃ©curitÃ©. L'utilisation de cette maniÃ¨re dans un
+environnement multi-utilisateur se fait Ã  vos propres risques !
 
-HELP-INDEX>Configuration des appareils GPS série
+HELP-INDEX>Configuration des appareils GPS sÃ©rie
 
-           Configuration des appareils GPS série
+           Configuration des appareils GPS sÃ©rie
 
-Définissez le port série de votre récepteur GPS. Les valeurs courantes
+DÃ©finissez le port sÃ©rie de votre rÃ©cepteur GPS. Les valeurs courantes
 sont /dev/ttyS0 (COM1) ou /dev/ttyS1 (COM2).
 
-Le champ « Commentaire » vous permet d'attribuer un nom ou un
+Le champ Â« Commentaire Â» vous permet d'attribuer un nom ou un
 commentaire au port.
 
-L'option « Activer au démarrage » indique à Xastir de rechercher cet
-appareil et d'établir la communication avec lui au lancement du
+L'option Â« Activer au dÃ©marrage Â» indique Ã  Xastir de rechercher cet
+appareil et d'Ã©tablir la communication avec lui au lancement du
 programme.
 
-L'option « Régler l'horloge system sur celle du GPS » indique à Xastir
-de tenter de synchroniser l'horloge du système avec le signal horaire
-de haute précision du récepteur GPS.  Cette opération nécessite les
-privilèges d'administrateur sur la plupart des systèmes.
+L'option Â« RÃ©gler l'horloge system sur celle du GPS Â» indique Ã  Xastir
+de tenter de synchroniser l'horloge du systÃ¨me avec le signal horaire
+de haute prÃ©cision du rÃ©cepteur GPS.  Cette opÃ©ration nÃ©cessite les
+privilÃ¨ges d'administrateur sur la plupart des systÃ¨mes.
 
-Définissez ensuite le débit en bauds dans les paramètres du port, et
-les paramètres dans « StyleType du port ». Le paramètre « Type du port »
-8N1 correspond à 8 bits de données, aucune parité et 1 bit
-d'arrêt. 7E1 correspond à 7 bits de données, parité paire et 1 bit
-d'arrêt.  7O1 correspond à 7 bits de données, parité impaire et 1 bit
-d'arrêt. Ces paramètres doivent correspondre à ceux de votre GPS. La
-plupart des récepteurs GPS utilisent 4800 bauds et 8,n,1.
+DÃ©finissez ensuite le dÃ©bit en bauds dans les paramÃ¨tres du port, et
+les paramÃ¨tres dans Â« StyleType du port Â». Le paramÃ¨tre Â« Type du port Â»
+8N1 correspond Ã  8 bits de donnÃ©es, aucune paritÃ© et 1 bit
+d'arrÃªt. 7E1 correspond Ã  7 bits de donnÃ©es, paritÃ© paire et 1 bit
+d'arrÃªt.  7O1 correspond Ã  7 bits de donnÃ©es, paritÃ© impaire et 1 bit
+d'arrÃªt. Ces paramÃ¨tres doivent correspondre Ã  ceux de votre GPS. La
+plupart des rÃ©cepteurs GPS utilisent 4800 bauds et 8,n,1.
 
-HELP-INDEX>Configuration des appareils GPS en réseau
+HELP-INDEX>Configuration des appareils GPS en rÃ©seau
 
-           Configuration des appareils GPS en réseau
+           Configuration des appareils GPS en rÃ©seau
 
-Si vous devez partager les données GPS avec différents programmes ou
-machines, cette option est la plus appropriée. Xastir fonctionne avec
-gpsd, ce qui permet à plusieurs connexions de partager vos données
+Si vous devez partager les donnÃ©es GPS avec diffÃ©rents programmes ou
+machines, cette option est la plus appropriÃ©e. Xastir fonctionne avec
+gpsd, ce qui permet Ã  plusieurs connexions de partager vos donnÃ©es
 GPS.
 
-Définissez le nom d'hôte (ou l'adresse IP) et le numéro de port de
-l'hôte gpsd sur votre réseau.
+DÃ©finissez le nom d'hÃ´te (ou l'adresse IP) et le numÃ©ro de port de
+l'hÃ´te gpsd sur votre rÃ©seau.
 
-Le champ « Commentaire » vous permet d'attribuer un nom convivial ou
+Le champ Â« Commentaire Â» vous permet d'attribuer un nom convivial ou
 un commentaire au port.
 
-L'option « Activer au démarrage » indique à Xastir de rechercher cet
-appareil et d'établir la communication avec lui au lancement du
+L'option Â« Activer au dÃ©marrage Â» indique Ã  Xastir de rechercher cet
+appareil et d'Ã©tablir la communication avec lui au lancement du
 programme.
 
-L'option « Reconnexion sur erreur réseau? » indique à Xastir de tenter de se
-reconnecter en cas d'interruption du flux de données.
+L'option Â« Reconnexion sur erreur rÃ©seau? Â» indique Ã  Xastir de tenter de se
+reconnecter en cas d'interruption du flux de donnÃ©es.
 
-L'option « Régler l'horloge système sur celle du GPS ? » indique à
-Xastir de synchroniser l'horloge du système avec le signal horaire de
-haute précision du récepteur GPS. Cette opération nécessite les
-privilèges administrateur sur la plupart des systèmes.
+L'option Â« RÃ©gler l'horloge systÃ¨me sur celle du GPS ? Â» indique Ã 
+Xastir de synchroniser l'horloge du systÃ¨me avec le signal horaire de
+haute prÃ©cision du rÃ©cepteur GPS. Cette opÃ©ration nÃ©cessite les
+privilÃ¨ges administrateur sur la plupart des systÃ¨mes.
 
 HELP-INDEX>Configuration du serveur Internet
 
            Configuration du serveur Internet
 
 Les serveurs Internet vous permettent d'envoyer et de recevoir des
-données dans le monde entier.
+donnÃ©es dans le monde entier.
 
-Sélectionner « Activer au démarrage » indique à Xastir de rechercher
-cet appareil et d'établir la communication avec lui au lancement du
+SÃ©lectionner Â« Activer au dÃ©marrage Â» indique Ã  Xastir de rechercher
+cet appareil et d'Ã©tablir la communication avec lui au lancement du
 programme.
 
-Sélectionner « Permettre transmission » indique à Xastir que toutes
-les données Internet sortantes peuvent être envoyées à cet appareil.
+SÃ©lectionner Â« Permettre transmission Â» indique Ã  Xastir que toutes
+les donnÃ©es Internet sortantes peuvent Ãªtre envoyÃ©es Ã  cet appareil.
 
-Saisissez le nom d'hôte (ou l'adresse IP) et le numéro de port du
+Saisissez le nom d'hÃ´te (ou l'adresse IP) et le numÃ©ro de port du
 serveur Internet que vous souhaitez contacter.
 
 Saisissez un mot de passe valide pour valider votre connexion ; cela
-permettra la transmission de vos données via une passerelle IGate. Si
-vous n'avez pas de mot de passe, utilisez le programme « callpass »
-fourni pour en générer un. Notez que les mots de passe dépendent des
-indicatifs d'appel. Depuis le répertoire src, la commande « make
-callpass » devrait créer l'exécutable s'il n'est pas déjà compilé.
+permettra la transmission de vos donnÃ©es via une passerelle IGate. Si
+vous n'avez pas de mot de passe, utilisez le programme Â« callpass Â»
+fourni pour en gÃ©nÃ©rer un. Notez que les mots de passe dÃ©pendent des
+indicatifs d'appel. Depuis le rÃ©pertoire src, la commande Â« make
+callpass Â» devrait crÃ©er l'exÃ©cutable s'il n'est pas dÃ©jÃ  compilÃ©.
 
-Saisissez les paramètres de filtrage. Cela envoie un message spécial
-au serveur demandant que les données soient filtrées d'une certaine
-manière. Le format exact de ce champ est entièrement spécifié ;
+Saisissez les paramÃ¨tres de filtrage. Cela envoie un message spÃ©cial
+au serveur demandant que les donnÃ©es soient filtrÃ©es d'une certaine
+maniÃ¨re. Le format exact de ce champ est entiÃ¨rement spÃ©cifiÃ© ;
 veuillez consulter APRSSIG pour plus d'informations.
 
-Le champ « Commentaire » vous permet de définir un nom ou un
+Le champ Â« Commentaire Â» vous permet de dÃ©finir un nom ou un
 commentaire pour le port.
 
-Sélectionner « Reconnexion sur erreur réseau? » indique à Xastir de
-tenter de se reconnecter lorsque le flux de données est interrompu.
+SÃ©lectionner Â« Reconnexion sur erreur rÃ©seau? Â» indique Ã  Xastir de
+tenter de se reconnecter lorsque le flux de donnÃ©es est interrompu.
 
-HELP-INDEX>Configuration d'une station météo série
+HELP-INDEX>Configuration d'une station mÃ©tÃ©o sÃ©rie
 
-           Configuration d'une station météo série
+           Configuration d'une station mÃ©tÃ©o sÃ©rie
 
-Définissez le périphérique du port série pour votre station météo. Les
-valeurs courantes /dev/ttyS0 (COM1) ou /dev/ttyS1 (COM2) peuvent être
-utilisées.
+DÃ©finissez le pÃ©riphÃ©rique du port sÃ©rie pour votre station mÃ©tÃ©o. Les
+valeurs courantes /dev/ttyS0 (COM1) ou /dev/ttyS1 (COM2) peuvent Ãªtre
+utilisÃ©es.
 
-Le champ « Commentaire » vous permet de définir un nom ou un
+Le champ Â« Commentaire Â» vous permet de dÃ©finir un nom ou un
 commentaire pour le port.
 
-En sélectionnant « Activer au démarrage », Xastir recherchera ce
-périphérique et établira la communication avec celui-ci au lancement
+En sÃ©lectionnant Â« Activer au dÃ©marrage Â», Xastir recherchera ce
+pÃ©riphÃ©rique et Ã©tablira la communication avec celui-ci au lancement
 du programme.
 
-Définissez ensuite le débit en bauds dans les paramètres du port, et
-les paramètres dans le style du port. Le style de port 8N1 correspond
-à 8 bits de données, aucune parité et 1 bit d'arrêt.  7E1 correspond à
-7 bits de données, parité paire et 1 bit d'arrêt. 7O1 correspond à 7
-bits de données, parité impaire et 1 bit d'arrêt. Ces paramètres
-doivent correspondre à ceux de votre station météo.  L'option « Type
-de données » vous permet de spécifier le type de données série que le
-programme recherchera. La fonction de détection automatique recherche
-d'abord les données météorologiques au format binaire, comme celles
-utilisées par la station Radio Shack WX-200. Si aucune donnée binaire
-n'est trouvée dans le flux, Xastir recherchera une station météo de
+DÃ©finissez ensuite le dÃ©bit en bauds dans les paramÃ¨tres du port, et
+les paramÃ¨tres dans le style du port. Le style de port 8N1 correspond
+Ã  8 bits de donnÃ©es, aucune paritÃ© et 1 bit d'arrÃªt.  7E1 correspond Ã 
+7 bits de donnÃ©es, paritÃ© paire et 1 bit d'arrÃªt. 7O1 correspond Ã  7
+bits de donnÃ©es, paritÃ© impaire et 1 bit d'arrÃªt. Ces paramÃ¨tres
+doivent correspondre Ã  ceux de votre station mÃ©tÃ©o.  L'option Â« Type
+de donnÃ©es Â» vous permet de spÃ©cifier le type de donnÃ©es sÃ©rie que le
+programme recherchera. La fonction de dÃ©tection automatique recherche
+d'abord les donnÃ©es mÃ©tÃ©orologiques au format binaire, comme celles
+utilisÃ©es par la station Radio Shack WX-200. Si aucune donnÃ©e binaire
+n'est trouvÃ©e dans le flux, Xastir recherchera une station mÃ©tÃ©o de
 type ASCII (comme Peet Bros.).
 
-Définissez maintenant le facteur de correction du pluviomètre. Xastir
-exige que le pluviomètre fournisse des données par incréments de 0,01
-pouce. Si l'unité fournit des données par incréments de 0,1 pouce ou
-0,1 millimètre, une correction doit être spécifiée pour obtenir des
-mesures précises.
+DÃ©finissez maintenant le facteur de correction du pluviomÃ¨tre. Xastir
+exige que le pluviomÃ¨tre fournisse des donnÃ©es par incrÃ©ments de 0,01
+pouce. Si l'unitÃ© fournit des donnÃ©es par incrÃ©ments de 0,1 pouce ou
+0,1 millimÃ¨tre, une correction doit Ãªtre spÃ©cifiÃ©e pour obtenir des
+mesures prÃ©cises.
 
-HELP-INDEX>Configurer une station météo en réseau
+HELP-INDEX>Configurer une station mÃ©tÃ©o en rÃ©seau
 
-           Configurer une station météo en réseau
+           Configurer une station mÃ©tÃ©o en rÃ©seau
 
-Xastir peut utiliser des serveurs de données météorologiques tels que
-wx200d.  wx200d permet plusieurs connexions réseau, partageant ainsi
-les données météorologiques avec plusieurs programmes ou ordinateurs.
+Xastir peut utiliser des serveurs de donnÃ©es mÃ©tÃ©orologiques tels que
+wx200d.  wx200d permet plusieurs connexions rÃ©seau, partageant ainsi
+les donnÃ©es mÃ©tÃ©orologiques avec plusieurs programmes ou ordinateurs.
 
-Saisissez le nom d'hôte (ou l'adresse IP) et le numéro de port du
-serveur de données météorologiques que vous souhaitez contacter.
+Saisissez le nom d'hÃ´te (ou l'adresse IP) et le numÃ©ro de port du
+serveur de donnÃ©es mÃ©tÃ©orologiques que vous souhaitez contacter.
 
-Le champ « Commentaire » vous permet d'attribuer un nom convivial ou
+Le champ Â« Commentaire Â» vous permet d'attribuer un nom convivial ou
 un commentaire au port.
 
-L'option « Activer au démarrage » indique à Xastir de rechercher cet
-appareil et d'établir la communication avec lui au lancement du
+L'option Â« Activer au dÃ©marrage Â» indique Ã  Xastir de rechercher cet
+appareil et d'Ã©tablir la communication avec lui au lancement du
 programme.
 
-L'option « Reconnexion sur erreur réseau? » indique à Xastir de tenter de se
-reconnecter si le flux de données est interrompu.
+L'option Â« Reconnexion sur erreur rÃ©seau? Â» indique Ã  Xastir de tenter de se
+reconnecter si le flux de donnÃ©es est interrompu.
 
-Comme précédemment, le type de données remplace la détection
+Comme prÃ©cÃ©demment, le type de donnÃ©es remplace la dÃ©tection
 automatique.
 
-Définissez maintenant le facteur de correction du pluviomètre. Xastir
-exige que le pluviomètre affiche les précipitations par incréments de
-0,01 pouce. Si l'appareil affiche les précipitations par incréments de
-0,1 pouce ou de 0,1 millimètre, une correction doit être spécifiée
-pour obtenir des mesures précises.
+DÃ©finissez maintenant le facteur de correction du pluviomÃ¨tre. Xastir
+exige que le pluviomÃ¨tre affiche les prÃ©cipitations par incrÃ©ments de
+0,01 pouce. Si l'appareil affiche les prÃ©cipitations par incrÃ©ments de
+0,1 pouce ou de 0,1 millimÃ¨tre, une correction doit Ãªtre spÃ©cifiÃ©e
+pour obtenir des mesures prÃ©cises.
 
 HELP-INDEX>Configuration d'une connexion AGWPE
 
            Configuration d'une connexion AGWPE
 
-Xastir peut utiliser une interface réseau AGWPE fonctionnant sous
-Windows comme interface TNC. Il prend également en charge la sécurité
-par identifiant et mot de passe intégrée à AGWPE, mais vous devez
+Xastir peut utiliser une interface rÃ©seau AGWPE fonctionnant sous
+Windows comme interface TNC. Il prend Ã©galement en charge la sÃ©curitÃ©
+par identifiant et mot de passe intÃ©grÃ©e Ã  AGWPE, mais vous devez
 configurer le compte dans l'application AGWPE en utilisant votre
 indicatif d'appel comme nom d'utilisateur, en majuscules.  Par exemple
-: « AB7CD ».
+: Â« AB7CD Â».
 
-Les autres options sont décrites dans les sections relatives aux
-interfaces TNC série et aux interfaces réseau.
+Les autres options sont dÃ©crites dans les sections relatives aux
+interfaces TNC sÃ©rie et aux interfaces rÃ©seau.
 
-HELP-INDEX>Configurer une connexion à une base de données SQL
+HELP-INDEX>Configurer une connexion Ã  une base de donnÃ©es SQL
 
-           Configurer une connexion à une base de données SQL
-           [Expérimental]
+           Configurer une connexion Ã  une base de donnÃ©es SQL
+           [ExpÃ©rimental]
 
-Xastir peut, à titre expérimental, stocker et récupérer les données
-des stations à partir d'une base de données MySQL ou d'une base de
-données PostgreSQL + PostGIS. Consultez la section « OPTIONNEL :
-Expérimental. Ajouter la prise en charge des bases de données SIG »
-dans le fichier INSTALL pour plus d'informations. Les données des
-stations et des objets sont stockées sous forme de données spatiales
-et peuvent être récupérées par d'autres applications SIG. Par exemple,
-Xastir peut écrire les emplacements des stations dans une base de
-données PostGIS, à partir de laquelle elles peuvent également être
-visualisées à l'aide de QGIS. Les connexions aux bases de données SQL
-permettent également la persistance des données entre les sessions
-Xastir. Tous les aspects de la prise en charge des bases de données
-spatiales, y compris les structures de base de données, sont
-actuellement expérimentaux et peuvent être modifiés à tout
-moment. Vous pouvez configurer plusieurs connexions à des bases de
-données SQL, mais une seule doit être active à la fois.
+Xastir peut, Ã  titre expÃ©rimental, stocker et rÃ©cupÃ©rer les donnÃ©es
+des stations Ã  partir d'une base de donnÃ©es MySQL ou d'une base de
+donnÃ©es PostgreSQL + PostGIS. Consultez la section Â« OPTIONNEL :
+ExpÃ©rimental. Ajouter la prise en charge des bases de donnÃ©es SIG Â»
+dans le fichier INSTALL pour plus d'informations. Les donnÃ©es des
+stations et des objets sont stockÃ©es sous forme de donnÃ©es spatiales
+et peuvent Ãªtre rÃ©cupÃ©rÃ©es par d'autres applications SIG. Par exemple,
+Xastir peut Ã©crire les emplacements des stations dans une base de
+donnÃ©es PostGIS, Ã  partir de laquelle elles peuvent Ã©galement Ãªtre
+visualisÃ©es Ã  l'aide de QGIS. Les connexions aux bases de donnÃ©es SQL
+permettent Ã©galement la persistance des donnÃ©es entre les sessions
+Xastir. Tous les aspects de la prise en charge des bases de donnÃ©es
+spatiales, y compris les structures de base de donnÃ©es, sont
+actuellement expÃ©rimentaux et peuvent Ãªtre modifiÃ©s Ã  tout
+moment. Vous pouvez configurer plusieurs connexions Ã  des bases de
+donnÃ©es SQL, mais une seule doit Ãªtre active Ã  la fois.
 
-Avant de créer une connexion à une base de données dans Xastir, vous
-devrez créer une base de données à laquelle vous connecter, créer un
-ensemble de tables appropriées (voir les scripts db_gis_xxxxx.sql dans
-le répertoire scripts) et ajouter un utilisateur avec un mot de passe
-et les droits d'accès à la base de données. Pour les bases de données
-PostGIS, vous devrez peut-être également configurer l'utilisateur de
-manière appropriée dans pg_hba.conf.
+Avant de crÃ©er une connexion Ã  une base de donnÃ©es dans Xastir, vous
+devrez crÃ©er une base de donnÃ©es Ã  laquelle vous connecter, crÃ©er un
+ensemble de tables appropriÃ©es (voir les scripts db_gis_xxxxx.sql dans
+le rÃ©pertoire scripts) et ajouter un utilisateur avec un mot de passe
+et les droits d'accÃ¨s Ã  la base de donnÃ©es. Pour les bases de donnÃ©es
+PostGIS, vous devrez peut-Ãªtre Ã©galement configurer l'utilisateur de
+maniÃ¨re appropriÃ©e dans pg_hba.conf.
 
-Les options de configuration de la boîte de dialogue de la base de
-données SQL incluent :
+Les options de configuration de la boÃ®te de dialogue de la base de
+donnÃ©es SQL incluent :
 
-Base de données : MySQL (lat/long) pour les très anciennes bases de données MySQL,
+Base de donnÃ©es : MySQL (lat/long) pour les trÃ¨s anciennes bases de donnÃ©es MySQL,
 PostGIS pour PostgreSQL + PostGIS, et
-MySQL (Spatial) pour les bases de données MySQL actuelles.
-Avec les tables pour : Actuellement, seul Xastir est pris en charge. Avant de créer une connexion à une base de données dans Xastir, vous devrez créer une
-base de données à laquelle vous connecter, créer un ensemble de tables approprié
-(voir les scripts db_gis_xxxxx.sql dans le répertoire scripts) et ajouter un utilisateur
-avec un mot de passe et les droits d'accès à la base de données. Pour les bases de données PostGIS,
-vous devrez peut-être également configurer correctement l'utilisateur dans pg_hba.conf.
+MySQL (Spatial) pour les bases de donnÃ©es MySQL actuelles.
+Avec les tables pour : Actuellement, seul Xastir est pris en charge. Avant de crÃ©er une connexion Ã  une base de donnÃ©es dans Xastir, vous devrez crÃ©er une
+base de donnÃ©es Ã  laquelle vous connecter, crÃ©er un ensemble de tables appropriÃ©
+(voir les scripts db_gis_xxxxx.sql dans le rÃ©pertoire scripts) et ajouter un utilisateur
+avec un mot de passe et les droits d'accÃ¨s Ã  la base de donnÃ©es. Pour les bases de donnÃ©es PostGIS,
+vous devrez peut-Ãªtre Ã©galement configurer correctement l'utilisateur dans pg_hba.conf.
 
-Les options de configuration de la boîte de dialogue de la base de
-données SQL incluent :
-Base de données : MySQL (lat/long) pour les très anciennes bases de données MySQL,
+Les options de configuration de la boÃ®te de dialogue de la base de
+donnÃ©es SQL incluent :
+Base de donnÃ©es : MySQL (lat/long) pour les trÃ¨s anciennes bases de donnÃ©es MySQL,
 PostGIS pour PostgreSQL + PostGIS, et
-MySQL (Spatial) pour les bases de données MySQL actuelles.
-Avec les tables pour : Actuellement, seul le schéma simple de Xastir est pris en charge - une table plate très basique
+MySQL (Spatial) pour les bases de donnÃ©es MySQL actuelles.
+Avec les tables pour : Actuellement, seul le schÃ©ma simple de Xastir est pris en charge - une table plate trÃ¨s basique
 contenant des informations minimales sur les stations.
-Hôte : Adresse IP ou nom d'hôte du serveur de base de données, la valeur par défaut est localhost.
-Port : La valeur par défaut est 3306 pour MySQL et 5432 pour PostgreSQL. La base de données peut
-être sur un serveur distant, mais le port approprié devra être
+HÃ´te : Adresse IP ou nom d'hÃ´te du serveur de base de donnÃ©es, la valeur par dÃ©faut est localhost.
+Port : La valeur par dÃ©faut est 3306 pour MySQL et 5432 pour PostgreSQL. La base de donnÃ©es peut
+Ãªtre sur un serveur distant, mais le port appropriÃ© devra Ãªtre
 ouvert dans les pare-feu.
-Nom d'utilisateur : Peut être unique à votre base de données, par exemple xastir_user
-Mot de passe : Unique à votre base de données.
-Nom du schéma : Nom de votre base de données. par exemple xastir
-Socket MySQL : vérifiez my.cnf ou mysql --help | grep socket
-Laissez vide pour les bases de données PostGIS.
-Reconnexion en cas de panne réseau : [Non encore implémenté]
-Les valeurs par défaut de MySQL et PostGIS fournies par les boutons peuvent
-être correctes ou non pour votre base de données.
+Nom d'utilisateur : Peut Ãªtre unique Ã  votre base de donnÃ©es, par exemple xastir_user
+Mot de passe : Unique Ã  votre base de donnÃ©es.
+Nom du schÃ©ma : Nom de votre base de donnÃ©es. par exemple xastir
+Socket MySQL : vÃ©rifiez my.cnf ou mysql --help | grep socket
+Laissez vide pour les bases de donnÃ©es PostGIS.
+Reconnexion en cas de panne rÃ©seau : [Non encore implÃ©mentÃ©]
+Les valeurs par dÃ©faut de MySQL et PostGIS fournies par les boutons peuvent
+Ãªtre correctes ou non pour votre base de donnÃ©es.
 
-Trois options contrôlent le comportement de l'interface de la base de
-données SQL : Activer au démarrage : Tente de se connecter à cette
-base de données et de commencer à stocker les données des stations dès
-le démarrage de Xastir (si l'option « Stocker les données entrantes »
-est également sélectionnée).
+Trois options contrÃ´lent le comportement de l'interface de la base de
+donnÃ©es SQL : Activer au dÃ©marrage : Tente de se connecter Ã  cette
+base de donnÃ©es et de commencer Ã  stocker les donnÃ©es des stations dÃ¨s
+le dÃ©marrage de Xastir (si l'option Â« Stocker les donnÃ©es entrantes Â»
+est Ã©galement sÃ©lectionnÃ©e).
 
-Stocker les données entrantes : Stocke chaque rapport de station (y
-compris les objets et les éléments) sous forme d'enregistrement dans
-la base de données. Toutes les stations entendues sur toutes les
-interfaces seront stockées dans la base de données - si vous êtes
-connecté à des flux Internet et que vous laissez Xastir en
-fonctionnement, cela peut facilement représenter un million
+Stocker les donnÃ©es entrantes : Stocke chaque rapport de station (y
+compris les objets et les Ã©lÃ©ments) sous forme d'enregistrement dans
+la base de donnÃ©es. Toutes les stations entendues sur toutes les
+interfaces seront stockÃ©es dans la base de donnÃ©es - si vous Ãªtes
+connectÃ© Ã  des flux Internet et que vous laissez Xastir en
+fonctionnement, cela peut facilement reprÃ©senter un million
 d'enregistrements par jour.
 
-Charger les données au démarrage : Récupère toutes les données des
-stations de la base de données lors du redémarrage de
-Xastir. Actuellement, c'est le seul moyen de récupérer des données
-persistantes à partir d'une base de données. Tentera de se connecter à
-la base de données et de récupérer les données indépendamment des
-paramètres « Activer au démarrage » ou « Stocker les données entrantes
-». En raison d'erreurs d'arrondi et de conversion, les stations non
-mobiles peuvent se déplacer légèrement.
+Charger les donnÃ©es au dÃ©marrage : RÃ©cupÃ¨re toutes les donnÃ©es des
+stations de la base de donnÃ©es lors du redÃ©marrage de
+Xastir. Actuellement, c'est le seul moyen de rÃ©cupÃ©rer des donnÃ©es
+persistantes Ã  partir d'une base de donnÃ©es. Tentera de se connecter Ã 
+la base de donnÃ©es et de rÃ©cupÃ©rer les donnÃ©es indÃ©pendamment des
+paramÃ¨tres Â« Activer au dÃ©marrage Â» ou Â« Stocker les donnÃ©es entrantes
+Â». En raison d'erreurs d'arrondi et de conversion, les stations non
+mobiles peuvent se dÃ©placer lÃ©gÃ¨rement.
 
-La zone « Dernière erreur » peut contenir ou non un message d'erreur
-permettant d'identifier les problèmes de connexion. Lorsque Xastir ne
-parvient pas à se connecter à une base de données, l'interface affiche
-« ERREUR » dans la liste des interfaces, et la dernière erreur peut
-être affichée ici. L'exécution de Xastir depuis la console et
-l'observation des messages d'erreur qui y apparaissent, ou l'exécution
+La zone Â« DerniÃ¨re erreur Â» peut contenir ou non un message d'erreur
+permettant d'identifier les problÃ¨mes de connexion. Lorsque Xastir ne
+parvient pas Ã  se connecter Ã  une base de donnÃ©es, l'interface affiche
+Â« ERREUR Â» dans la liste des interfaces, et la derniÃ¨re erreur peut
+Ãªtre affichÃ©e ici. L'exÃ©cution de Xastir depuis la console et
+l'observation des messages d'erreur qui y apparaissent, ou l'exÃ©cution
 de Xastir depuis la console avec l'option `xastir -v1`, peuvent aider
-à identifier la cause des problèmes de connexion, tout comme l'examen
-des journaux d'erreurs de la base de données.
+Ã  identifier la cause des problÃ¨mes de connexion, tout comme l'examen
+des journaux d'erreurs de la base de donnÃ©es.
 
-Vous ne pourrez configurer une interface de base de données SQL que si
-vous avez compilé Xastir avec la prise en charge du SGBD correspondant
+Vous ne pourrez configurer une interface de base de donnÃ©es SQL que si
+vous avez compilÃ© Xastir avec la prise en charge du SGBD correspondant
 (--with-mysql ou --with-postgis).
 
 HELP-INDEX>Table des symboles

--- a/help/help-German.dat
+++ b/help/help-German.dat
@@ -1,25 +1,25 @@
-HELP-INDEX>Einführende Worte / Lizenzbestimmungen
+HELP-INDEX>EinfÃ¼hrende Worte / Lizenzbestimmungen
 
-                  Einführende Worte / Lizenzbestimmungen
+                  EinfÃ¼hrende Worte / Lizenzbestimmungen
 
-Für die aktuellsten Informationen und genauere Installationshinweise
+FÃ¼r die aktuellsten Informationen und genauere Installationshinweise
 lesen sie bitte die README Datei im Xastir Hauptverzeichnis. Beachten
-Sie auch die Dateien LICENCE und COPYING für weitere Informationen.
+Sie auch die Dateien LICENCE und COPYING fÃ¼r weitere Informationen.
 
-Bitte denken sie daran, daß dieses Programm für den Einsatz im
-Amateurfunk bestimmt ist. In Deutschland muß man im Besitz eines
-Funkzeugnises sein, um auf Amateurfunkfrequenzen senden zu dürfen.
+Bitte denken sie daran, daÃŸ dieses Programm fÃ¼r den Einsatz im
+Amateurfunk bestimmt ist. In Deutschland muÃŸ man im Besitz eines
+Funkzeugnises sein, um auf Amateurfunkfrequenzen senden zu dÃ¼rfen.
 Informationen zum Erwerb eines Funkzeugisses findet man beim
-Amateurfunkclub DARC http://www.darc.de. Auch in anderen Ländern
-gelten ähnliche Bestimmungen, die zu beachten sind.
+Amateurfunkclub DARC http://www.darc.de. Auch in anderen LÃ¤ndern
+gelten Ã¤hnliche Bestimmungen, die zu beachten sind.
 
-Die Entwicklung der Software und die Dokumentation erfolgte zunächst in
-Englisch, so daß im Zweifelsfall die englische Version aktueller sein
-könnte. Die vorliegende deutsche Hilfedatei wurde von DK7IN übersetzt.
+Die Entwicklung der Software und die Dokumentation erfolgte zunÃ¤chst in
+Englisch, so daÃŸ im Zweifelsfall die englische Version aktueller sein
+kÃ¶nnte. Die vorliegende deutsche Hilfedatei wurde von DK7IN Ã¼bersetzt.
 Korrekturen und Anregungen bitte an xastir@dk7in.de
 
 
-LIZENZBESTIMMUNGEN für XASTIR:
+LIZENZBESTIMMUNGEN fÃ¼r XASTIR:
 
 XASTIR steht unter der GNU Lizenz, im Folgenden der englische
 Wortlaut. Die Details der GNU-Lizenz finden sich in der Datei
@@ -56,7 +56,7 @@ um XASTIR zu verfolgen.
 Weitere Informationen zur GNU Lizenz finden sich auf:
   http://www.gnu.org
 
-Informationen über Freie Software in deutscher Sprache
+Informationen Ã¼ber Freie Software in deutscher Sprache
 finden Sie bei der Free Software Foundation Europe
   http://fsfeurope.org/index.de.html
 
@@ -71,18 +71,18 @@ XASTIR ist ein APRS(tm)-Programm, das als Open Source frei benutzt und an
 andere weitergegeben werden darf. Das Programm befindet sich momentan im
 Entwicklungsstadium und sollte nicht als fertiges Produkt angesehen
 werden! Mit ihrer Mitarbeit kann dieses Programm besser werden. Wenn sie
-also Programmiererfahrung haben, oder Dokumentation schreiben können,
-können wir ihre Hilfe gebrauchen. Wir haben eine Menge Ideen aber nur
-begrenzte Zeit. Wenn sie also denken, einen Beitrag leisten zu können,
+also Programmiererfahrung haben, oder Dokumentation schreiben kÃ¶nnen,
+kÃ¶nnen wir ihre Hilfe gebrauchen. Wir haben eine Menge Ideen aber nur
+begrenzte Zeit. Wenn sie also denken, einen Beitrag leisten zu kÃ¶nnen,
 lassen sie es uns wissen!
 
 
 APRS[tm] ist ein Warenzeichen von Bob Bruninga, seine Homepage ist
 "http://web.usna.navy.mil/~bruninga/aprs.html"
-Beachten Sie bitte, daß sehr viel Information zu APRS(tm) in
+Beachten Sie bitte, daÃŸ sehr viel Information zu APRS(tm) in
 der von Bob Bruninga geschriebenen Dokumentationen zu APRSdos
 enthalten ist. Eine weitere Informationsquelle ist die von
-http://www.tapr.org als PDF-Dokument erhältliche APRS Spezifikation.
+http://www.tapr.org als PDF-Dokument erhÃ¤ltliche APRS Spezifikation.
 
 HELP-INDEX>What's new in Xastir 2.0.9
 
@@ -340,20 +340,20 @@ HELP-INDEX>Der erste Aufruf von Xastir
                         Der erste Aufruf von Xastir
 
 Beim ersten Start von Xastir sollten sie das Programm aus einem
-Terminalfenster heraus aufrufen, um mögliche Fehlermeldungen sehen zu
-können. Da auf den meisten Systemen der Pfad so eingerichtet ist, daß
+Terminalfenster heraus aufrufen, um mÃ¶gliche Fehlermeldungen sehen zu
+kÃ¶nnen. Da auf den meisten Systemen der Pfad so eingerichtet ist, daÃŸ
 Programme in /usr/local/bin gefunden werden, reicht es am Prompt
-"xastir &" einzugeben. Auf anderen Systemen muß "/usr/local/bin/xastir &"
-eingegeben werden, um das Programm zu starten. Das '&' sorgt dafür, daß
-Xastir im Hintergrund gestartet wir, so daß das Terminalfenster noch
+"xastir &" einzugeben. Auf anderen Systemen muÃŸ "/usr/local/bin/xastir &"
+eingegeben werden, um das Programm zu starten. Das '&' sorgt dafÃ¼r, daÃŸ
+Xastir im Hintergrund gestartet wir, so daÃŸ das Terminalfenster noch
 anderweitig verwendet werden kann.
 
-Sie können beim Aufruf auch gleich die Sprache wählen. Um die Sprache zu
-ändern, rufen sie Xastir mit der Option -l auf:
+Sie kÃ¶nnen beim Aufruf auch gleich die Sprache wÃ¤hlen. Um die Sprache zu
+Ã¤ndern, rufen sie Xastir mit der Option -l auf:
 
     xastir -lGerman
 
-Weitere Möglichkeiten sind: 
+Weitere MÃ¶glichkeiten sind: 
     xastir -l Dutch 
     xastir -l English 
     xastir -l French 
@@ -365,15 +365,15 @@ Weitere Möglichkeiten sind:
     xastir -l PigLatin
     xastir -l PirateEnglish
 
-Die so gewählte Sprache wird in der Konfigurationsdatei des Benutzers
-gespeichert und auch beim nächsten Aufruf ohne diese Option verwendet.
+Die so gewÃ¤hlte Sprache wird in der Konfigurationsdatei des Benutzers
+gespeichert und auch beim nÃ¤chsten Aufruf ohne diese Option verwendet.
 Bei einem neu installierten Xastir ist die Voreinstellung Englisch
-bis zu einer Änderung mit dieser Option.
+bis zu einer Ã„nderung mit dieser Option.
 
-Die Menus am oberen Rand können auch mit Tastenkürzeln erreicht werden.
+Die Menus am oberen Rand kÃ¶nnen auch mit TastenkÃ¼rzeln erreicht werden.
 Diese funktionieren gegebenenfalls nicht, wenn NumLock eingeschaltet ist.
 
-Vor der Benutzung muß Xastir und einige Schnittstellen konfiguriert
+Vor der Benutzung muÃŸ Xastir und einige Schnittstellen konfiguriert
 werden. Die Schnittstellenkonfiguration ist detailliert in der Hilfe
 unter "Schnittstellen" beschrieben.
 
@@ -386,71 +386,71 @@ Klicken sie auf Datei, Einstellungen, dann auf Meine Stationsdaten
 Tragen sie ihr Amateurfunk-Rufzeichen ein.
 
 Tragen sie die Position ihrer Station ein, wenn sie Xastir nicht
-zusammen mit einem GPS-Empfänger einsetzen. Sie können ihre ungefähre
+zusammen mit einem GPS-EmpfÃ¤nger einsetzen. Sie kÃ¶nnen ihre ungefÃ¤hre
 Position auch mit einer Karte in Xastir bestimmen indem sie die Maus
 auf der Karte plazieren und die Position in der Statuszeile ablesen.
-Wenn sie einen GPS-Empfänger haben können sie diesen Schritt
-überspringen und stattdessen später den GPS-Empfänger einrichten.
+Wenn sie einen GPS-EmpfÃ¤nger haben kÃ¶nnen sie diesen Schritt
+Ã¼berspringen und stattdessen spÃ¤ter den GPS-EmpfÃ¤nger einrichten.
 
-Wählen sie ein Symbol für ihre Station, hierzu ist die Angabe der
-Gruppe und des eigentlichen Symbolzeichens erforderlich. Sie können
-dies manuell eintragen, oder nach Drücken auf Auswahl aus einer
-grafischen Symbolübersicht auswählen. Es stehen zwei Gruppen von
-Symbolen zur Verfügung. Eine Beschreibung der Symbolbedeutung findet
+WÃ¤hlen sie ein Symbol fÃ¼r ihre Station, hierzu ist die Angabe der
+Gruppe und des eigentlichen Symbolzeichens erforderlich. Sie kÃ¶nnen
+dies manuell eintragen, oder nach DrÃ¼cken auf Auswahl aus einer
+grafischen SymbolÃ¼bersicht auswÃ¤hlen. Es stehen zwei Gruppen von
+Symbolen zur VerfÃ¼gung. Eine Beschreibung der Symbolbedeutung findet
 sich im Hilfetext "Symboltabelle". 
 
-Für einige Symbole der sekundären Gruppe kann auch ein Overlay
+FÃ¼r einige Symbole der sekundÃ¤ren Gruppe kann auch ein Overlay
 spezifiziert werden. Hierbei wird das Symbol zusammen mit dem
 Overlay-Zeichen dargestellt, z.B. ein Autosymbol mit der Zahl 1.
 
-Um Overlays zu nutzen müssen sie ein Symbol der sekundären Gruppe wählen
-und das gewünschte Überlagerungszeichen in das Feld Gruppe/Overlay
-eintragen. Nur Zahlen und Großbuchstaben sind als Overlay zulässig.
-Nach den APRS-Spezifikationen kann nicht jedes Symbol überlagert werden,
-aber Xastir erzwingt dies nicht, wie möglicherweise andere Programme.
-Beachten sie, daß bisher auch nicht alle Symbole belegt sind und manche
+Um Overlays zu nutzen mÃ¼ssen sie ein Symbol der sekundÃ¤ren Gruppe wÃ¤hlen
+und das gewÃ¼nschte Ãœberlagerungszeichen in das Feld Gruppe/Overlay
+eintragen. Nur Zahlen und GroÃŸbuchstaben sind als Overlay zulÃ¤ssig.
+Nach den APRS-Spezifikationen kann nicht jedes Symbol Ã¼berlagert werden,
+aber Xastir erzwingt dies nicht, wie mÃ¶glicherweise andere Programme.
+Beachten sie, daÃŸ bisher auch nicht alle Symbole belegt sind und manche
 eventuell nicht ganz den APRS-Spezifikationen entsprechen.
 
-Tragen sie als nächstes die Daten für Leistung, Höhe, Gewinn und
-Vorzugsrichtung für ihre Station ein. Es ist eine sinnvolle Information
-wird aber nicht unbedingt benötigt. Wählen sie einfach "Kein PHG", wenn
+Tragen sie als nÃ¤chstes die Daten fÃ¼r Leistung, HÃ¶he, Gewinn und
+Vorzugsrichtung fÃ¼r ihre Station ein. Es ist eine sinnvolle Information
+wird aber nicht unbedingt benÃ¶tigt. WÃ¤hlen sie einfach "Kein PHG", wenn
 sie diese Daten nicht aussenden wollen. Diese Einstellungen geben eine
-grobe Vorstellung von der Reichweite ihrer Station. Wählen sie die Werte,
-die den ihren am nächsten kommen.
+grobe Vorstellung von der Reichweite ihrer Station. WÃ¤hlen sie die Werte,
+die den ihren am nÃ¤chsten kommen.
 
-Eine andere Möglichkeit wäre es, stattdessen die Reichweite RNG in
-Meilen im Kommentar zu spezifizieren. Für Details ziehen sie bitte
+Eine andere MÃ¶glichkeit wÃ¤re es, stattdessen die Reichweite RNG in
+Meilen im Kommentar zu spezifizieren. FÃ¼r Details ziehen sie bitte
 die APRS-Spezifikationen zu Rate.
 
-Benutzen sie hier bitte die nicht die Höhe über dem Boden oder
-Meereshöhe, sondern die Höhe gegenüber dem durchschnittlichen Gelände.
-Die Angabe ist in Fuß, Meter müssen mit 3,28 multipliziert werden.
+Benutzen sie hier bitte die nicht die HÃ¶he Ã¼ber dem Boden oder
+MeereshÃ¶he, sondern die HÃ¶he gegenÃ¼ber dem durchschnittlichen GelÃ¤nde.
+Die Angabe ist in FuÃŸ, Meter mÃ¼ssen mit 3,28 multipliziert werden.
 
 Als Gewinn tragen sie den Antennengewinn in dBi ein.
 
-Anmerkung: Die Angabe des Gewinns ist primär für Vertikalantennen
-gedacht, für Beams sollten kleinere Werte eingetragen werden. Die Grund
-hierfür ist, daß bei gesetzter Vorzugsrichtung, die Ellipse für die
-Reichweite nur um ein Drittel in die angegebene Richtung vergrößert wird.
-Wird der Gewinn eines Beams größer angegeben, so wird nur die
-Reichweitenmarkierung unrealistisch groß, statt daß die deren
-Richtwirkung erhöht würde.
+Anmerkung: Die Angabe des Gewinns ist primÃ¤r fÃ¼r Vertikalantennen
+gedacht, fÃ¼r Beams sollten kleinere Werte eingetragen werden. Die Grund
+hierfÃ¼r ist, daÃŸ bei gesetzter Vorzugsrichtung, die Ellipse fÃ¼r die
+Reichweite nur um ein Drittel in die angegebene Richtung vergrÃ¶ÃŸert wird.
+Wird der Gewinn eines Beams grÃ¶ÃŸer angegeben, so wird nur die
+Reichweitenmarkierung unrealistisch groÃŸ, statt daÃŸ die deren
+Richtwirkung erhÃ¶ht wÃ¼rde.
 
-Bei der Angabe einer Vorzugsrichtung ihrer Antenne wären z.B. 90° eine
+Bei der Angabe einer Vorzugsrichtung ihrer Antenne wÃ¤ren z.B. 90Â° eine
 Antenne, die nach Osten weist.
 
 Geben sie einen Kommentar ein, dies ist nicht notwendig, erlaubt aber
-die Übermittlung sinnvoller Informationen, wie z.B. den Namen und die
-E-Mail-Adresse. Es wird zusammen mit den Positionsmeldungen übertragen.
+die Ãœbermittlung sinnvoller Informationen, wie z.B. den Namen und die
+E-Mail-Adresse. Es wird zusammen mit den Positionsmeldungen Ã¼bertragen.
 
 Die Positionsverschleierung erlaubt ihnen einszustellen, wie genau ihre
-Position übermittelt wird. Bei "Keine" werden die exakten eingetragenen
-oder vom GPS empfangenen Daten ausgesendet. Die anderen Möglichkeiten
-setzen die übermittelte Position irgendwo in den gewählten Bereich.
+Position Ã¼bermittelt wird. Bei "Keine" werden die exakten eingetragenen
+oder vom GPS empfangenen Daten ausgesendet. Die anderen MÃ¶glichkeiten
+setzen die Ã¼bermittelte Position irgendwo in den gewÃ¤hlten Bereich.
 Einige Stationen, die nicht ganz den Spezifikationen entsprechen,
 verstehen jedoch keine Positionsverschleierung, so z.B. auch findu.com.
 
-Bei einem Klick auf OK werden die Änderungen gesichert, bei Abbrechen
+Bei einem Klick auf OK werden die Ã„nderungen gesichert, bei Abbrechen
 bleiben die vorherigen Einstellungen erhalten.
 
 HELP-INDEX>Grundeinstellungen
@@ -459,55 +459,55 @@ HELP-INDEX>Grundeinstellungen
 
 Klicken sie auf Datei, Einstellungen, dann auf Grundeinstellungen
 
-Auf dieser Seite werden einige Standardwerte für den Programmablauf
+Auf dieser Seite werden einige Standardwerte fÃ¼r den Programmablauf
 eingestellt. Alte Stationen werden nach einiger Zeit schemenhaft
-dargestellt und die zugehörigen Spuren gestrichelt.
+dargestellt und die zugehÃ¶rigen Spuren gestrichelt.
 
 In der ersten Zeile wird festgelegt, nach welcher Zeit eine Station nur
-noch schemenhaft angezeigt wird. In der nächsten Zeile wird festgelegt,
+noch schemenhaft angezeigt wird. In der nÃ¤chsten Zeile wird festgelegt,
 nach welcher Zeit eine Station ganz vom Bildschirm verschwindet. Nach
 dem Doppelten dieser Zeit wird die Station dann auch aus den internen
-Datenbanken gelöscht.
+Datenbanken gelÃ¶scht.
 
-Die dritte Zeile legt fest, in welchen Abständen die eigene Position
-übermittelt wird. Für Feststationen sind 30 Minuten ein guter Wert, es
-sollten auf alle Fälle nicht unter 10 Minuten sein. Bei Mobilstationen
-kann ein kürzeres Intervall sinnvoll sein. Diese Einstellung wird auch
+Die dritte Zeile legt fest, in welchen AbstÃ¤nden die eigene Position
+Ã¼bermittelt wird. FÃ¼r Feststationen sind 30 Minuten ein guter Wert, es
+sollten auf alle FÃ¤lle nicht unter 10 Minuten sein. Bei Mobilstationen
+kann ein kÃ¼rzeres Intervall sinnvoll sein. Diese Einstellung wird auch
 verwendet, um Objekte und Items wiederholt zu senden. Versuchen sie hier
-eine sinnvolle Einstellung zu finden, um nicht zu viel unnötigen Verkehr
+eine sinnvolle Einstellung zu finden, um nicht zu viel unnÃ¶tigen Verkehr
 zu produzieren.
 
 GPS Zeit legt das Zeitintervall fest, nach dem nach neuen GPS Daten
-geschaut wird. Diese Option ist für Stationen mit gemeinsamen Zugriff
-auf TNC und GPS über ein HSP-Kabel.
+geschaut wird. Diese Option ist fÃ¼r Stationen mit gemeinsamen Zugriff
+auf TNC und GPS Ã¼ber ein HSP-Kabel.
 
 Mit dem Sendeformat der Station wird festgelegt, welche Art von Paketen
 die Station sendet.
 
-IGate Options ermöglicht die Errichtung einer Brücke zwischen Internet
+IGate Options ermÃ¶glicht die Errichtung einer BrÃ¼cke zwischen Internet
 und Funk. Diese Option sollte mit Vorsicht benutzt werden. Als
-Fumkamateur sind sie selbst dafür verantwortlich, was aus dem Internet
-kommt und über ihre Funkanlage ausgesendet wird. Sie müssen außerdem bei
+Fumkamateur sind sie selbst dafÃ¼r verantwortlich, was aus dem Internet
+kommt und Ã¼ber ihre Funkanlage ausgesendet wird. Sie mÃ¼ssen auÃŸerdem bei
 jeder Schnittstelle eine IGate-Einstellung machen, damit dies
-funktioniert. Wenn sie wollen, daß ihr IGate NWS Wetterwarnungen über
-Funk weitergibt, müssen sie eine Datei ~/.xastir/data/nws-stations.txt
-anlegen, in der alle Stationen aufgeführt sind (wie z.B. "PHISVR"),
-deren Daten sie über Funk weiterreichen wollen.
+funktioniert. Wenn sie wollen, daÃŸ ihr IGate NWS Wetterwarnungen Ã¼ber
+Funk weitergibt, mÃ¼ssen sie eine Datei ~/.xastir/data/nws-stations.txt
+anlegen, in der alle Stationen aufgefÃ¼hrt sind (wie z.B. "PHISVR"),
+deren Daten sie Ã¼ber Funk weiterreichen wollen.
 
 Bei Aktivierung von "Sende komprimierte Position" wird die Position in
 einem neueren, komprimierten Format gesendet. Hierdurch werden die
-gesendeten Pakete kürzer, so daß die Kapazität des APRS(tm) Netzwerks
-steigt. Die maximale Auflösung der gesendeten Position ist ebenfalls
-höher. Allerdings können einige ältere Programme, einschließlich
-kürzlich erschienener Versionen von WinAPRS, dieses Format noch nicht
+gesendeten Pakete kÃ¼rzer, so daÃŸ die KapazitÃ¤t des APRS(tm) Netzwerks
+steigt. Die maximale AuflÃ¶sung der gesendeten Position ist ebenfalls
+hÃ¶her. Allerdings kÃ¶nnen einige Ã¤ltere Programme, einschlieÃŸlich
+kÃ¼rzlich erschienener Versionen von WinAPRS, dieses Format noch nicht
 dekodieren. Auch findu.com kann damit Probleme haben.
 
-Wenn "Sende Wetter Rohdaten" gewählt wurde, werden auch Pakete gesendet,
-die unverarbeitete Wetterstationsdaten enthalten. Dies ist nützlich für
+Wenn "Sende Wetter Rohdaten" gewÃ¤hlt wurde, werden auch Pakete gesendet,
+die unverarbeitete Wetterstationsdaten enthalten. Dies ist nÃ¼tzlich fÃ¼r
 Wetterstationen mit ASCII-Daten, wie Peet Bros. Wetterstationen.
 
-Sie können außerdem Alternatives Netz aktivieren, und dort ein eigenes
-Kürzel eintragen. Alternatives Netz erlaubt ihnen damit, ein privates
+Sie kÃ¶nnen auÃŸerdem Alternatives Netz aktivieren, und dort ein eigenes
+KÃ¼rzel eintragen. Alternatives Netz erlaubt ihnen damit, ein privates
 APRS-Netzwerk aufzubauen, mit Stationen, die ebenfalls Alternatives
 Netz aktiviert haben und das gleiche Rufzeichen benutzen.
 
@@ -517,26 +517,26 @@ HELP-INDEX>Audio Alarm
 
 Klicken sie auf Datei, Einstellungen, dann Audio Alarm.
 
-Um diese Option zu nutzen, benötigen sie eine Soundkarte und ein
+Um diese Option zu nutzen, benÃ¶tigen sie eine Soundkarte und ein
 Programm, das Audiodateien im WAV-Format abspielt. Tragen sie als
-Kommando dieses Programm ein und eventuell benötigte Kommandozeilen-
-parameter. Das ganze funktioniert natürlich nicht, wenn die einzige
-Soundkarte im System für ein Soundmodem benutzt wird...
+Kommando dieses Programm ein und eventuell benÃ¶tigte Kommandozeilen-
+parameter. Das ganze funktioniert natÃ¼rlich nicht, wenn die einzige
+Soundkarte im System fÃ¼r ein Soundmodem benutzt wird...
 
-Für verschiedene Ereignisse kann eine Datei eingetragen werden, z.B. eine
-wav-Datei, die abgespielt werden soll. Bei einigen Ereignissen können
-zusätzliche Parameter geändert werden. Für jedes Ereignis kann einzeln
+FÃ¼r verschiedene Ereignisse kann eine Datei eingetragen werden, z.B. eine
+wav-Datei, die abgespielt werden soll. Bei einigen Ereignissen kÃ¶nnen
+zusÃ¤tzliche Parameter geÃ¤ndert werden. FÃ¼r jedes Ereignis kann einzeln
 festgelegt werden, ob eine akustische Meldung erfolgen soll.
 
-Momentan steht zur Verfügung:
+Momentan steht zur VerfÃ¼gung:
 Abspielen einer Ansage beim Auftauchen einer neuen Station
 Abspielen einer Ansage bei einer neuen Nachricht
 Abspielen einer Ansage, wenn Daten von einer Station empfangen
-     werden, die sich innerhalb einer min/max Entfernung gemäß den
-     Annäherungs-Einstellungen befindet
-Abspielen einer Ansage, wenn Daten von einer Station über TNC
+     werden, die sich innerhalb einer min/max Entfernung gemÃ¤ÃŸ den
+     AnnÃ¤herungs-Einstellungen befindet
+Abspielen einer Ansage, wenn Daten von einer Station Ã¼ber TNC
      empfangen werden, die sich innerhalb einer min/max Entfernung
-     gemäß den Bandöffnungs-Einstellungen befindet
+     gemÃ¤ÃŸ den BandÃ¶ffnungs-Einstellungen befindet
 Abspielen einer Ansage bei einer Wetterwarnung
 
 
@@ -546,47 +546,47 @@ HELP-INDEX>Sprachausgabe
 
 Klicken sie auf Datei, Einstellungen, dann Sprachausgabe.
 
-Um diese Option zu nutzen, benötigen sie neben einer Soundkarte die
+Um diese Option zu nutzen, benÃ¶tigen sie neben einer Soundkarte die
 'Festival' Sprachsynthese Software. Installieren sie Festival und starten
-sie es als Server bevor sie Xastir aufrufen. Das Kommando hierfür heißt
-üblicherweise "festival --server &".
+sie es als Server bevor sie Xastir aufrufen. Das Kommando hierfÃ¼r heiÃŸt
+Ã¼blicherweise "festival --server &".
 
-Nachdem Festival installiert ist, kann Xastir für folgende Fälle eine
+Nachdem Festival installiert ist, kann Xastir fÃ¼r folgende FÃ¤lle eine
 Sprachausgabe vornehmen:
 
 o Ansagen des Rufzeichens einer neuen Station.
 
-o Ansagen, daß eine neue Nachricht eingetroffen ist.
+o Ansagen, daÃŸ eine neue Nachricht eingetroffen ist.
 
 o Den Text einer Nachricht vorlesen.
 
 o Eine Ansage, wenn Daten von einer Station empfangen wurden, die sich
-  innerhalb einer min/max Entfernung gemäß den
-  Annäherungs-Einstellungen (siehe Audio Alarm) befindet.
+  innerhalb einer min/max Entfernung gemÃ¤ÃŸ den
+  AnnÃ¤herungs-Einstellungen (siehe Audio Alarm) befindet.
 
-o Eine Ansage, wenn Daten von einer Station über TNC empfangen werden,
+o Eine Ansage, wenn Daten von einer Station Ã¼ber TNC empfangen werden,
   die sich innerhalb einer min/max Entfernung
-  gemäß den Bandöffnungs-Einstellungen (siehe Audio Alarm) befindet.
+  gemÃ¤ÃŸ den BandÃ¶ffnungs-Einstellungen (siehe Audio Alarm) befindet.
 
-o Die Ansage einer Wetterwarnung ist bisher noch nicht verfügbar.
+o Die Ansage einer Wetterwarnung ist bisher noch nicht verfÃ¼gbar.
 
-Informationen zu Festival erhalten sie über:
+Informationen zu Festival erhalten sie Ã¼ber:
   http://www.speech.cs.cmu.edu/festival/
 
-HELP-INDEX>Maßeinheiten
+HELP-INDEX>MaÃŸeinheiten
 
-                             Maßeinheiten
+                             MaÃŸeinheiten
 
 Als Standardeinstellung wird das metrische System mit mm, cm, m, km,
-km/h, usw. verwendet. Wenn sie englische Maßeinheiten bevorzugen,
-klicken sie auf Datei, Einstellungen und aktivieren sie Englische Maße,
-um Zoll, Fuß, mph, usw. anzuzeigen.
+km/h, usw. verwendet. Wenn sie englische MaÃŸeinheiten bevorzugen,
+klicken sie auf Datei, Einstellungen und aktivieren sie Englische MaÃŸe,
+um Zoll, FuÃŸ, mph, usw. anzuzeigen.
 
 HELP-INDEX>Einstellungen sichern
 
                          Einstellungen sichern
 
-Über Datei, Einstellungen, Einstellungen sichern können alle
+Ãœber Datei, Einstellungen, Einstellungen sichern kÃ¶nnen alle
 vorgenommenen Einstellungen sofort in der Konfigurationsdatei gespeichert
 werden. Aber auch beim Verlassen des Programms werden die Einstellungen
 gespeichert.
@@ -599,7 +599,7 @@ Am unteren Rand des Bildschirms werden verschiedene Statusmeldungen
 dargestellt:
 
 Im ersten Feld (links) werden allgemeine Statusmeldungen angezeigt, sie
-werden nach kurzer Zeit wieder gelöscht.
+werden nach kurzer Zeit wieder gelÃ¶scht.
 
 Das zweite Feld zeigt bei Mausbewegungen die aktuelle Position auf der
 Karte unter dem Mauszeiger an.
@@ -610,19 +610,19 @@ der Datenbank an.
 Das vierte Feld zeigt den aktuellen Zoomstatus an und ein "Tr", wenn eine
 Station verfolgt wird (Tracking).
 
-Das letzte Feld zeigt mit Symbolen den Status für jedes Gerät an, wobei
-die Schnittstellen von links nach rechts (0 bis 9) gezählt werden. Der
-Status wird vertikal in drei Bereiche unterteilt. Oben Art des Geräts,
-in der Mitte der Datenfluß und unten der Betriebszustand.
+Das letzte Feld zeigt mit Symbolen den Status fÃ¼r jedes GerÃ¤t an, wobei
+die Schnittstellen von links nach rechts (0 bis 9) gezÃ¤hlt werden. Der
+Status wird vertikal in drei Bereiche unterteilt. Oben Art des GerÃ¤ts,
+in der Mitte der DatenfluÃŸ und unten der Betriebszustand.
 
-Die Art des Geräts kann anhand der Farbe unterschieden werden. Blau steht
-für die verschiedenen TNC Geräte, grün sind GPS-Empfänger, gelb Internet
+Die Art des GerÃ¤ts kann anhand der Farbe unterschieden werden. Blau steht
+fÃ¼r die verschiedenen TNC GerÃ¤te, grÃ¼n sind GPS-EmpfÃ¤nger, gelb Internet
 Server und orange Wetterstationen.
 
 In der Mitte zeigt ein links weisender Pfeil empfangene Daten an, ein
-rechtsweisender Pfeil steht für über dieses Gerät gesendete Daten.
+rechtsweisender Pfeil steht fÃ¼r Ã¼ber dieses GerÃ¤t gesendete Daten.
 
-Ein grünes Rechteck im unteren Bereich zeigt, daß diese Schnittstelle
+Ein grÃ¼nes Rechteck im unteren Bereich zeigt, daÃŸ diese Schnittstelle
 aktiviert ist. Ein rotes Rechteck deutet auf eine aktive Schnittstelle
 hin, bei der aber ein Fehler aufgetreten ist. Anderenfalls wird nichts
 angezeigt, wenn die Schnittstelle nicht aktiv ist.
@@ -632,203 +632,203 @@ HELP-INDEX>Verschieben der Karte und Mauszeiger-Menu
                   Verschieben der Karte und Mauszeiger-Menu        
 
 Das Verschieben der Karte ist sehr einfach, die Geschwindigkeit des
-Bildaufbaus hängt jedoch von der Rechnerleistung und dem Umfang der zu
+Bildaufbaus hÃ¤ngt jedoch von der Rechnerleistung und dem Umfang der zu
 ladenden Kartendaten ab.
 
 Zoomen:
 Man kann in der Karte zoomen, indem man auf der Karte mit der rechten
-Maustaste klickt (und diese gedrückt hält). Es erscheint ein PopUp-Menu,
-mit der Möglichkeit, hinein oder heraus zu zoomen, oder auf eine der
+Maustaste klickt (und diese gedrÃ¼ckt hÃ¤lt). Es erscheint ein PopUp-Menu,
+mit der MÃ¶glichkeit, hinein oder heraus zu zoomen, oder auf eine der
 vordefinierten Skalierungsfaktoren zu wechseln.
 
 Die Zoom-Funktionen zentrieren die Karte gleichzeitig an dem Punkt, an
-dem die rechte Maustaste gedrückt wurde. Bei "Zoomebenen" erhält man ein
-Untermenu. Die Skalierungen 1-64 sind für die nähere Umgebung, während
-256 und höher größere Bereiche darstellen. Je kleiner die Zahl, umso
+dem die rechte Maustaste gedrÃ¼ckt wurde. Bei "Zoomebenen" erhÃ¤lt man ein
+Untermenu. Die Skalierungen 1-64 sind fÃ¼r die nÃ¤here Umgebung, wÃ¤hrend
+256 und hÃ¶her grÃ¶ÃŸere Bereiche darstellen. Je kleiner die Zahl, umso
 lokaler wird der Kartenausschnitt.
 
 Ein schnelleres Hineinzoomen in einen Kartenausschnitt kann mit der Maus
 erreicht werden, wenn man auf mit der linken Maustaste auf eine Ecke des
-gewünschten Ausschnitts klickt, bei gedrückter Maustaste zur
-gegenüberliegeden Ecke fährt und dort die Taste losläßt. Die Karte wird
-in der Mitte des gewählten Ausschnitts neu zentriert, für die Skalierung
-wird nur die Höhe des Ausschnitts verwendet, die Breite wird der
-Bildschirmgröße entsprechend angepaßt. Die Schaltknöpfe "Messen" und
-"Bewegen" dürfen hierfür nicht aktiviert sein.
+gewÃ¼nschten Ausschnitts klickt, bei gedrÃ¼ckter Maustaste zur
+gegenÃ¼berliegeden Ecke fÃ¤hrt und dort die Taste loslÃ¤ÃŸt. Die Karte wird
+in der Mitte des gewÃ¤hlten Ausschnitts neu zentriert, fÃ¼r die Skalierung
+wird nur die HÃ¶he des Ausschnitts verwendet, die Breite wird der
+BildschirmgrÃ¶ÃŸe entsprechend angepaÃŸt. Die SchaltknÃ¶pfe "Messen" und
+"Bewegen" dÃ¼rfen hierfÃ¼r nicht aktiviert sein.
 
-Weiterhin besteht die Möglichkeit die PgUp und PgDn Tasten zum Zoomen zu
+Weiterhin besteht die MÃ¶glichkeit die PgUp und PgDn Tasten zum Zoomen zu
 verwenden. Hierbei bleibt das Zentrum er Karte erhalten.
 
 Verschieben/Zentrieren:
-Die Karte kann bei gleicher Auflösung neu zentriert werden, indem man
+Die Karte kann bei gleicher AuflÃ¶sung neu zentriert werden, indem man
 mit der linken Maustaste auf das neue Zentrum klickt. Beim Klicken mit
-der mittleren Maustaste wird die Karte neu zentriert, außerdem wird die
-Auflösung durch Herauszoomen auf die Hälfte reduziert.
+der mittleren Maustaste wird die Karte neu zentriert, auÃŸerdem wird die
+AuflÃ¶sung durch Herauszoomen auf die HÃ¤lfte reduziert.
 
-Ein Verschieben kann über das Mauszeiger-Menu oder durch die Pfeile am
+Ein Verschieben kann Ã¼ber das Mauszeiger-Menu oder durch die Pfeile am
 oberen Bildschirmrand erfolgen. Die Karte wird nur um einen Teil der
-Bildschirmgröße verschoben, so daß genügend Daten bestehen bleiben, um
+BildschirmgrÃ¶ÃŸe verschoben, so daÃŸ genÃ¼gend Daten bestehen bleiben, um
 sich wieder zurechtzufinden. Auch die Cursortasten verschieben die Karte.
 
 Informationen zum Mauszeiger-Menu:
-"Stationsinfo" versucht zunächst die Station zu finden, die der Stelle,
-an der die rechte Maustaste gedrückt wurde, am nächsten liegt. Befinden
-sich dort mehrere Stationen, so kommt zunächst ein PopUp-Fenster mit
-einer Stationsliste, aus der man die gewünschte wählen kann. Danach, oder
-wenn nur eine Station direkt in unmittelbarer Nähe ist, öffnet ein
+"Stationsinfo" versucht zunÃ¤chst die Station zu finden, die der Stelle,
+an der die rechte Maustaste gedrÃ¼ckt wurde, am nÃ¤chsten liegt. Befinden
+sich dort mehrere Stationen, so kommt zunÃ¤chst ein PopUp-Fenster mit
+einer Stationsliste, aus der man die gewÃ¼nschte wÃ¤hlen kann. Danach, oder
+wenn nur eine Station direkt in unmittelbarer NÃ¤he ist, Ã¶ffnet ein
 Fenster mit verschiedenen Daten zu dieser Station. Bei Mobilstationen mit
-vielen Daten kann dies auf langsamen Computern etwas Zeit benötigen. Um
-alte Stationen zu sehen, kann vorübergehend "Alte Daten zeigen" im Menu
+vielen Daten kann dies auf langsamen Computern etwas Zeit benÃ¶tigen. Um
+alte Stationen zu sehen, kann vorÃ¼bergehend "Alte Daten zeigen" im Menu
 "Ansicht" eingeschaltet werden.
 
-Über den Menupunkt "Letzte Ansicht" kann der vorherigen Kartenausschnitt
+Ãœber den Menupunkt "Letzte Ansicht" kann der vorherigen Kartenausschnitt
 wieder hergestellt werden.
 
-Für Informationen zu Objekten siehe den Hilfetext "Objekte und Items"
+FÃ¼r Informationen zu Objekten siehe den Hilfetext "Objekte und Items"
 
 HELP-INDEX>Objekte und Items
 
                           Objekte und Items
 
 Eine Station kann verschiedene Objekte auf der Karte setzen, deren
-Position auch über Funk an andere Stationen weitergegeben wird. Bei den
-Namen für Objekte bestehen nicht so viele Einschränkungen wie für die
+Position auch Ã¼ber Funk an andere Stationen weitergegeben wird. Bei den
+Namen fÃ¼r Objekte bestehen nicht so viele EinschrÃ¤nkungen wie fÃ¼r die
 Stationsnamen.
 
-Objekte und Items sind ziemlich das gleiche, sie werden manchmal für
-etwas unterschiedliche Zwecke angewandt. Objekte werden oft für
-bewegliche oder veränderliche Dinge eingsetzt, wie z.B. Wirbelstürme,
-während Items im Allgemeinen für unbewegliche Dinge, z.B. eine
+Objekte und Items sind ziemlich das gleiche, sie werden manchmal fÃ¼r
+etwas unterschiedliche Zwecke angewandt. Objekte werden oft fÃ¼r
+bewegliche oder verÃ¤nderliche Dinge eingsetzt, wie z.B. WirbelstÃ¼rme,
+wÃ¤hrend Items im Allgemeinen fÃ¼r unbewegliche Dinge, z.B. eine
 Wasserstation, eingesetzt werden. Da Items von einigen APRS-Programmen
-nicht dekodiert werden können, werden aber oftmals auch unbewegliche
+nicht dekodiert werden kÃ¶nnen, werden aber oftmals auch unbewegliche
 Objekte verwendet.
 
-Über das Mauszeiger-Menu hat man Zugriff zu "Objekt Neu" und "Objekt
-ändern. Maßgeblich für das Objekt ist dabei die Position des Mauszeigers
+Ãœber das Mauszeiger-Menu hat man Zugriff zu "Objekt Neu" und "Objekt
+Ã¤ndern. MaÃŸgeblich fÃ¼r das Objekt ist dabei die Position des Mauszeigers
 bei Aufruf des Mauszeiger-Menus.
 
 Neben normalen Objekten mit einem Symbol an der Position gibt es noch
-spezielle Objekte. Flächenobjekte sind geeignet, wenn es darum geht einen
-größeren Bereich auf der Karte zu markieren. Man kann damit auch Wege,
-Straßen oder Grenzen zeichnen, ein Suchgebiet abstecken, oder wenn es
-sein muß auch ein Schachbrett um über APRS zu spielen :-) Beachten sie,
-daß Flächenobjekte nicht in allen APRS-Programmen implementiert sind und
+spezielle Objekte. FlÃ¤chenobjekte sind geeignet, wenn es darum geht einen
+grÃ¶ÃŸeren Bereich auf der Karte zu markieren. Man kann damit auch Wege,
+StraÃŸen oder Grenzen zeichnen, ein Suchgebiet abstecken, oder wenn es
+sein muÃŸ auch ein Schachbrett um Ã¼ber APRS zu spielen :-) Beachten sie,
+daÃŸ FlÃ¤chenobjekte nicht in allen APRS-Programmen implementiert sind und
 wenn, dann auch teilweise unterschiedlich dargestellt werden. Die anderen
 beiden, Signpost und Peil-Objekte werden weiter unten beschrieben.
 
-Objekte werden in den gleichen Abständen wie die eigenen Stationsdaten,
+Objekte werden in den gleichen AbstÃ¤nden wie die eigenen Stationsdaten,
 die in "Datei-Einstellungen-Grundeinstellungen" festgelegt sind,
 wiederholt ausgesendet, insgesamt bis zum Doppelten der ebenfalls dort
-definierten Anzeigezeit für Stationen. Auch gelöschte Objekte werden
+definierten Anzeigezeit fÃ¼r Stationen. Auch gelÃ¶schte Objekte werden
 wiederholt gesendet, bis sie in der Datenbank auslaufen.
 
 
-Bei "Objekt Neu" wird die Position, an der das Mauszeiger-Menu geöffnet
-wurde, als Vorgabe für ein neu zu erstellendes Objekt verwendet. Nach
-Eingabe eines Namens kann man ein anderes Symbol für das Objekt wählen,
-einen Kommentar eintragen und es über das Menu ein neues Objekt oder
+Bei "Objekt Neu" wird die Position, an der das Mauszeiger-Menu geÃ¶ffnet
+wurde, als Vorgabe fÃ¼r ein neu zu erstellendes Objekt verwendet. Nach
+Eingabe eines Namens kann man ein anderes Symbol fÃ¼r das Objekt wÃ¤hlen,
+einen Kommentar eintragen und es Ã¼ber das Menu ein neues Objekt oder
 Item erstellen.
 
-Bei "Objekt Ändern" erhält man einen ähnlichen Dialog, bei dem allerdings
+Bei "Objekt Ã„ndern" erhÃ¤lt man einen Ã¤hnlichen Dialog, bei dem allerdings
 die Daten des Objekt an der Position des Mauszeigers bereits eingetragen
-sind. Einige Daten, wie z.B. der Objektname, können nicht geändert
-werden. Hierüber ist auch das Löschen eines Objekts möglich.
+sind. Einige Daten, wie z.B. der Objektname, kÃ¶nnen nicht geÃ¤ndert
+werden. HierÃ¼ber ist auch das LÃ¶schen eines Objekts mÃ¶glich.
 
-Objekte und Items können auch mit der Maus auf der Karte verschoben
+Objekte und Items kÃ¶nnen auch mit der Maus auf der Karte verschoben
 werden, wenn der Schaltknopf "Bewegen" auf der oberen Leiste aktiviert
 ist.
 
-Erläuterung der einzelnen Einträge im Objekt-Dialog:
+ErlÃ¤uterung der einzelnen EintrÃ¤ge im Objekt-Dialog:
 
 = Signpost-Objekt =
 Durch Aktivieren wird aus dem Objekt ein Signpost-Objekt, auf einem
-Hinweisschild können drei Zeichen dargestellt werden, die sichtbar
+Hinweisschild kÃ¶nnen drei Zeichen dargestellt werden, die sichtbar
 werden, wenn an der betreffenden Position hineingezoomt wird. Hinweis:
 Das funktioniert SO noch nicht...
 
-= Flächenobjekt =
-Hierdurch wird das Objekt als ein Flächenobjekt definiert, zusätzlich
-werden die unten erläuterten Steuerfunktionen für Flächenobjekte
+= FlÃ¤chenobjekt =
+Hierdurch wird das Objekt als ein FlÃ¤chenobjekt definiert, zusÃ¤tzlich
+werden die unten erlÃ¤uterten Steuerfunktionen fÃ¼r FlÃ¤chenobjekte
 eingeschaltet.
 
 = Peil-Objekt =
 Hierbei handelt es sich um eine Peilmeldung, die mit dem DF-Symbol
-markiert wird. Sie können zwischen einer Meldung mit Rundstrahl- oder
-Richtantenne wählen und die spezifischen Daten eintragen. Nähere Details
-über diese Techniken finden sich unter
+markiert wird. Sie kÃ¶nnen zwischen einer Meldung mit Rundstrahl- oder
+Richtantenne wÃ¤hlen und die spezifischen Daten eintragen. NÃ¤here Details
+Ã¼ber diese Techniken finden sich unter
    http://web.usna.navy.mil/~bruninga/dfing.html
 und in der APRSdos Dokumentation.
 
 = Name =
 Dies ist der Name des Objekts, der aus bis zu neun Zeichen bestehen kann,
-wobei auch Leerzeichen innerhalb des Namens zulässig sind. Beim Ändern
-eines Objekts kann der Name nicht mehr geändert werden. Falls trotzdem
-erforderlich, muß das Objekt zunächst gelöscht und dann mit neuem Namen
-neu erstellt werden. Wenn Sie das Objekt als Flächenobjekt, Signpost-
-oder Peil-Objekt definieren, wird der dann unnötige Name gelöscht.
+wobei auch Leerzeichen innerhalb des Namens zulÃ¤ssig sind. Beim Ã„ndern
+eines Objekts kann der Name nicht mehr geÃ¤ndert werden. Falls trotzdem
+erforderlich, muÃŸ das Objekt zunÃ¤chst gelÃ¶scht und dann mit neuem Namen
+neu erstellt werden. Wenn Sie das Objekt als FlÃ¤chenobjekt, Signpost-
+oder Peil-Objekt definieren, wird der dann unnÃ¶tige Name gelÃ¶scht.
 
 = Stations-Symbol =
-Wählen sie ein Symbol für das Objekt, hierzu ist die Angabe der
-Gruppe und des eigentlichen Symbolzeichens erforderlich. Sie können
-dies manuell eintragen, oder nach Drücken auf "Auswahl" aus einer
-grafischen Symbolübersicht auswählen. Es stehen zwei Gruppen von
-Symbolen zur Verfügung. Eine Beschreibung der Symbolbedeutung findet
-sich im Hilfetext "Symboltabelle". Bei Signpost-, Flächen- und
-Peil-Objekten läßt sich das Symbol nicht ändern.
+WÃ¤hlen sie ein Symbol fÃ¼r das Objekt, hierzu ist die Angabe der
+Gruppe und des eigentlichen Symbolzeichens erforderlich. Sie kÃ¶nnen
+dies manuell eintragen, oder nach DrÃ¼cken auf "Auswahl" aus einer
+grafischen SymbolÃ¼bersicht auswÃ¤hlen. Es stehen zwei Gruppen von
+Symbolen zur VerfÃ¼gung. Eine Beschreibung der Symbolbedeutung findet
+sich im Hilfetext "Symboltabelle". Bei Signpost-, FlÃ¤chen- und
+Peil-Objekten lÃ¤ÃŸt sich das Symbol nicht Ã¤ndern.
 
 = Position =
 Hier wird die Position des Objekts eingegeben. Wenn Sie ein neues Objekt
 erstellen, so wurde dort bereits die Position eingetragen, an der Sie
 mit der rechten Maustaste geklickt hatten, um das Mauszeiger-Menu
 aufzurufen. Wenn Sie das Objekt verschoben haben, so steht dort die neue
-Position. Sie können die Daten aber auch manuell eintragen, z.B. wenn
-Ihnen jemand eine Position über Sprechfunk durchgegeben hat.
+Position. Sie kÃ¶nnen die Daten aber auch manuell eintragen, z.B. wenn
+Ihnen jemand eine Position Ã¼ber Sprechfunk durchgegeben hat.
 
 = Allgemeine Optionen =
-Hier können Sie die Geschwindigkeit, die Bewegungsrichtung und die Höhe
+Hier kÃ¶nnen Sie die Geschwindigkeit, die Bewegungsrichtung und die HÃ¶he
 des Objekts eintragen. Bei einigen Objekten ist die Angabe von
-Geschwindigkeit und Richtung nicht möglich, die Felder sind dann in Grau
+Geschwindigkeit und Richtung nicht mÃ¶glich, die Felder sind dann in Grau
 dargestellt.
 
 = Signpost Text =
-Hier können Sie für ein Signpost-Objekt den Text (ein bis drei Zeichen)
-angeben, der auf dem Hinweisschild erscheinen soll. Beachten Sie, daß
+Hier kÃ¶nnen Sie fÃ¼r ein Signpost-Objekt den Text (ein bis drei Zeichen)
+angeben, der auf dem Hinweisschild erscheinen soll. Beachten Sie, daÃŸ
 Xastir Signpost-Objekte momentan noch nicht richtig anzeigt.
 
-= Flächenobjekt =
-Flächenobjekte werden eingesetzt, um spezielle Teile einer Karte
-herauszuheben oder zusätzliche Details zu zeichnen. Hierzu dienen die
-folgenden Einträge:
+= FlÃ¤chenobjekt =
+FlÃ¤chenobjekte werden eingesetzt, um spezielle Teile einer Karte
+herauszuheben oder zusÃ¤tzliche Details zu zeichnen. Hierzu dienen die
+folgenden EintrÃ¤ge:
 
   = Helle Farben =
-    Wenn aktiviert, werden hellere, sonst dunklere Farben für die Flächen
+    Wenn aktiviert, werden hellere, sonst dunklere Farben fÃ¼r die FlÃ¤chen
     verwendet.
 
-  = Flächen füllen =
-    Wenn markiert, werden die Flächen mit Objektfarbe gefüllt, ansonsten
+  = FlÃ¤chen fÃ¼llen =
+    Wenn markiert, werden die FlÃ¤chen mit Objektfarbe gefÃ¼llt, ansonsten
     wird nur die Umrandung dargestellt.
 
   = Objekt-Typ =
-    Verschiedene geometrische Grundformen können hier gewählt werden:
+    Verschiedene geometrische Grundformen kÃ¶nnen hier gewÃ¤hlt werden:
     Kreis/Ellipse, Linie nach rechts, Linie nach links, Dreieck, Rechteck
 
   = Objektfarbe =
-    Hier wird die Farbe gewählt in der das Objekt gezeichnet wird. Dies
+    Hier wird die Farbe gewÃ¤hlt in der das Objekt gezeichnet wird. Dies
     wird auch durch das Markieren von "Helle Farben" (siehe oben)
-    beeinflußt. Es stehen zur Verfügung:
-    Schwarz, Blau, Grün, Cyan, Rot, Violett, Gelb, Grau
+    beeinfluÃŸt. Es stehen zur VerfÃ¼gung:
+    Schwarz, Blau, GrÃ¼n, Cyan, Rot, Violett, Gelb, Grau
 
   = nach oben =
-    Ausdehnung des Flächenobjekts nach oben in 1/100 Grad. 
+    Ausdehnung des FlÃ¤chenobjekts nach oben in 1/100 Grad. 
 
   = nach links =
-    Ausdehnung des Flächenobjekts nach links in 1/100 Grad. 
+    Ausdehnung des FlÃ¤chenobjekts nach links in 1/100 Grad. 
 
   = Korridor =
     Gibt die Breite eines Linienobjekts an und wird in Meilen
     spezifiziert.
 
-Denken Sie daran, Ihre Objekte zu löschen, wenn sie nicht mehr benötigt
+Denken Sie daran, Ihre Objekte zu lÃ¶schen, wenn sie nicht mehr benÃ¶tigt
 werden. Anderenfalls werden sie wiederholt gesendet und erscheinen auf
 dem Bildschirm anderer Stationen bis sie verfallen.
 
@@ -836,55 +836,55 @@ HELP-INDEX>Listendarstellungen
 
                          Listendarstellungen
                          
-Über den Menupunkt "Zeige" können verschiedene Daten der Stationen meist
+Ãœber den Menupunkt "Zeige" kÃ¶nnen verschiedene Daten der Stationen meist
 in Form von Listen dargestellt werden.
 
 = Berichte =
-Berichte (bulletin boards) sind eine Möglichkeit, über APRS Nachrichten
-und wichtige Ankündigungen an alle zu senden. Wenn Sie mit dem Internet
+Berichte (bulletin boards) sind eine MÃ¶glichkeit, Ã¼ber APRS Nachrichten
+und wichtige AnkÃ¼ndigungen an alle zu senden. Wenn Sie mit dem Internet
 verbunden sind, ist es sinnvoll, den Einzugsbereich auf wenige 100km
 einzustellen um so Berichte aus anderen Teilen der Welt zu ignorieren.
-Der Eintrag einer '0' im Feld Bereich bedeutet keinerlei Einschränkungen,
+Der Eintrag einer '0' im Feld Bereich bedeutet keinerlei EinschrÃ¤nkungen,
 d.h. alle Berichte werden empfangen. Klicken Sie auf "neuen Bereich
-setzen" um den eingegebenen Wert zu übernehmen.
-Xastir unterstützt das Senden von Berichten momentan noch nicht.
+setzen" um den eingegebenen Wert zu Ã¼bernehmen.
+Xastir unterstÃ¼tzt das Senden von Berichten momentan noch nicht.
 
 = Packet Radio =
-Hier werden die über Packet Radio oder das Internet ankommenden Rohdaten
-dargestellt. Es kann gewählt werden, ob nur Daten vom TNC, nur
+Hier werden die Ã¼ber Packet Radio oder das Internet ankommenden Rohdaten
+dargestellt. Es kann gewÃ¤hlt werden, ob nur Daten vom TNC, nur
 Daten aus dem Internet, oder beides angezeigt werden soll.
 
 = Mobilstationen =
 Dies ist eine Liste von Stationen, die sich bewegen, typischerweise also
 Mobilstationen. Die Bedeutung des Symbols wird dabei ignoriert, es wird
 nur festgestellt, ob sich die Station bewegt. Die angezeigte Information
-umfaßt neben der letzten bekannten Position auch Geschwindigkeit,
-Bewegungsrichtung, Höhe, Anzahl der empfangenen Pakete, Anzahl der
+umfaÃŸt neben der letzten bekannten Position auch Geschwindigkeit,
+Bewegungsrichtung, HÃ¶he, Anzahl der empfangenen Pakete, Anzahl der
 sichtbaren Satelliten sowie Abstand und Richtung von unserer eigenen
 Station.
 
 = Alle Stationen =
 Hier wird eine Tabelle mit allen Stationen in alphabetischer Reihenfolge
-angezeigt. Es umfaßt auch die Anzahl der gehörten Pakete, die Zeit zu der
-die Station zuletzt gehört wurde, den Pfad, den das letzte Paket genommen
-hatte, PHG und natürlich den Kommentar.
+angezeigt. Es umfaÃŸt auch die Anzahl der gehÃ¶rten Pakete, die Zeit zu der
+die Station zuletzt gehÃ¶rt wurde, den Pfad, den das letzte Paket genommen
+hatte, PHG und natÃ¼rlich den Kommentar.
 
 = Lokale Stationen =
-Eine ähnliche Tabelle wie zuvor, allerdings werden nur Stationen
-angezeigt, die über den eigenen TNC gehört wurden.
+Eine Ã¤hnliche Tabelle wie zuvor, allerdings werden nur Stationen
+angezeigt, die Ã¼ber den eigenen TNC gehÃ¶rt wurden.
 
 = Letzte Stationen =
-Eine Liste mit allen Stationen in der Reihenfolge, in der sie gehört
-wurden. Die zuletzt gehörten Stationen stehen oben am Beginn der Liste.
-Angezeigt wird wiederum die Anzahl der gehörten Pakete, die Zeit zu der
-die Station zuletzt gehört wurde, den Pfad, den das letzte Paket genommen
+Eine Liste mit allen Stationen in der Reihenfolge, in der sie gehÃ¶rt
+wurden. Die zuletzt gehÃ¶rten Stationen stehen oben am Beginn der Liste.
+Angezeigt wird wiederum die Anzahl der gehÃ¶rten Pakete, die Zeit zu der
+die Station zuletzt gehÃ¶rt wurde, den Pfad, den das letzte Paket genommen
 hatte, PHG und der Kommentar.
 
 = Wetterstationen =
-Diese Liste umfaßt nur APRS Wetterstationen mit deren Daten. Aufgeführt
-werden Windgeschwindigkeit- und richtung, Geschwindigkeit von Böen, die
-Temperatur, die Luftfeuchtigkeit, den Druck, Regenmenge während der
-letzten Stunde, seit Mitternacht und während der letzten 24 Stunden.
+Diese Liste umfaÃŸt nur APRS Wetterstationen mit deren Daten. AufgefÃ¼hrt
+werden Windgeschwindigkeit- und richtung, Geschwindigkeit von BÃ¶en, die
+Temperatur, die Luftfeuchtigkeit, den Druck, Regenmenge wÃ¤hrend der
+letzten Stunde, seit Mitternacht und wÃ¤hrend der letzten 24 Stunden.
 
 = Eigene Wetterdaten =
 Wenn eine eigene Wetterstation vorhanden ist und in Xastir konfiguriert
@@ -895,13 +895,13 @@ Zeigt die empfangenen Wetterwarnungen des amerikanischen NWS an.
 
 = Nachrichten =
 Zeigt den Nachrichtenverkehr zwischen den verschiedenen Stationen solange
-das Fenster geöffnet ist. Dies beinhaltet Quelle und Ziel, über welche
-Schnittstelle sie lif und den Inhalt der Nachricht. Über "Bereich" kann
-die Anzeige auf Nachrichten von Stationen in der Umgebung beschränkt
+das Fenster geÃ¶ffnet ist. Dies beinhaltet Quelle und Ziel, Ã¼ber welche
+Schnittstelle sie lif und den Inhalt der Nachricht. Ãœber "Bereich" kann
+die Anzeige auf Nachrichten von Stationen in der Umgebung beschrÃ¤nkt
 werden, bei Eingabe von '0' werden alle Nachrichten angezeigt.
 
 = Laufzeit =
-Zeigt an, seit wie lange Xastir bereits läuft.
+Zeigt an, seit wie lange Xastir bereits lÃ¤uft.
 
 HELP-INDEX>Kartenauswahl und Einstellungen
 
@@ -910,10 +910,10 @@ HELP-INDEX>Kartenauswahl und Einstellungen
 = Kartenauswahl =
 Hiermit erhalten sie eine Liste aller Dateien im Kartenverzeichnis. Wenn
 sie einen Dateinamen markieren, so wird die Karte beim Klicken auf OK
-geladen und angezeigt, wenn sie in den aktuellen Bildauschnitt fällt.
-Sie können mehrere Karten gleichzeitig auswählen. Abbruch verwirft die
-Änderungen in der Kartenauswahl. Es gibt auch Buttons um alle Karten
-gleichzeitig abzuwählen oder bestimmte Kartentypen zu laden.
+geladen und angezeigt, wenn sie in den aktuellen Bildauschnitt fÃ¤llt.
+Sie kÃ¶nnen mehrere Karten gleichzeitig auswÃ¤hlen. Abbruch verwirft die
+Ã„nderungen in der Kartenauswahl. Es gibt auch Buttons um alle Karten
+gleichzeitig abzuwÃ¤hlen oder bestimmte Kartentypen zu laden.
 
 = Ausschnitte =
 Genaueres siehe im Hilfetext zu "Gespeicherte Kartenausschnitten"
@@ -921,24 +921,24 @@ Genaueres siehe im Hilfetext zu "Gespeicherte Kartenausschnitten"
 = Objekt in Karte suchen =
 Hiermit erhalten Sie einen Dialog zur Suche eines bestimmten Objekts in
 einer GNIS Datei. Falls gefunden wird die Karte an dieser Stelle neu
-zentriert. Die zuletzt befragte GNIS-Datei wird beim nächsten Aufruf
-wiederum als Vorgabe gewählt.
+zentriert. Die zuletzt befragte GNIS-Datei wird beim nÃ¤chsten Aufruf
+wiederum als Vorgabe gewÃ¤hlt.
 
 = Alle Karten verbergen =
-Hiermit kann das Laden aller Karten vorübergehend verhindert werden. Dies
+Hiermit kann das Laden aller Karten vorÃ¼bergehend verhindert werden. Dies
 ist vor allem dann vorteilhaft, wenn man die Karte oft verschiebt oder
-zoomt und der langsame Kartenaufbau dazwischen störend wirkt. Bei einem
+zoomt und der langsame Kartenaufbau dazwischen stÃ¶rend wirkt. Bei einem
 Neustart von Xastir ist diese Option immer ausgeschaltet.
 
 = Automatische Karte (An/Aus) =
 Falls eingeschaltet, wird jede Karte im Kartenverzeichnis oder einem
-Unterverzeichnis geladen, die für den aktuell dargestellten Ausschnitt
-gültig ist. Sie können beliebig viele Uterverzeichnis-Ebenen unterhalb
+Unterverzeichnis geladen, die fÃ¼r den aktuell dargestellten Ausschnitt
+gÃ¼ltig ist. Sie kÃ¶nnen beliebig viele Uterverzeichnis-Ebenen unterhalb
 des Kartenverzeichnisses anlegen, die automatisch durchsucht werden. Alle
-Karten werden im dargestellten Ausschnitt überlagert. Die Reihenfolge
-hängt von der alphabetischen Sortierung ab, gegebenenfalls kann man Links
+Karten werden im dargestellten Ausschnitt Ã¼berlagert. Die Reihenfolge
+hÃ¤ngt von der alphabetischen Sortierung ab, gegebenenfalls kann man Links
 auf andere Namen anlegen, um die Sortierung flexibler handhaben zu
-können. Wenn sie viele oder komplexe Karten haben, oder einen langsamen
+kÃ¶nnen. Wenn sie viele oder komplexe Karten haben, oder einen langsamen
 Computer, dann kann das Laden der Karten sehr lange dauern. Wenn diese
 Option ausgeschaltet ist, werden die in der Kartenauswahl markierten
 Karten geladen.
@@ -949,104 +949,104 @@ bzw. 1 Grad Abstand gezeichnet.
 
 = Ebenen (An/Aus) =
 Falls eingeschaltet, werden Details bei der Darstellung herausgefiltert
-wenn größere Bereiche durch herauszoomen dargestellt werden. Dies
+wenn grÃ¶ÃŸere Bereiche durch herauszoomen dargestellt werden. Dies
 funktioniert nicht mit allen Karten, es verringert auch nicht die
-Ladezeit, sondern sorgt nur dafür, daß der Bildschirm lesbar bleibt. Ein
-Beispiel hierfür sind Karten die aus den Tiger Line Karten von
+Ladezeit, sondern sorgt nur dafÃ¼r, daÃŸ der Bildschirm lesbar bleibt. Ein
+Beispiel hierfÃ¼r sind Karten die aus den Tiger Line Karten von
 aprs.rutgers.edu erzeugt wurden.
 
 = Kartenbeschriftungen =
-Hiermit können Kartenbeschriftungen ein- oder ausgeschaltet werden, die
+Hiermit kÃ¶nnen Kartenbeschriftungen ein- oder ausgeschaltet werden, die
 in Karten im dosAPRS, WinAPRS, GNIS und ESRI Shapefile Format enthalten
 sind.
 
-= Flächen einfärben (An/Aus) =
-Diese Option legt das Einfärben bei Vektorkarten fest. In manchen Fällen
-ist es sinnvoll, die Füllung zu entfernen, um darunterliegende weitere
-Karten sehen zu können. Die Karten werden in alphabetischer Reihenfolge
-geladen, so daß ein Umbenennen oder ein Link eine weitere Möglichkeit in
+= FlÃ¤chen einfÃ¤rben (An/Aus) =
+Diese Option legt das EinfÃ¤rben bei Vektorkarten fest. In manchen FÃ¤llen
+ist es sinnvoll, die FÃ¼llung zu entfernen, um darunterliegende weitere
+Karten sehen zu kÃ¶nnen. Die Karten werden in alphabetischer Reihenfolge
+geladen, so daÃŸ ein Umbenennen oder ein Link eine weitere MÃ¶glichkeit in
 diesem Fall darstellt.
 
 = Wetterwarnung Counties =
-Bei Wetterwarnungen des amerikanischen NWS können einzelne Counties, für
-die eine Wetterwarnung vorliegt, eingefärbt werden. Dies kann hiermit
+Bei Wetterwarnungen des amerikanischen NWS kÃ¶nnen einzelne Counties, fÃ¼r
+die eine Wetterwarnung vorliegt, eingefÃ¤rbt werden. Dies kann hiermit
 gesteuert werden.
 
 = Hintergrundfarbe (An/Aus) =
-Ermöglicht die Auswahl der bei transparenten Karten durchscheinenden
+ErmÃ¶glicht die Auswahl der bei transparenten Karten durchscheinenden
 Hintergrundfarbe.
 
-= Intensität =
-Hiermit kann die Farbsättigung der Karte gesteuert werden. Dieser
-Menupunkt erscheint nur, wenn Xastir mit GeoTIFF-Unterstützung und/oder
+= IntensitÃ¤t =
+Hiermit kann die FarbsÃ¤ttigung der Karte gesteuert werden. Dieser
+Menupunkt erscheint nur, wenn Xastir mit GeoTIFF-UnterstÃ¼tzung und/oder
 ImageMagick zusammen kompiliert wurde.
 
 = Textdarstellung =
-Ermöglicht die Auswahl zwischen zwei verschiedenen Arten der
-Schriftdarstellung für Stationsinformationen auf der Karte.
+ErmÃ¶glicht die Auswahl zwischen zwei verschiedenen Arten der
+Schriftdarstellung fÃ¼r Stationsinformationen auf der Karte.
 
 = Mauszeiger-Menu =
-Öffnet das Mauszeiger-Menu, das sonst beim Klick mit der rechten
+Ã–ffnet das Mauszeiger-Menu, das sonst beim Klick mit der rechten
 Maustaste erscheint.
 
 
 Eine Anmerkung zu Karten:
-Viele der zur Zeit erhältlichen Vektorkarten für die USA sind mit dem
-NAD-27 Datum erstellt worden, während Xastir und andere APRS Programme
+Viele der zur Zeit erhÃ¤ltlichen Vektorkarten fÃ¼r die USA sind mit dem
+NAD-27 Datum erstellt worden, wÃ¤hrend Xastir und andere APRS Programme
 das aktuelle WGS-84 Datum verwenden. Wenn man sehr weit auf einen kleinen
 Kartenausschnitt herein zoomt werden die Abweichungen durch das falsche
 Kartendatum deutlich. Bei den USGS Topographischen Karten wird die
-Datumsabweichung von Xastir korrigiert, so daß Positionen hiermit im
+Datumsabweichung von Xastir korrigiert, so daÃŸ Positionen hiermit im
 Allgemeinen genauer sind als mit anderen topographischen Karten.
 
-HELP-INDEX>Kartendateien und County-Daten für Wetterwarnungen
+HELP-INDEX>Kartendateien und County-Daten fÃ¼r Wetterwarnungen
 
-          Kartendateien und County-Daten für Wetterwarnungen
+          Kartendateien und County-Daten fÃ¼r Wetterwarnungen
 
 Kartentypen
 Xastir kann mit den verschiedensten Kartentypen arbeiten. Alle DosAPRS-,
-WinAPRS- und MacAPRS-Karten werden unterstützt. Zusätzlich unterstützt
+WinAPRS- und MacAPRS-Karten werden unterstÃ¼tzt. ZusÃ¤tzlich unterstÃ¼tzt
 Xastir von Haus aus Karten im PocketAPRS-Format, Bezeichnungen aus GNIS-
 Dateien (Geographic Names Information System) und Karten im XPixmap-
-Grafikformat. Xastir kann so kompiliert werden, daß externe Bibliotheken
-eingebunden werden können, um topographische Karten im GeoTIFF-Format und
-ESRI Shapefiles zu unterstützen. Die Fähigkeit mit Karten in den
+Grafikformat. Xastir kann so kompiliert werden, daÃŸ externe Bibliotheken
+eingebunden werden kÃ¶nnen, um topographische Karten im GeoTIFF-Format und
+ESRI Shapefiles zu unterstÃ¼tzen. Die FÃ¤higkeit mit Karten in den
 verschiedensten Grafikformaten umzugehen kann durch das Kompilieren mit
-ImageMagick-Unterstützung stark erweitert werden (siehe
-"http://www.imagemagick.org/www/formats.html"). Xastir unterstützt die
-Darstellung von Bereichen von Wetterwarnungen auf Karten, hierzu können
+ImageMagick-UnterstÃ¼tzung stark erweitert werden (siehe
+"http://www.imagemagick.org/www/formats.html"). Xastir unterstÃ¼tzt die
+Darstellung von Bereichen von Wetterwarnungen auf Karten, hierzu kÃ¶nnen
 die Daten im klassischen dosAPRS/WinAPRS-Format vorliegen, die Einbindung
-im neuen ESRI Shapefile-Format wird in Kürze vollständig sein. Einen
+im neuen ESRI Shapefile-Format wird in KÃ¼rze vollstÃ¤ndig sein. Einen
 Hinweis auf die Quellen von verschiedenen Kartenformaten finden Sie in
 der Datei README.1ST.
 
 Karten-Verzeichnisse
 Alle Kartendateien sollten unter /usr/local/share/xastir/maps auf Ihrm
 Computer gespeichert werden. Zur besseren Organisation und Trennung der
-Karten können sie dort auch beliebige Unterverzeichnisse anlegen. Bei der
+Karten kÃ¶nnen sie dort auch beliebige Unterverzeichnisse anlegen. Bei der
 Kartenauswahl werden die Karten mit ihrem ralativen Pfad alphabetisch
-sortiert angezeigt. Symbolische Links können helfen, um die Reihenfolge
-gegebenenfalls zu ändern.
+sortiert angezeigt. Symbolische Links kÃ¶nnen helfen, um die Reihenfolge
+gegebenenfalls zu Ã¤ndern.
 
 Hinweise zur Installation und Organisation der Karten finden sich
 ebenfalls in README.1ST.
 
-Für Karten im Pixelgrafikformat werden immer zwei Dateien benötigt, zum
+FÃ¼r Karten im Pixelgrafikformat werden immer zwei Dateien benÃ¶tigt, zum
 einen die Grafikdatei im .xpm Format (oder andere Formate bei
-ImageMagick-Unterstützung) und eine Kalibrierungsdatei (.geo). Das
-Standardgrafikformat ohne zusätzliche Bibliotheken ist .xpm, um Platz zu
-sparen können diese Dateien aber auch mit gzip gepackt werden
+ImageMagick-UnterstÃ¼tzung) und eine Kalibrierungsdatei (.geo). Das
+Standardgrafikformat ohne zusÃ¤tzliche Bibliotheken ist .xpm, um Platz zu
+sparen kÃ¶nnen diese Dateien aber auch mit gzip gepackt werden
 ("gzip map.xpm" erzeugt die komprimierte Datei "map.xpm.gz"). Dies wird
-von Xastir automatisch erkannt und beim Laden der Karte berücksichtigt.
-Sie können XView, Gimp, ImageMagick oder andere Programme benutzen, um
+von Xastir automatisch erkannt und beim Laden der Karte berÃ¼cksichtigt.
+Sie kÃ¶nnen XView, Gimp, ImageMagick oder andere Programme benutzen, um
 Grafiken zu konvertieren, die als gif, jpg oder tiff-Dateien vorliegen,
 wenn Sie nicht ImageMagick hinzukompilieren wollen. Sollten Sie Probleme
-mit Karten im .xpm-Format haben, versuchen Sie zunächst, die Grafik in
+mit Karten im .xpm-Format haben, versuchen Sie zunÃ¤chst, die Grafik in
 Gimp zu laden und wieder abzuspeichern, hierdurch werden alle, evtl.
-unbekannten, Farbnamen in Binärdarstellung umgewandelt.
+unbekannten, Farbnamen in BinÃ¤rdarstellung umgewandelt.
 
 Die .geo-Datei ist eine Textdatei, die Kartenposition in der Welt
-festlegt. Zur Erläuterung hier die Datei world1.geo:
+festlegt. Zur ErlÃ¤uterung hier die Datei world1.geo:
 
 FILENAME   world1.xpm
 #          x          y        lon         lat
@@ -1054,28 +1054,28 @@ TIEPOINT   0          0        -180        90
 TIEPOINT   640        320      180         -90
 
 Dieses einfache Beispiel besteht aus vier grundlegenden Komponenten. Die
-erste Zeile (FILENAME) legt die Grafikdatei fest, die für diese Karte
+erste Zeile (FILENAME) legt die Grafikdatei fest, die fÃ¼r diese Karte
 benutzt werden soll. Bei einer komprimierten .xpm-Datei ist die Angabe
 der Endung ".gz" optional. Wenn kein Pfad angegeben wird, wird die
 Grafikdatei im gleichen Verzeichnis wie die .geo-Datei gesucht.
 Unter FILENAME kann auch eine URL angegeben werden, unter der Xastir die
-Kartengrafik mittels wget herunterladen kann. Dies bedeutet, daß so
-ziemlich jedes Bild, daß über HTTP oder FTP im Internet verfügbar ist,
+Kartengrafik mittels wget herunterladen kann. Dies bedeutet, daÃŸ so
+ziemlich jedes Bild, daÃŸ Ã¼ber HTTP oder FTP im Internet verfÃ¼gbar ist,
 als Karte dienen kann.
 
 Die zweite Zeile ist eine Kommenarzeile, dies wird durch ein '#' als
 erstes Zeichen einer Zeile festgelegt.
 
 Die letzten beiden Zeilen binden x-y-Positionen in der Grafikdatei an
-Koordinaten (Längen- und Breitengrade) in der realen Welt. Zwei solche
-Punkte werden benötigt und sie sollten für eine hohe Genauigkeit
-möglichst weit auseinander in den Ecken der Grafikdatei liegen, z.B. oben
+Koordinaten (LÃ¤ngen- und Breitengrade) in der realen Welt. Zwei solche
+Punkte werden benÃ¶tigt und sie sollten fÃ¼r eine hohe Genauigkeit
+mÃ¶glichst weit auseinander in den Ecken der Grafikdatei liegen, z.B. oben
 links und unten rechts.
 
-Um eine solche Karte zu verwenden, wählen Sie in der Kartenauswahl die
-zugehörige .geo-Datei.
+Um eine solche Karte zu verwenden, wÃ¤hlen Sie in der Kartenauswahl die
+zugehÃ¶rige .geo-Datei.
 
-Die Größe der Grafikdatei kann optional ebenfalls in der .geo-Datei
+Die GrÃ¶ÃŸe der Grafikdatei kann optional ebenfalls in der .geo-Datei
 angegeben werden:
 
 FILENAME        Agnes_Mountain.xpm.gz
@@ -1087,29 +1087,29 @@ TIEPOINT        1337    1999    -120.87619806   48.24982052
 #
 IMAGESIZE       1338    2000
 
-Mit IMAGESIZE wird die Bildgröße in Pixel angegeben. Xastir benutzt diese
+Mit IMAGESIZE wird die BildgrÃ¶ÃŸe in Pixel angegeben. Xastir benutzt diese
 Information, um Karten, die nicht in den aktuell dargestellten Ausschnitt
-fallen, möglichst schnell aussortieren zu können. Wird dies nicht
-angegeben, muß Xastir die Grafikdatei zum Berechnen auf alle Fälle immer
+fallen, mÃ¶glichst schnell aussortieren zu kÃ¶nnen. Wird dies nicht
+angegeben, muÃŸ Xastir die Grafikdatei zum Berechnen auf alle FÃ¤lle immer
 laden.
 
-Wenn Xastir mit Unterstützung von ImageMagick kompiliert wurde, so stehen
-außer .xpm sämtliche Grafikformate zur Verfügung, die von ImageMagick
-selbst oder seinen Bibliotheken unterstützt werden.
+Wenn Xastir mit UnterstÃ¼tzung von ImageMagick kompiliert wurde, so stehen
+auÃŸer .xpm sÃ¤mtliche Grafikformate zur VerfÃ¼gung, die von ImageMagick
+selbst oder seinen Bibliotheken unterstÃ¼tzt werden.
 
 Es gibt verschiedene "spezielle" .geo-Dateien, die von Xastir verwendet
-werden können:
+werden kÃ¶nnen:
 
 o Eine Datei mit dem Wort "FINDU" und einer weiteren Zeile
-  "CALL <callsign>" lädt historische Spurdaten der mit dem Call
-  spezifizierten Station. Dies ist allerdings inzwischen über das
+  "CALL <callsign>" lÃ¤dt historische Spurdaten der mit dem Call
+  spezifizierten Station. Dies ist allerdings inzwischen Ã¼ber das
   Stationsmenu einfacher zu bewerkstelligen.
   
 
 geoTIFF Karten sind ebenfalls eine Kombination aus zwei Dateien, einer
-.tif und einer .fgd Datei. Die .tif-Datei enthält die eigentlichen
-Kartendaten, die .fgd-Kalibrierungsdatei benötigt nur vier Einträge wie
-im folgenden Fall, kann aber viele Andere Einträge zusätzlich enhalten:
+.tif und einer .fgd Datei. Die .tif-Datei enthÃ¤lt die eigentlichen
+Kartendaten, die .fgd-Kalibrierungsdatei benÃ¶tigt nur vier EintrÃ¤ge wie
+im folgenden Fall, kann aber viele Andere EintrÃ¤ge zusÃ¤tzlich enhalten:
 
 1.5.1.1   WEST BOUNDING COORDINATE:  -122.000000
 1.5.1.2   EAST BOUNDING COORDINATE:  -120.000000
@@ -1118,55 +1118,55 @@ im folgenden Fall, kann aber viele Andere Einträge zusätzlich enhalten:
 
 Xastir benutzt diese vier Zeilen, um die Eckpunkte der Karte zu
 berechnen, und um festzustellen, ob die Karte in den gerade angezeigten
-Ausschnitt fällt. Wenn es sich bei Ihren Daten um topographische 
+Ausschnitt fÃ¤llt. Wenn es sich bei Ihren Daten um topographische 
 USGS-Karten handelt, sollten auch die .fgd-Dateien vorliegen. Xastir
-ist in der Lage das Datum von NAD27 in WGS84 umzurechnen, so daß auch
-USGS-Karten unter Xastir eine höhere Genauigkeit erreichen.
+ist in der Lage das Datum von NAD27 in WGS84 umzurechnen, so daÃŸ auch
+USGS-Karten unter Xastir eine hÃ¶here Genauigkeit erreichen.
 
 Wenn Sie keine .fgd-Datei haben, wird die Karte problemlos geladen,
-allerdings werden die weißen Ränder am Kartenrand nicht beschnitten und
-die Karte könnte eine leicht falsche Größe und Rotation besitzen.
+allerdings werden die weiÃŸen RÃ¤nder am Kartenrand nicht beschnitten und
+die Karte kÃ¶nnte eine leicht falsche GrÃ¶ÃŸe und Rotation besitzen.
 
 Xastir kann nun USGS geoTIFF topographische Karten direkt von einer CD
 laden. Mounten Sie das CD-ROM manuell oder automatisch durch automounter,
-und achten Sie darauf, daß ein symbolischer Link im Kartenverzeichnis auf
+und achten Sie darauf, daÃŸ ein symbolischer Link im Kartenverzeichnis auf
 das gemountete Laufwerk zeigt. Das war es!
 
 
 Auch Shapefiles sind eine Kombination aus mehreren Dateien, .shp, .dbf
-und .shx. Sie müssen nur die .shp-Datei auswählen, um die Karte zu laden.
-Die anderen Dateien müssen jedoch vorhanden sein, um die Karte
-ordnungsgemäß laden zu können.
+und .shx. Sie mÃ¼ssen nur die .shp-Datei auswÃ¤hlen, um die Karte zu laden.
+Die anderen Dateien mÃ¼ssen jedoch vorhanden sein, um die Karte
+ordnungsgemÃ¤ÃŸ laden zu kÃ¶nnen.
 
 
 GNIS (Geographic Names Information System) Daten bestehen aus einer
 Sammlung von Namen von Orten oder geographischen Objekten mit ihren
 jeweiligen Positionen. Diese Bezeichnungen werden wie die in Dos/WinAPRS
 Karten dargestellt. Je weiter man hineinzoomt, umso mehr detailiertere
-Bezeichnungen erscheinen, unter der Annahme, daß eine GNIS-Datei als
-Karte gewählt wurde und die Darstellung von Bezeichnungen im Kartenmenu
+Bezeichnungen erscheinen, unter der Annahme, daÃŸ eine GNIS-Datei als
+Karte gewÃ¤hlt wurde und die Darstellung von Bezeichnungen im Kartenmenu
 eingeschaltet wurden.
 
 
-County Karten für Wetterwarnungen
+County Karten fÃ¼r Wetterwarnungen
 Alle County-Karten sollten im Verzeichnis /usr/local/share/xastir/Counties
-gespeichert werden. Es gibt verschiedene Formate für diese Karten, aber
-dieses Verzeichnis wird immer Unterverzeichnisse für jeden Staat/Marine-
-Bereich haben (Abkürzung aus zwei Buchstaben).
-Das alte Format benutzt <ST><COUNTYNAME>.map, während das neue Format
-<ST>Z<NWSZONECODE>.map benutzt. Die Installation wird ausführlicher in
-README.1ST im Abschnitt über die Quelle von Karten beschrieben.
+gespeichert werden. Es gibt verschiedene Formate fÃ¼r diese Karten, aber
+dieses Verzeichnis wird immer Unterverzeichnisse fÃ¼r jeden Staat/Marine-
+Bereich haben (AbkÃ¼rzung aus zwei Buchstaben).
+Das alte Format benutzt <ST><COUNTYNAME>.map, wÃ¤hrend das neue Format
+<ST>Z<NWSZONECODE>.map benutzt. Die Installation wird ausfÃ¼hrlicher in
+README.1ST im Abschnitt Ã¼ber die Quelle von Karten beschrieben.
 
 Wenn eine NWS Nachricht empfangen wird, so werden die entsprechenden
-Bereiche eingefärbt, um den Bereich der Warnung zu kennzeichnen. Die
+Bereiche eingefÃ¤rbt, um den Bereich der Warnung zu kennzeichnen. Die
 verschiedenen Farben beschreiben dabei die Art der Warnung.
-Ursprünglich wurden folgende Farben verwendet:
+UrsprÃ¼nglich wurden folgende Farben verwendet:
 Cyan for advisory, yellow for watch, red for warning, orange for
 cancelled alert, royal blue for tests, and green for undetermined
 alert levels.
-Inzwischen können die Farben davon etwas abweichen, da die Flächen nun
-nicht mehr gefüllt werden, sondern nur noch in der Farbe geändert werden,
-so daß man die darunterliegende Karte noch erkennen kann.
+Inzwischen kÃ¶nnen die Farben davon etwas abweichen, da die FlÃ¤chen nun
+nicht mehr gefÃ¼llt werden, sondern nur noch in der Farbe geÃ¤ndert werden,
+so daÃŸ man die darunterliegende Karte noch erkennen kann.
 Die Darstellung von Wetterwarnungen kann im Kartenmenu ein- bzw.
 ausgeschaltet werden.
 
@@ -1177,7 +1177,7 @@ HELP-INDEX>Ansicht
 Die Optionen in diesem Menu erlauben ihnen festzulegen, welche Daten
 zu den Stationen auf der Karte angezeigt werden sollen. Es erlaubt
 Ihnen auch Stationen zu suchen und zu verfolgen, oder Stationen oder
-deren Spur zu löschen.
+deren Spur zu lÃ¶schen.
 
 = Station finden =
   Siehe hierzu unter "Stationen finden".
@@ -1186,15 +1186,15 @@ deren Spur zu löschen.
   Siehe hierzu unter "Verfolgen von Stationen".
 
 = Spur von Findu holen =
-  Lädt alte Spurdaten einer Station aus dem Internet von findu.com.
+  LÃ¤dt alte Spurdaten einer Station aus dem Internet von findu.com.
   Momentan werden die Daten der letzten beiden Wochen geladen.
 
 = Symbole =
   Hiermit kann festgelegt werden, ob Symbole auf der Karte gezeichnet
-  werden sollen. Die meisten folgenden Optionen hängen hiervon ebenfalls
+  werden sollen. Die meisten folgenden Optionen hÃ¤ngen hiervon ebenfalls
   ab. Bei alten Stationen wird das Symbol nur noch schememhaft in der
-  Standardausrichtung gezeichnet, die zugehörige Spur wird gestrichelt
-  und alle Daten außer dem Rufzeichen verschwinden vom Bildschirm.
+  Standardausrichtung gezeichnet, die zugehÃ¶rige Spur wird gestrichelt
+  und alle Daten auÃŸer dem Rufzeichen verschwinden vom Bildschirm.
 
 = Symbole drehen =
   Wenn eingeschaltet, werden einige Symbole auf der Karte gedreht, um
@@ -1206,128 +1206,128 @@ deren Spur zu löschen.
 = Geschwindigkeit =
   Zeigt die Geschwindigkeit einer Station in roter Schrift unterhalb
   von Rufzeichen und Richtung an, sofern eine Geschwindigkeit
-  übermittelt wird.
+  Ã¼bermittelt wird.
 = - kurz =
   Wenn markiert wird die Geschwindigkeit in Kurzform ohne Einheit
   angezeigt.
 
-= Höhe =
-  Zeigt die Höhe oberhalb des Rufzeichens in blauer Schrift an,
-  sofern sie übermittelt wurde.
+= HÃ¶he =
+  Zeigt die HÃ¶he oberhalb des Rufzeichens in blauer Schrift an,
+  sofern sie Ã¼bermittelt wurde.
 
 = Kurs =
   Zeigt die Richtung, in die sich die Station bewegt, unterhalb des
-  Rufzeichens in grüner Schrift an, sofern die Station einen Kurs
-  übermittelt.
+  Rufzeichens in grÃ¼ner Schrift an, sofern die Station einen Kurs
+  Ã¼bermittelt.
 
 = Entfernung/Richtung =
-  Ermöglicht die Anzeige der Entfernung von der eigenen Station und der
+  ErmÃ¶glicht die Anzeige der Entfernung von der eigenen Station und der
   Richtung, in der sich die Station von der eigenen Station aus befindet.
   Diese beiden Werte werden links vom Symbol dargestellt.
 
 = Wetterdaten =
   Wenn eingeschaltet, werden bei Wetterstationen unterhalb des Symbols
-  die letzten Wetterdaten aufgelistet (Temperatur, Wind- und Böen-
+  die letzten Wetterdaten aufgelistet (Temperatur, Wind- und BÃ¶en-
   geschwindigkeit, Windrichtung und Feuchtigkeit.
 = - nur Temperatur =
   Wenn markiert wird nur die Temperatur angezeigt.
 
 = Leistung/Gewinn =
-  Wenn PHG-Daten übermittelt werden, wird ein Kreis um die Station
-  gezeichnet, dessen Radius aus Leistung, Höhe und Antennengewinn
-  berechnet wird. Wenn sich zwei Kreise überschneiden sind die
-  Stationen theoretisch in Reichweite für eine Simplexverbindung.
-  In der Praxis is dies aber nur eine sehr grobe Näherung, vor allem
-  in Gegenden mit sich änderndem Gelände.
+  Wenn PHG-Daten Ã¼bermittelt werden, wird ein Kreis um die Station
+  gezeichnet, dessen Radius aus Leistung, HÃ¶he und Antennengewinn
+  berechnet wird. Wenn sich zwei Kreise Ã¼berschneiden sind die
+  Stationen theoretisch in Reichweite fÃ¼r eine Simplexverbindung.
+  In der Praxis is dies aber nur eine sehr grobe NÃ¤herung, vor allem
+  in Gegenden mit sich Ã¤nderndem GelÃ¤nde.
 = - mit Standardwert =
-  Für Stationen, die keine PHG-Daten übermitteln, wird stattdessen
-  ein Standardwert genäß den APRS-Spezifikationen verwendet.
+  FÃ¼r Stationen, die keine PHG-Daten Ã¼bermitteln, wird stattdessen
+  ein Standardwert genÃ¤ÃŸ den APRS-Spezifikationen verwendet.
 = - bei Mobilstationen =
-  Hiermit können auch für Mobilstationen Entfernungskreise gezeichnet
+  Hiermit kÃ¶nnen auch fÃ¼r Mobilstationen Entfernungskreise gezeichnet
   werden.
 
 = Positionsverschleierung =
-  Wenn eingeschaltet, wird die Fläche markiert, in der sich eine Station
+  Wenn eingeschaltet, wird die FlÃ¤che markiert, in der sich eine Station
   mit Positionsverschleierung befinden kann. Die betreffende Station
   wird in der Mitte dieses Bereichs positioniert.
   
 = Alte Daten zeigen =
   Xastir zeigt Daten auch noch an, nachdem sie eigentlich bereits als
-  alt deklariert wurden. Diese Zeiten können unter Datei-Einstellungen-
-  Grundeinstellungen geämdert werden.
+  alt deklariert wurden. Diese Zeiten kÃ¶nnen unter Datei-Einstellungen-
+  Grundeinstellungen geÃ¤mdert werden.
 
 = DF Kreise zeigen =
-  Wenn eingeschaltet, werden auch alle Kreise für Peilungen (Direction
+  Wenn eingeschaltet, werden auch alle Kreise fÃ¼r Peilungen (Direction
   Finding) angezeigt.
   
 = Spuren =
-  Wenn markiert, wird für Mobilstationen eine farbige Spur mit den
+  Wenn markiert, wird fÃ¼r Mobilstationen eine farbige Spur mit den
   letzten maximal 100 Positionen gezeichnet. Jeder neuen Mobilstation
   wird hierzu eine neue Farbe aus einer Tabelle zugewiesen.
 
-= Stationen löschen =
-  Dies löscht alle Stationsdaten außer den eigenen. Dies ist
-  z.B. nützlich, wenn der Speicher knapp bemessen ist.
+= Stationen lÃ¶schen =
+  Dies lÃ¶scht alle Stationsdaten auÃŸer den eigenen. Dies ist
+  z.B. nÃ¼tzlich, wenn der Speicher knapp bemessen ist.
 
-= Spuren Löschen =
-  Löschen alle Spuren der Mobilstationen. Dies ist z.B. nützlich,
+= Spuren LÃ¶schen =
+  LÃ¶schen alle Spuren der Mobilstationen. Dies ist z.B. nÃ¼tzlich,
   wenn der Speicher knapp bemessen ist. Die Spur einzelner Stationen
-  kann auch über das StationsInfo Menu gelöscht werden.
+  kann auch Ã¼ber das StationsInfo Menu gelÃ¶scht werden.
 
 HELP-INDEX>Nachrichten
 
                                 Nachrichten
 
 = Schicke Nachricht an =
-  Hiermit können Nachrichten mit einer einzelnen Station ausgetauscht
-  werden. Dies ist auch über das Menu StationsInfo möglich.
+  Hiermit kÃ¶nnen Nachrichten mit einer einzelnen Station ausgetauscht
+  werden. Dies ist auch Ã¼ber das Menu StationsInfo mÃ¶glich.
 
-= Öffne Gruppen Nachricht=
-  Dies funktioniert ähnlich, nur daß die Nachrichten an einen
+= Ã–ffne Gruppen Nachricht=
+  Dies funktioniert Ã¤hnlich, nur daÃŸ die Nachrichten an einen
   Gruppennamen geschickt werden. Die Gruppen werden in der Datei
   "groups" in ~/.xastir/config definiert. Gruppennachrichten sind noch
-  nicht voll implementiert und einige Probleme müssen noch beseitigt
+  nicht voll implementiert und einige Probleme mÃ¼ssen noch beseitigt
   werden.
 
-In Zukunft wird es auch möglich sein, Bulletins zu verschicken, dies ist
+In Zukunft wird es auch mÃ¶glich sein, Bulletins zu verschicken, dies ist
 aber momentan noch nicht implementiert.
 
-Im Nachrichtenfenster muß zunächst das Rufzeichen der Station eingetragen
+Im Nachrichtenfenster muÃŸ zunÃ¤chst das Rufzeichen der Station eingetragen
 werden, der man eine Nachricht schicken will. Darunter kann man dann eine 
 Zeile des Nachrichtentexts (max. 250 Zeichen) eingeben und mit
-"Sende jetzt!" abschicken. Bis zu einer Bestätigung (ACK) durch die
+"Sende jetzt!" abschicken. Bis zu einer BestÃ¤tigung (ACK) durch die
 Gegenstation bleibt dieser Button inaktiv (grau).
 
-Es stehen maximal zehn Fenster für Nachrichten an verschiedene Rufzeichen
-zur Verfügung.
+Es stehen maximal zehn Fenster fÃ¼r Nachrichten an verschiedene Rufzeichen
+zur VerfÃ¼gung.
 
-Beim Empfang einer an die eigene Station gerichteten Nachricht öffnet
+Beim Empfang einer an die eigene Station gerichteten Nachricht Ã¶ffnet
 sich automatisch das Nachrichtenfenster, wobei das Rufzeichen des
 Absenders bereits eingetragen ist.
 
-Im großen Fenster sind oben die ausgehenden und unten die eingetroffenen
+Im groÃŸen Fenster sind oben die ausgehenden und unten die eingetroffenen
 Nachrichten sortiert nach ihrer Zeilennummer aufgelistet.
 
 Mit "Beenden" wird das Nachrichtenfenster verlassen.
 Mit "Neues Rufzeichen" kann man nachschauen, welche Nachrichten eine
-Station früher gesendet hatte. Sie können dies auch einsetzen, um mit
+Station frÃ¼her gesendet hatte. Sie kÃ¶nnen dies auch einsetzen, um mit
 einer anderen Station Nachrichten auszutauschen.
-Mit "Lösche Nachrichten" wird die angezeigte Liste mit Nachrichten
-gelöscht.
+Mit "LÃ¶sche Nachrichten" wird die angezeigte Liste mit Nachrichten
+gelÃ¶scht.
 
-= Lösche alle ausgehenden Nachrichten =
-  Hiermit werden alle noch nicht bestätigten gesendeten Nachrichten
-  gelöscht. Anderenfalls wird mehrfach versucht, diese zuzustellen.
+= LÃ¶sche alle ausgehenden Nachrichten =
+  Hiermit werden alle noch nicht bestÃ¤tigten gesendeten Nachrichten
+  gelÃ¶scht. Anderenfalls wird mehrfach versucht, diese zuzustellen.
 
 = Stationen Allgemein =
   Dies sendet ein ?APRS? Paket, wodurch alle lokalen Stationen mit
   ihrer Position und/oder ihrem Status antworten sollten. Viele
   Programme ignorieren diese Anfrage, da eine Antwort zu einer Flut
-  von Daten führen kann.
+  von Daten fÃ¼hren kann.
 
 = IGate Stationen =
   Dies sendet ein ?IGATE? Paket, wodurch alle IGate-Stationen antworten
-  und ihre Möglichkeiten mitteilen sollten.
+  und ihre MÃ¶glichkeiten mitteilen sollten.
 
 = Wetterstationen =
   Dies sendet ein ?WX? Paket, wodurch alle lokalen Wetterstationen ihre
@@ -1344,25 +1344,25 @@ HELP-INDEX>Schnittstellen
 
                            Schnittstellen
 
-In diesem Menu können Einstellungen zu den vershiedenen Schnittstellen
+In diesem Menu kÃ¶nnen Einstellungen zu den vershiedenen Schnittstellen
 gemacht werden.
 
 = Schnittstellen Ein/Aus =
-  Diese Option öffnet ein Fenster, in dem Sie alle Ihre konfigurierten
-  Schnittstellen ein- oder ausschalten können.
+  Diese Option Ã¶ffnet ein Fenster, in dem Sie alle Ihre konfigurierten
+  Schnittstellen ein- oder ausschalten kÃ¶nnen.
 
 = Einstellungen =
   Eine Liste mit den installierten Schnittstellen erscheint und erlaubt
-  Ihnen deren Einstellungen zu änden und weitere Schnittstellen
-  hinzuzufügen bzw. vorhandene zu löschen. Näheres finden Sie unter
+  Ihnen deren Einstellungen zu Ã¤nden und weitere Schnittstellen
+  hinzuzufÃ¼gen bzw. vorhandene zu lÃ¶schen. NÃ¤heres finden Sie unter
   "Schnittstellen Konfiguration"
 
 = Nicht senden: ALLES =
-  Wenn markiert wird überhaupt NICHT gesendet.
-  Für diese und die folgenden beiden Optionen gilt, daß es sich um
-  globale Einstellungen handelt, die für alle Schnittstellen gelten.
-  Die meisten Schnittstellen bieten auch die Möglichkeit, das Senden
-  über diese spezielle Schnittstelle einzeln auszuschalten.
+  Wenn markiert wird Ã¼berhaupt NICHT gesendet.
+  FÃ¼r diese und die folgenden beiden Optionen gilt, daÃŸ es sich um
+  globale Einstellungen handelt, die fÃ¼r alle Schnittstellen gelten.
+  Die meisten Schnittstellen bieten auch die MÃ¶glichkeit, das Senden
+  Ã¼ber diese spezielle Schnittstelle einzeln auszuschalten.
 
 = Nicht senden: Meine Position =
   Wenn markiert wird die eigene Position nicht gesendet.
@@ -1371,110 +1371,110 @@ gemacht werden.
   Wenn markiert wird die eigenen Objekte nicht gesendet.
 
 = Sende jetzt! =
-  Führt dazu, daß alle eingeschalteten Schnittstellen ein Positions-
-  Paket senden. Es ist nicht funktionsfähig (grau), wenn das Senden
-  grundsätzlich ausgeschaltet ist.  
+  FÃ¼hrt dazu, daÃŸ alle eingeschalteten Schnittstellen ein Positions-
+  Paket senden. Es ist nicht funktionsfÃ¤hig (grau), wenn das Senden
+  grundsÃ¤tzlich ausgeschaltet ist.  
 
 HELP-INDEX>Stations-Info
 
                            Stations-Info
 
-Das Fenster Stations-Info zeigt alle Daten an, die von Xastir für diese
+Das Fenster Stations-Info zeigt alle Daten an, die von Xastir fÃ¼r diese
 Station dekodiert wurden.
 
-Es können die folgenden Informationen angezeigt werden: Die Anzahl der
-gehörten Pakete, die Uhrzeit, zu der die Station zuletzt gehört wurde,
-über welche Schnittstelle dies erfolgte, den Kommentar, PHG (aus
-Leistung, Höhe und Gewinn), Entfernung und Richtung von meiner Station,
+Es kÃ¶nnen die folgenden Informationen angezeigt werden: Die Anzahl der
+gehÃ¶rten Pakete, die Uhrzeit, zu der die Station zuletzt gehÃ¶rt wurde,
+Ã¼ber welche Schnittstelle dies erfolgte, den Kommentar, PHG (aus
+Leistung, HÃ¶he und Gewinn), Entfernung und Richtung von meiner Station,
 Wetterdaten und die letzte Position.
 Bei Stationen, die sich bewegen, folgt ein Tracklog mit den neuesten
 Daten ganz oben. Ein '+' vor einer Zeile markiert den Start eines neuen
-Tracks (wenn zuvor eine große Zeit- bzw. Ortsdifferenz vorlag). Ein Stern
-am Ende einer Zeile weist darauf hin, daß die Station an der jeweiligen
-Position auf direktem Weg gehört werden konnte (ohne Digipeater).
+Tracks (wenn zuvor eine groÃŸe Zeit- bzw. Ortsdifferenz vorlag). Ein Stern
+am Ende einer Zeile weist darauf hin, daÃŸ die Station an der jeweiligen
+Position auf direktem Weg gehÃ¶rt werden konnte (ohne Digipeater).
 
-Nur für die eigene Station gibt es ein Feld "Echo von", das die letzten
-sechs Digipeater aufführt, die mein Paket als erste weitergegeben haben.
+Nur fÃ¼r die eigene Station gibt es ein Feld "Echo von", das die letzten
+sechs Digipeater auffÃ¼hrt, die mein Paket als erste weitergegeben haben.
 
 Am unteren Rand des Fensters befinden sich zwei Reihen mit vier Aktions-
-feldern, deren Funktion abhängig von der Art der dargestellten Station
+feldern, deren Funktion abhÃ¤ngig von der Art der dargestellten Station
 ist.
 
-Für Objekte/Items:
+FÃ¼r Objekte/Items:
 
-Track speichern    Objekt ändern         --leer--           Schließen
+Track speichern    Objekt Ã¤ndern         --leer--           SchlieÃŸen
 ? Stationsversion  ? Trace         ? unbest. Nachrichten  Stationsanfrage
 
 
-Für andere Stationen:
+FÃ¼r andere Stationen:
 
-Track speichern    Nachricht senden    FCC/RAC Datenbank       Schließen
+Track speichern    Nachricht senden    FCC/RAC Datenbank       SchlieÃŸen
 ? Stationsversion  ? Trace           ? unbest. Nachrichten  Stationsanfrage
 
 Bei sich bewegenden Stationen fehlt die Anfrage nach der Stationsversion,
-stattdessen findet sich dort "Spur löschen". Hiermit werden alle
+stattdessen findet sich dort "Spur lÃ¶schen". Hiermit werden alle
 Bewegungsdaten dieser Station in der Datenbank und vom Bildschirm
-gelöscht.
+gelÃ¶scht.
 
 Mit "Spur speichern" wird die Position und falls vorhanden, alle
 Bewegungsdaten in einer Datei auf der Festplatte gespeichert. Das
-derzeit benutzte Format ist dem ähnlich, das bei GPS-Empfängern zum
-Einsatz kommt, die Spezifikationen könnten sich aber in zukünftigen
-Versionen noch ändern. Es gibt momentan keinen Weg, diese Daten wieder
-einzulesen, dies ist aber für die Zukunft geplant. Das Ziel ist es auch
-GPS Tracklog-Dateien in ähnlicher Art laden und darstellen zu können.
+derzeit benutzte Format ist dem Ã¤hnlich, das bei GPS-EmpfÃ¤ngern zum
+Einsatz kommt, die Spezifikationen kÃ¶nnten sich aber in zukÃ¼nftigen
+Versionen noch Ã¤ndern. Es gibt momentan keinen Weg, diese Daten wieder
+einzulesen, dies ist aber fÃ¼r die Zukunft geplant. Das Ziel ist es auch
+GPS Tracklog-Dateien in Ã¤hnlicher Art laden und darstellen zu kÃ¶nnen.
 Diese Tracklog-Dateien werden im Verzeichnis ~/.xastir/tracklogs
 abgelegt, der Dateiname besteht aus dem jeweiligen Rufzeichen mit der
 Erweiterung ".trk".
 
-"Objekt/Item ändern" öffnet das Fenster zum Ändern von Objekten.
+"Objekt/Item Ã¤ndern" Ã¶ffnet das Fenster zum Ã„ndern von Objekten.
 
-"Sende Nachricht" öffnet für diese Station ein Nachrichtenfenster und
-ermöglicht an diese Station eine Nachricht zu senden.
+"Sende Nachricht" Ã¶ffnet fÃ¼r diese Station ein Nachrichtenfenster und
+ermÃ¶glicht an diese Station eine Nachricht zu senden.
 
 Wenn die FCC (U.S. Federal Communications Commission) oder RAC (Radio
 Amateurs of Canada) Datenbank installiert ist und das Rufzeichen aus
 dem US-amerikanischen bzw. kanadischen Kontingent stammt, so ist das
 "FCC/RAC Suche"-Feld vorhanden, sonst nicht. Die FCC- und RAC-Dateien
 sollten sich im Verzeichnis /usr/local/share/xastir/fcc befinden, wobei auf
-Groß-/Kleinschreibung zu achten ist. Wenn die Suche erfolgreich ist,
+GroÃŸ-/Kleinschreibung zu achten ist. Wenn die Suche erfolgreich ist,
 wird Name und Adresse der Station im Stations-Info Fenster angezeigt.
 Anweisungen zur Installation dieser Datenbanken finden sich in der
 Datei README.1ST.
 
-Xastir erzeugt beim Start eine Indexdatei für jede dieser Datenbanken.
-Wenn eine Rufzeichendatei aktualisiert wird, während Xastir läuft, so
-wird der Index bei der nächsten Suche erstellt oder neu aufgebaut.
-Spezielle Präfixe werden NICHT berücksichtigt.
+Xastir erzeugt beim Start eine Indexdatei fÃ¼r jede dieser Datenbanken.
+Wenn eine Rufzeichendatei aktualisiert wird, wÃ¤hrend Xastir lÃ¤uft, so
+wird der Index bei der nÃ¤chsten Suche erstellt oder neu aufgebaut.
+Spezielle PrÃ¤fixe werden NICHT berÃ¼cksichtigt.
 
 HELP-INDEX>Erstellen von Protokolldateien
 
                     Erstellen von Protokolldateien
 
-Xastir kann empfangene Daten in Protokolldateien schreiben, so daß sie
-später wieder eingespielt werden, oder zu Debuggingzwecken analysiert
-werden können. Alle diese Einstellungen werden im Menu "Datei"
+Xastir kann empfangene Daten in Protokolldateien schreiben, so daÃŸ sie
+spÃ¤ter wieder eingespielt werden, oder zu Debuggingzwecken analysiert
+werden kÃ¶nnen. Alle diese Einstellungen werden im Menu "Datei"
 vorgenommen.
 
 = TNC protokollieren =
-  Protokolliert alle Daten, die über den TNC empfangen bzw. gesendet
-  werden. Dieses Protokoll kann über "Protokolldatei laden" zu einem
-  späteren Zeitpunkt wieder eingelesen werden.
+  Protokolliert alle Daten, die Ã¼ber den TNC empfangen bzw. gesendet
+  werden. Dieses Protokoll kann Ã¼ber "Protokolldatei laden" zu einem
+  spÃ¤teren Zeitpunkt wieder eingelesen werden.
 
 = Netz protokollieren =
-  Protokolliert alle Daten, die über das Internet empfangen bzw. gesendet
-  werden. Dieses Protokoll kann über "Protokolldatei laden" zu einem
-  späteren Zeitpunkt wieder eingelesen werden. Wenn Sie keine
+  Protokolliert alle Daten, die Ã¼ber das Internet empfangen bzw. gesendet
+  werden. Dieses Protokoll kann Ã¼ber "Protokolldatei laden" zu einem
+  spÃ¤teren Zeitpunkt wieder eingelesen werden. Wenn Sie keine
   Schnittstelle gestartet haben und Ihre Position oder die eigenen
   Objekte lokal protokollieren wollen, ist dies die geeignete Methode.
 
 = IGate protokollieren =
   Protokolliert alle weitergereichten Daten in beide Richtungen, bei
-  unterdrückten Weiterleitungen auch den Grund hierfür. Dies beinhaltet
+  unterdrÃ¼ckten Weiterleitungen auch den Grund hierfÃ¼r. Dies beinhaltet
   auch NWS Nachrichten, die in Richtung Funk weitergeleitet werden
-  (gemäß ~/.xastir/data/nws-stations.txt: eine Textdatei, die alle
+  (gemÃ¤ÃŸ ~/.xastir/data/nws-stations.txt: eine Textdatei, die alle
   Rufzeichen bzw. NWS Station wie z.B. "SECIND" angibt, deren Daten
-  über Funk weitergegeben werden sollen).
+  Ã¼ber Funk weitergegeben werden sollen).
   
 = Wetter protokollieren =
   Protokolliert alle Wetterdaten, die von Ihrer Wetterstation empfangen
@@ -1485,12 +1485,12 @@ HELP-INDEX>Wiedergeben einer Protokolldatei
                       Wiedergeben einer Protokolldatei
 
 Klicken sie auf Datei, dann auf "Protokolldatei laden". In einem
-Auswahlfenster können sie eine Datei auswählen, deren Inhalt von Xastir
-geladen werden soll. Es muß sich dabei um eine Datei mit TNC Rohdaten
+Auswahlfenster kÃ¶nnen sie eine Datei auswÃ¤hlen, deren Inhalt von Xastir
+geladen werden soll. Es muÃŸ sich dabei um eine Datei mit TNC Rohdaten
 handeln, wie sie auch von Xastir als Protokolldatei geschrieben werden
 kann. Die Station funktioniert dabei weiterhin wie gewohnt, die
 eingespielten Daten werden aber nicht wieder ausgesendet. Wenn sie Daten
-protokollieren, finden sie diese Dateien üblicherweise in ~/.xastir/logs/ 
+protokollieren, finden sie diese Dateien Ã¼blicherweise in ~/.xastir/logs/ 
 
 HELP-INDEX>Finden einer Station
 
@@ -1498,15 +1498,15 @@ HELP-INDEX>Finden einer Station
 
 Klicken sie auf Ansicht, dann auf "Station finden". Ein Fenster
 erscheint, in dem sie das Rufzeichen der zu suchenden Station eingeben
-können. In der Standardeinstellung wird nach Übereinstimmung mit dem
+kÃ¶nnen. In der Standardeinstellung wird nach Ãœbereinstimmung mit dem
 kompletten Rufzeichen (Exact Match) gesucht.
 
-Bei Objekten, die Kleinbuchstaben enthalten, muß "Match Case" gewählt
+Bei Objekten, die Kleinbuchstaben enthalten, muÃŸ "Match Case" gewÃ¤hlt
 werden! Entgegen dem Namen wird ohne "Match Case" der Suchbegriff nur in
-Großbuchstaben umgesetzt...
+GroÃŸbuchstaben umgesetzt...
  
 Mit "Finde jetzt!" wird der Suchvorgang gestarted und bei Erfolg der
-Bildausschnitt so justiert, daß die Station mit einer Übereinstimmung
+Bildausschnitt so justiert, daÃŸ die Station mit einer Ãœbereinstimmung
 in der Mitte zu sehen ist.
 
 HELP-INDEX>Gespeicherte Kartenausschnitte
@@ -1514,19 +1514,19 @@ HELP-INDEX>Gespeicherte Kartenausschnitte
                      Gespeicherte Kartenausschnitte
 
 Klicken sie auf Karten, dann auf "Ausschnitte" und sie erhalten ein
-PopUp-Fenster mit früher gespeicherten Kartenausschnitten. Beim ersten
-Aufruf wird diese Liste noch leer sein. Sie können den aktuellen
+PopUp-Fenster mit frÃ¼her gespeicherten Kartenausschnitten. Beim ersten
+Aufruf wird diese Liste noch leer sein. Sie kÃ¶nnen den aktuellen
 Kartenausschnitt unter einem Namen speichern. Geben sie diesen Namen
-unter "Neuer Name" ein und wählen anschließend "Hinzufügen".
+unter "Neuer Name" ein und wÃ¤hlen anschlieÃŸend "HinzufÃ¼gen".
 
-Nach Markieren eines Namens aus der Liste können sie den gespeicherten
+Nach Markieren eines Namens aus der Liste kÃ¶nnen sie den gespeicherten
 Kartenausschnitt durch "Aktivieren!" wieder herstellen.
 
-Durch Markieren und "Löschen" können Einträge aus der Liste auch wieder
+Durch Markieren und "LÃ¶schen" kÃ¶nnen EintrÃ¤ge aus der Liste auch wieder
 entfernt werden.
 
-"Karte - Objekt in Karte suchen" ist eine weitere Möglichkeit, um einen
-Kartenausschnitt zu ändern, indem ein bestimmtes Objekt bei installierten
+"Karte - Objekt in Karte suchen" ist eine weitere MÃ¶glichkeit, um einen
+Kartenausschnitt zu Ã¤ndern, indem ein bestimmtes Objekt bei installierten
 GNIS-Dateien gesucht werden kann.
 
 HELP-INDEX>Verfolgen einer Station
@@ -1534,9 +1534,9 @@ HELP-INDEX>Verfolgen einer Station
                   Verfolgen einer Station (Tracking)
 
 Klicken sie auf Ansicht, dann auf "Verfolge Station". Geben sie das
-Rufzeichen ein und drücken sie "Verfolge jetzt!". Die verfolgte Station
+Rufzeichen ein und drÃ¼cken sie "Verfolge jetzt!". Die verfolgte Station
 bleibt nun immer auf dem Bildschirm sichtbar. Wenn die Station nahe an
-den Rand des Kartenausschnitts gelangt, wird die Karte nachgeführt. Um
+den Rand des Kartenausschnitts gelangt, wird die Karte nachgefÃ¼hrt. Um
 das Tracking wieder aufzuheben klicken sie auf "Verfolgung aufheben".
 
 HELP-INDEX>Schnittstellen Konfiguration
@@ -1545,176 +1545,176 @@ HELP-INDEX>Schnittstellen Konfiguration
  
 Klicken sie auf Schnittstellen, dann auf Einstellungen
 
-Es erscheint ein Fenster "Installierte Schnittstellen", für die
-verschiedenen Geräte, die sie mit Xastir zusammen benutzen wollen. Dort
-können sie Schnittstellen hinzufügen, löschen und deren Eigenschaften
-ändern.
+Es erscheint ein Fenster "Installierte Schnittstellen", fÃ¼r die
+verschiedenen GerÃ¤te, die sie mit Xastir zusammen benutzen wollen. Dort
+kÃ¶nnen sie Schnittstellen hinzufÃ¼gen, lÃ¶schen und deren Eigenschaften
+Ã¤ndern.
 
-Durch Klick auf "Hinzufügen" können sie ein neues Gerät anmelden,
+Durch Klick auf "HinzufÃ¼gen" kÃ¶nnen sie ein neues GerÃ¤t anmelden,
 es erscheint ein Fenster zur Auswahl des Schnittstellentyps.
 
-Momentan sind verfügbar:
+Momentan sind verfÃ¼gbar:
   Serieller TNC
   Serieller TNC plus GPS mit HSP-Kabel
-  Serieller GPS-Empfänger
+  Serieller GPS-EmpfÃ¤nger
   Serielle Wetterstation
   Internet Server
   AX.25 TNC
-  GPS über Netzwerk (via gpsd)
-  Wetterstation über Netzwerk
+  GPS Ã¼ber Netzwerk (via gpsd)
+  Wetterstation Ã¼ber Netzwerk
 
-Markieren sie das gewünschte Gerät aus der Liste und Klicken auf
-"Hinzufügen", es erscheint dann ein Fenster, indem sie die verschiedene
-Eigenschaften für dieses Gerät festlegen können. Tragen sie die
-benötigten Werte ein und bestätigen sie mit OK.
+Markieren sie das gewÃ¼nschte GerÃ¤t aus der Liste und Klicken auf
+"HinzufÃ¼gen", es erscheint dann ein Fenster, indem sie die verschiedene
+Eigenschaften fÃ¼r dieses GerÃ¤t festlegen kÃ¶nnen. Tragen sie die
+benÃ¶tigten Werte ein und bestÃ¤tigen sie mit OK.
 
-Ein Gerät kann nach Markierung mit einem Klick auf "Löschen" wieder
+Ein GerÃ¤t kann nach Markierung mit einem Klick auf "LÃ¶schen" wieder
 entfernt werden.
 
-Mit "Einstellungen" erhalten sie für das markierte Gerät aus der
-Schnittstellenliste ein Fenster, indem sie verschiedene Parameter ändern
-können.
+Mit "Einstellungen" erhalten sie fÃ¼r das markierte GerÃ¤t aus der
+Schnittstellenliste ein Fenster, indem sie verschiedene Parameter Ã¤ndern
+kÃ¶nnen.
 
-Weiterfürende Hilfe findet man in den Abschnitten für die einzelnen
+WeiterfÃ¼rende Hilfe findet man in den Abschnitten fÃ¼r die einzelnen
 Schnittstellentypen.
 
 HELP-INDEX>Serieller TNC
 
                                Serieller TNC
 
-Dieser Abschnitt behandelt das Hinzufügen oder Ändern von seriellen TNCs
-und seriellen TNCs mit einem GPS über ein HSP-Kabel.
+Dieser Abschnitt behandelt das HinzufÃ¼gen oder Ã„ndern von seriellen TNCs
+und seriellen TNCs mit einem GPS Ã¼ber ein HSP-Kabel.
 
-Wenn sie ein HSP-Kabel besitzen, können sie diesen Eintrag auswählen und
-dann sowohl den TNC als auch den GPS-Empfänger über die gleiche serielle
-Schnittstelle anschließen. Es handelt sich um ein spezielles Kabel, bei
-dem die Empfangsleitung durch den Computer zwischen den beiden Geräten
-umgeschaltet werden kann. Es arbeitet möglicherweise nicht mit allen
-möglichen Kombinationen von Computer, TNC und GPS. Der TNC und der GPS
-müssen auf die gleichen Kommunikationsparameter eingestellt werden,
-üblicherweise also 4800 bps, 8 Datenbits, keine Parität und 1 Stopbit.
+Wenn sie ein HSP-Kabel besitzen, kÃ¶nnen sie diesen Eintrag auswÃ¤hlen und
+dann sowohl den TNC als auch den GPS-EmpfÃ¤nger Ã¼ber die gleiche serielle
+Schnittstelle anschlieÃŸen. Es handelt sich um ein spezielles Kabel, bei
+dem die Empfangsleitung durch den Computer zwischen den beiden GerÃ¤ten
+umgeschaltet werden kann. Es arbeitet mÃ¶glicherweise nicht mit allen
+mÃ¶glichen Kombinationen von Computer, TNC und GPS. Der TNC und der GPS
+mÃ¼ssen auf die gleichen Kommunikationsparameter eingestellt werden,
+Ã¼blicherweise also 4800 bps, 8 Datenbits, keine ParitÃ¤t und 1 Stopbit.
 
-Optionen für die TNC-Schnittstelle:
+Optionen fÃ¼r die TNC-Schnittstelle:
 Durch Markieren von "Beim Start aktivieren" wird Xastir bei jedem
 Programmstart versuchen, diese Schnittstelle einzuschalten.
 
-"Senden erlaubt" legt fest, ob über diese Schnittstelle überhaupt Daten
-gesendet werden dürfen.
+"Senden erlaubt" legt fest, ob Ã¼ber diese Schnittstelle Ã¼berhaupt Daten
+gesendet werden dÃ¼rfen.
 
 Als TNC Port wird das Unix Device eingetragen, mit dem der TNC (oder TNC
 und GPS) verbunden ist. Normalerweise geben sie hier /dev/ttyS0 (COM1),
 /dev/ttyS1 (COM2) etc. an.
 
-Setzen sie nun die Baudrate und die Anzahl der Datenbits. 8N1 steht für
-8 Datenbits, keine Parität und 1 Stopbit, 7E1 für 7 Datenbits, gerade
-Parität und 1 Stopbit und 7O1 arbeitet mit ungerader Parität. Bei
-Verwendung des HSP-Kabels müssen diese Einstellungen für TNC und GPS
+Setzen sie nun die Baudrate und die Anzahl der Datenbits. 8N1 steht fÃ¼r
+8 Datenbits, keine ParitÃ¤t und 1 Stopbit, 7E1 fÃ¼r 7 Datenbits, gerade
+ParitÃ¤t und 1 Stopbit und 7O1 arbeitet mit ungerader ParitÃ¤t. Bei
+Verwendung des HSP-Kabels mÃ¼ssen diese Einstellungen fÃ¼r TNC und GPS
 identisch sein.
 
-Mit den IGate Optionen können sie festlegen, in welche Richtung
-Internetverkehr über diese Schnittstelle erfolgen kann. Dies kann für
-jedes Gerät getrennt eingestellt werden. Wenn sie kein IGate betreiben,
+Mit den IGate Optionen kÃ¶nnen sie festlegen, in welche Richtung
+Internetverkehr Ã¼ber diese Schnittstelle erfolgen kann. Dies kann fÃ¼r
+jedes GerÃ¤t getrennt eingestellt werden. Wenn sie kein IGate betreiben,
 lassen sie die Einstellungen auf "Disable".
 
 Tragen sie bis zu drei UNPROTO Pfade ein, Xastir gibt dabei das
 Zielrufzeichen vor. Falls mehrere Pfade (bis zu drei) eingetragen wurden,
 so verwendet Xastir diese abwechselnd bei jeder Aussendung, um so auch in
-schwierigen Situationen gehört zu werden. Wenn sie nur lokalen Verkehr
-haben, so genügt ein einzelnes WIDE2-2. Bei wenig Leistung oder größerer
-Entfernung von einem Digipeater dürfte "WIDE1-1,WIDE2-2" besser funktionieren.
-Wenn sie das Rufzeichen eines benachbarten Digis kennen, können sie auch
-alle Pakete über diesen schicken, indem sie es an erster Stelle nennen,
-also z.B. "DB0XYZ,WIDE2-2". Für die meisten Stationen wird ein Pfad genügen,
+schwierigen Situationen gehÃ¶rt zu werden. Wenn sie nur lokalen Verkehr
+haben, so genÃ¼gt ein einzelnes WIDE2-2. Bei wenig Leistung oder grÃ¶ÃŸerer
+Entfernung von einem Digipeater dÃ¼rfte "WIDE1-1,WIDE2-2" besser funktionieren.
+Wenn sie das Rufzeichen eines benachbarten Digis kennen, kÃ¶nnen sie auch
+alle Pakete Ã¼ber diesen schicken, indem sie es an erster Stelle nennen,
+also z.B. "DB0XYZ,WIDE2-2". FÃ¼r die meisten Stationen wird ein Pfad genÃ¼gen,
 in abgelegenen Gegenden oder unter schwierigen Bedingungen kann es
-sinnvoll sein, mehrere einzutragen. Am besten läßt es sich mit örtlichen
-Funkamateuren abklären, welcher Pfad geeignet ist, um einerseits gut
-gehört zu werden, andererseits aber die Frequenzen nicht unnötig zu
+sinnvoll sein, mehrere einzutragen. Am besten lÃ¤ÃŸt es sich mit Ã¶rtlichen
+Funkamateuren abklÃ¤ren, welcher Pfad geeignet ist, um einerseits gut
+gehÃ¶rt zu werden, andererseits aber die Frequenzen nicht unnÃ¶tig zu
 belasten. In Gegenden mit intelligenten Digis, die Wiederholungsschleifen
 weitgehend vermeiden, kann auch z.B. WIDE3-3 oder "WIDE1-1,WIDE3-3"
 verwendet werden.
 
 Die TNC Startup und Shutdown Dateien befinden sich im Verzeichnis
 /usr/local/share/xastir/config und werden beim Starten bzw. Stoppen der
-TNC-Verbindung zur Initialisierung ausgeführt. Es handelt sich um
+TNC-Verbindung zur Initialisierung ausgefÃ¼hrt. Es handelt sich um
 normale Textdateien mit Kommandos, die an den TNC gesendet werden.
 
 HELP-INDEX>AX.25 TNC Schnittstellen
 
                          AX.25 TNC Schnittstellen
 
-Als AX.25 TNC Device kann jedes Gerät verwendet werden, daß über ein
+Als AX.25 TNC Device kann jedes GerÃ¤t verwendet werden, daÃŸ Ã¼ber ein
 Linux AX.25 Treiber angesprochen werden kann. Hierbei handelt es sich um
 einen Kernel-Treiber, der z.B. auch das Baycom-Modem oder ein Packet
-Radio über die Soundkarte unterstützt. Diese Geräte müssen vor dem Start
-von Xastir in Linux eingerichtet werden, bevor sie benutzt werden können.
+Radio Ã¼ber die Soundkarte unterstÃ¼tzt. Diese GerÃ¤te mÃ¼ssen vor dem Start
+von Xastir in Linux eingerichtet werden, bevor sie benutzt werden kÃ¶nnen.
 
 Durch Markieren von "Beim Start aktivieren" wird Xastir bei jedem
 Programmstart versuchen, diese Schnittstelle einzuschalten.
 
-"Senden erlaubt" legt fest, ob über diese Schnittstelle überhaupt Daten
-gesendet werden dürfen.
+"Senden erlaubt" legt fest, ob Ã¼ber diese Schnittstelle Ã¼berhaupt Daten
+gesendet werden dÃ¼rfen.
 
-Mit den IGate Optionen können sie festlegen, in welche Richtung
-Internetverkehr über diese Schnittstelle erfolgen kann. Dies kann für
-jedes Gerät getrennt eingestellt werden. Wenn sie kein IGate betreiben,
+Mit den IGate Optionen kÃ¶nnen sie festlegen, in welche Richtung
+Internetverkehr Ã¼ber diese Schnittstelle erfolgen kann. Dies kann fÃ¼r
+jedes GerÃ¤t getrennt eingestellt werden. Wenn sie kein IGate betreiben,
 lassen sie die Einstellungen auf "Disable".
 
-Geben sie den für das AX.25-Gerät festgelegten Device-Namen an, wie er
+Geben sie den fÃ¼r das AX.25-GerÃ¤t festgelegten Device-Namen an, wie er
 in der Datei /etc/ax25/axports steht.
 
 Tragen sie bis zu drei UNPROTO Pfade ein, Xastir gibt dabei das
 Zielrufzeichen vor. Falls mehrere Pfade (bis zu drei) eingetragen wurden,
 so verwendet Xastir diese abwechselnd bei jeder Aussendung, um so auch in
-schwierigen Situationen gehört zu werden. Wenn sie nur lokalen Verkehr
-haben, so genügt ein einzelnes WIDE2-2. Bei wenig Leistung oder größerer
-Entfernung von einem Digipeater dürfte "WIDE1-1,WIDE2-2" besser funktionieren.
-Wenn sie das Rufzeichen eines benachbarten Digis kennen, können sie auch
-alle Pakete über diesen schicken, indem sie es an erster Stelle nennen,
-also z.B. "DB0XYZ,WIDE2-2". Für die meisten Stationen wird ein Pfad genügen,
+schwierigen Situationen gehÃ¶rt zu werden. Wenn sie nur lokalen Verkehr
+haben, so genÃ¼gt ein einzelnes WIDE2-2. Bei wenig Leistung oder grÃ¶ÃŸerer
+Entfernung von einem Digipeater dÃ¼rfte "WIDE1-1,WIDE2-2" besser funktionieren.
+Wenn sie das Rufzeichen eines benachbarten Digis kennen, kÃ¶nnen sie auch
+alle Pakete Ã¼ber diesen schicken, indem sie es an erster Stelle nennen,
+also z.B. "DB0XYZ,WIDE2-2". FÃ¼r die meisten Stationen wird ein Pfad genÃ¼gen,
 in abgelegenen Gegenden oder unter schwierigen Bedingungen kann es
-sinnvoll sein, mehrere einzutragen. Am besten läßt es sich mit örtlichen
-Funkamateuren abklären, welcher Pfad geeignet ist, um einerseits gut
-gehört zu werden, andererseits aber die Frequenzen nicht unnötig zu
+sinnvoll sein, mehrere einzutragen. Am besten lÃ¤ÃŸt es sich mit Ã¶rtlichen
+Funkamateuren abklÃ¤ren, welcher Pfad geeignet ist, um einerseits gut
+gehÃ¶rt zu werden, andererseits aber die Frequenzen nicht unnÃ¶tig zu
 belasten. In Gegenden mit intelligenten Digis, die Wiederholungsschleifen
 weitgehend vermeiden, kann auch z.B. WIDE3-3 oder "WIDE1-1,WIDE3-3"
 verwendet werden.
 
-Anmerkung: Um die AX.25 Treiber verwenden zu können, muß Xastir unter
-"root"-Rechten laufen. Um Xastir als normaler Benutzer zu starten, muß
+Anmerkung: Um die AX.25 Treiber verwenden zu kÃ¶nnen, muÃŸ Xastir unter
+"root"-Rechten laufen. Um Xastir als normaler Benutzer zu starten, muÃŸ
 das suid Bit beim Xastir-Programm gesetzt werden. Hierzu dient das
 folgende Kommando (als root): "chmod a+s /usr/local/bin/xastir".
 
-Beachten sie bitte, daß jedes Programm, das auf diese Weise läuft, als
+Beachten sie bitte, daÃŸ jedes Programm, das auf diese Weise lÃ¤uft, als
 Sicherheitsrisiko angesehen werden kann. Es wurde nicht besonders auf
-mögliche Sicherheitsrisiken hin getestet, benutzen sie es also in einer
+mÃ¶gliche Sicherheitsrisiken hin getestet, benutzen sie es also in einer
 Mehrbenutzer-Umgebung mit Vorsicht und auf eigenes Riskio!
 
 HELP-INDEX>Serieller GPS
 
                               Serieller GPS
 
-Setzen sie die serielle Schnittstelle für den GPS Empfänger. Gängige
-Einträge sind hier /dev/ttyS0 (COM1) oder /dev/ttyS1 (COM2).
+Setzen sie die serielle Schnittstelle fÃ¼r den GPS EmpfÃ¤nger. GÃ¤ngige
+EintrÃ¤ge sind hier /dev/ttyS0 (COM1) oder /dev/ttyS1 (COM2).
 
 Durch Markieren von "Beim Start aktivieren" wird Xastir bei jedem
 Programmstart versuchen, diese Schnittstelle einzuschalten.
 
-Setzen sie nun die Baudrate und die Anzahl der Datenbits. 8N1 steht für
-acht Datenbits, keine Parität und 1 Stopbit, 7E1 für 7 Datenbits, gerade
-Parität und 1 Stopbit und 7O1 arbeitet mit ungerader Parität. Die Daten
-müssen mit denen des GPS-Empfängers übereinstimmen, die meisten Geräte
-verwenden im benötigten NMEA-Modus 4800 bps und 8N1.
+Setzen sie nun die Baudrate und die Anzahl der Datenbits. 8N1 steht fÃ¼r
+acht Datenbits, keine ParitÃ¤t und 1 Stopbit, 7E1 fÃ¼r 7 Datenbits, gerade
+ParitÃ¤t und 1 Stopbit und 7O1 arbeitet mit ungerader ParitÃ¤t. Die Daten
+mÃ¼ssen mit denen des GPS-EmpfÃ¤ngers Ã¼bereinstimmen, die meisten GerÃ¤te
+verwenden im benÃ¶tigten NMEA-Modus 4800 bps und 8N1.
 
-HELP-INDEX>GPS über Netzwerk
+HELP-INDEX>GPS Ã¼ber Netzwerk
 
-                             GPS über Netzwerk
+                             GPS Ã¼ber Netzwerk
 
-Wenn sie die GPS-Daten für verschiedene Programme bzw. Computer
-benötigen, ist diese Auswahl die geeignetste. Hierzu muß vorher der gpsd
+Wenn sie die GPS-Daten fÃ¼r verschiedene Programme bzw. Computer
+benÃ¶tigen, ist diese Auswahl die geeignetste. Hierzu muÃŸ vorher der gpsd
 eingerichtet worden sein, von dem Xastir dann, neben anderen Programmen,
 die GPS-Daten beziehen kann.
 
-Tragen sie Namen (oder IP-Adresse) und Port-Nummer für den gpsd Rechner
+Tragen sie Namen (oder IP-Adresse) und Port-Nummer fÃ¼r den gpsd Rechner
 in ihrem Netzwerk ein.
 
 Durch Markieren von "Beim Start aktivieren" wird Xastir bei jedem
@@ -1733,15 +1733,15 @@ lokale Daten ins Internet zu senden.
 Durch Markieren von "Beim Start aktivieren" wird Xastir bei jedem
 Programmstart versuchen, diese Schnittstelle einzuschalten.
 
-"Senden erlaubt" legt fest, ob über diese Schnittstelle überhaupt Daten
-ins Internet gesendet werden dürfen.
+"Senden erlaubt" legt fest, ob Ã¼ber diese Schnittstelle Ã¼berhaupt Daten
+ins Internet gesendet werden dÃ¼rfen.
 
 Tragen sie Namen (oder IP-Adresse) und Port-Nummer des Internet Servers
 ein, den sie ansprechen wollen.
 
-Geben sie einen gültigen Schlüssel (Pass-Code) ein um Daten über ein
-IGate senden zu können. Wenn sie keinen Schlüssel passend zu ihrem
-Rufzeichen haben, können sie einen mit dem beigefügten Programm
+Geben sie einen gÃ¼ltigen SchlÃ¼ssel (Pass-Code) ein um Daten Ã¼ber ein
+IGate senden zu kÃ¶nnen. Wenn sie keinen SchlÃ¼ssel passend zu ihrem
+Rufzeichen haben, kÃ¶nnen sie einen mit dem beigefÃ¼gten Programm
 "callpass" erzeugen. Wenn es noch nicht bereits kompiliert wurde, geben
 hierzu sie im src Verzeicnis "make callpass" ein.
 
@@ -1752,31 +1752,31 @@ HELP-INDEX>Serielle Wetterstation
 
                           Serielle Wetterstation
 
-Tragen sie die serielle Schnittstelle für die Wetterstation ein. Gängige
-Einträge sind hier /dev/ttyS0 (COM1) oder /dev/ttyS1 (COM2).
+Tragen sie die serielle Schnittstelle fÃ¼r die Wetterstation ein. GÃ¤ngige
+EintrÃ¤ge sind hier /dev/ttyS0 (COM1) oder /dev/ttyS1 (COM2).
 
 Durch Markieren von "Beim Start aktivieren" wird Xastir bei jedem
 Programmstart versuchen, diese Schnittstelle einzuschalten.
 
-Setzen sie nun die Baudrate und die Anzahl der Datenbits. 8N1 steht für
-acht Datenbits, keine Parität und 1 Stopbit, 7E1 für 7 Datenbits, gerade
-Parität und 1 Stopbit und 7O1 arbeitet mit ungerader Parität. Die Daten
-müssen mit denen ihrer Wetterstation übereinstimmen.
+Setzen sie nun die Baudrate und die Anzahl der Datenbits. 8N1 steht fÃ¼r
+acht Datenbits, keine ParitÃ¤t und 1 Stopbit, 7E1 fÃ¼r 7 Datenbits, gerade
+ParitÃ¤t und 1 Stopbit und 7O1 arbeitet mit ungerader ParitÃ¤t. Die Daten
+mÃ¼ssen mit denen ihrer Wetterstation Ã¼bereinstimmen.
 
 Durch die Angabe der "Datenart" kann festgelegt werden, welche Daten das
-Programm über die serielle Schnittstelle erwartet. Bei "Automatisch" wird
-zunächst nach Wetterdaten im Binärformat geschaut, wie es die Radio Shack
-WX-200 Wetterstation liefert. Falls keine Binärdaten im Datenstrom
+Programm Ã¼ber die serielle Schnittstelle erwartet. Bei "Automatisch" wird
+zunÃ¤chst nach Wetterdaten im BinÃ¤rformat geschaut, wie es die Radio Shack
+WX-200 Wetterstation liefert. Falls keine BinÃ¤rdaten im Datenstrom
 gefunden werden, versucht Xastir eine Wetterstation mit ASCII-Daten zu
 finden (wie Peet Bros.).
 
-HELP-INDEX>Wetterstation über Netzwerk
+HELP-INDEX>Wetterstation Ã¼ber Netzwerk
 
-                     Wetterstation über Netzwerk
+                     Wetterstation Ã¼ber Netzwerk
 
 Xastir kann Wetterdaten Server wie den wx200d ansprechen. wx200d erlaubt
-mehrere Netzwerkverbindungen, so daß Wetterdaten gleichzeitig
-verschiednen Programmen oder Computern zur Verfügung steht.
+mehrere Netzwerkverbindungen, so daÃŸ Wetterdaten gleichzeitig
+verschiednen Programmen oder Computern zur VerfÃ¼gung steht.
 
 Tragen sie Namen (oder IP-Adresse) und Port-Nummer des Wetterdaten
 Servers in ihrem Netzwerk ein.
@@ -1788,55 +1788,55 @@ Durch Markieren von "Wiederverbinden nach Fehler" versucht Xastir die
 Netzwerkverbindung nach einem Fehler wieder herzustellen.
 
 Wie im vorigen Abschnitt kann durch Angabe von "Datenart" die
-automatische Auswahl überschrieben werden.
+automatische Auswahl Ã¼berschrieben werden.
 
 HELP-INDEX>Ausdrucken des Bildschirms
 
                       Ausdrucken des Bildschirms
 
-Xastir kann den dargestellten Kartenausschnitt in Schwarz-Weiß oder in
-Farbe ausdrucken. Hierbei wird das Bild zunächst als XPixmap-Datei
+Xastir kann den dargestellten Kartenausschnitt in Schwarz-WeiÃŸ oder in
+Farbe ausdrucken. Hierbei wird das Bild zunÃ¤chst als XPixmap-Datei
 gespeichert, dann werden externen Zusatzprogramme gestartet, um es ins
 PostScript-Format zu konvertieren, zu skalieren und rotieren, eine
-Vorschau zu ermöglichen und es schließlich zu drucken.
+Vorschau zu ermÃ¶glichen und es schlieÃŸlich zu drucken.
 
-Hierfür muß Ihr System so eingerichtet sein, daß Sie PostScript-Dateien
-drucken können, gewöhnlich wird hierfür ghostscript, installierte
-Druckerfilter sowie ein lp oder lpr Druckerspooler benötigt. Für die
-Erstellung der Ausdrucke müssen dann die folgenden Pakete installiert
+HierfÃ¼r muÃŸ Ihr System so eingerichtet sein, daÃŸ Sie PostScript-Dateien
+drucken kÃ¶nnen, gewÃ¶hnlich wird hierfÃ¼r ghostscript, installierte
+Druckerfilter sowie ein lp oder lpr Druckerspooler benÃ¶tigt. FÃ¼r die
+Erstellung der Ausdrucke mÃ¼ssen dann die folgenden Pakete installiert
 sein: ImageMagick (speziell "convert"), Ghostscript nebst Schriften, und
-"gv". Wenn diese Pakete funktionsfähig sind, so sollte kurz nach dem
+"gv". Wenn diese Pakete funktionsfÃ¤hig sind, so sollte kurz nach dem
 Druckbefehl in Xastir ein "gv"-Fenster aufgehen, in dem man das Druckbild
-zunächst begutachten kann. Falls das Ergebnis zufriedenstellend ist, kann
+zunÃ¤chst begutachten kann. Falls das Ergebnis zufriedenstellend ist, kann
 es von gv aus ausgedruckt werden.
 
-Beachten Sie, daß es in Abhängigkeit von den dargestellten Karten
-sinnvoll sein kann, den Kartenhintergrund auf weiße Farbe zu ändern,
+Beachten Sie, daÃŸ es in AbhÃ¤ngigkeit von den dargestellten Karten
+sinnvoll sein kann, den Kartenhintergrund auf weiÃŸe Farbe zu Ã¤ndern,
 hierdurch kann gegebenenfalls einiges an Tinte gespart werden.
 
-HELP-INDEX>Erstellen automatischer Schnappschüsse
+HELP-INDEX>Erstellen automatischer SchnappschÃ¼sse
 
-                Erstellen automatischer Schnappschüsse
+                Erstellen automatischer SchnappschÃ¼sse
 
-Xastir hat die Fähigkeit, wiederholt automatische Schnappschüsse des
+Xastir hat die FÃ¤higkeit, wiederholt automatische SchnappschÃ¼sse des
 dargestellten Kartenausschnitts anzufertigen. Momentan erfolgt dies alle
-fünf Minuten. Unter der Voraussetzung, daß "convert" aus dem ImageMagick-
+fÃ¼nf Minuten. Unter der Voraussetzung, daÃŸ "convert" aus dem ImageMagick-
 Paket installiert ist, erzeugt Xastir eine XPM-Datei in /var/tmp und
 konvertiert diese dann in die PNG-Datei /var/tmp/xastir_snap.png.
-Hiermit kann das aktuelle Geschehen z.B. auf einer regelmäßig
-aktualisierten Webpage dargestellt werden. Schnappschüsse werden über
-Datei - Schnappschüsse eingeschaltet.
+Hiermit kann das aktuelle Geschehen z.B. auf einer regelmÃ¤ÃŸig
+aktualisierten Webpage dargestellt werden. SchnappschÃ¼sse werden Ã¼ber
+Datei - SchnappschÃ¼sse eingeschaltet.
 
 HELP-INDEX>Symboltabelle
 
                           Symboltabelle
 
-Dies sind die Definitionen der für ihre Station oder für Objekte
-wählbaren Symbole. Es stehen zwei Gruppen zur Verfügung, mit teilweise
+Dies sind die Definitionen der fÃ¼r ihre Station oder fÃ¼r Objekte
+wÃ¤hlbaren Symbole. Es stehen zwei Gruppen zur VerfÃ¼gung, mit teilweise
 unterschiedlichen Symbolen bei gleichem Symbolbuchstaben. Die Grafiken
 aus der alternative Gruppe "\" werden auch herangezogen, wenn ein Overlay
 erfolgen soll. Hierzu wird als Gruppe ein Buchstabe [A-Z] oder eine
-Zahl [0-9] eingegeben, dies erscheint dann überlagert über dem Symbol.
+Zahl [0-9] eingegeben, dies erscheint dann Ã¼berlagert Ã¼ber dem Symbol.
 Die aktuelle Liste findet man in der APRS Reference, die es bei
 http://www.tapr.org gibt.
 
@@ -1944,101 +1944,101 @@ HELP-INDEX>Was war neu in Xastir V1.0
 
                      Was war neu in Xastir V1.0
 
-Während des vergangenen Jahres wurde Xastir weiterentwickelt und dieses
-Release ist das Ergebnis dieser Bemühungen. Die Entwicklung wurde von
-Chuck Byam geleitet, der das Projekt mit dem Einverständnis von Frank
-Giannandrea übernommen hat. Viele andere haben zum Erfolg des Projects
+WÃ¤hrend des vergangenen Jahres wurde Xastir weiterentwickelt und dieses
+Release ist das Ergebnis dieser BemÃ¼hungen. Die Entwicklung wurde von
+Chuck Byam geleitet, der das Projekt mit dem EinverstÃ¤ndnis von Frank
+Giannandrea Ã¼bernommen hat. Viele andere haben zum Erfolg des Projects
 beigetragen, eine Auflistung findet sich in der Datei AUTHORS.
 
 Das Xastir Paket benutzt nun GNU autoconf um die Makefiles zu erstellen
 und verschiedene Eigenschaften aufgrund der installierten Bibliotheken
-und Software auszuwählen.
+und Software auszuwÃ¤hlen.
 
-Beim Start von Xastir V1.0 werden sie womöglich nicht sofort größere
-Änderungen entdecken. Die bekannte Bedienoberfläche wurde weitgehend
-beibehalten. Der größte Teil der Änderungen bleibt im Verborgenen und
+Beim Start von Xastir V1.0 werden sie womÃ¶glich nicht sofort grÃ¶ÃŸere
+Ã„nderungen entdecken. Die bekannte BedienoberflÃ¤che wurde weitgehend
+beibehalten. Der grÃ¶ÃŸte Teil der Ã„nderungen bleibt im Verborgenen und
 dient einer Steigerungen der Effizienz:
 
 o Die Startzeit des Programms wurde verbessert
 
-o Der Speicherbedarf wurde durch dynamische Speicherzuweisung für
+o Der Speicherbedarf wurde durch dynamische Speicherzuweisung fÃ¼r
   Stationen, Spuren und Wetterdaten stark verbessert. D.h. es wird kein
-  Speicher mehr verschwendet für nicht vorhandene Spurdaten bei festen
+  Speicher mehr verschwendet fÃ¼r nicht vorhandene Spurdaten bei festen
   Stationen oder Wetterdaten bei den meisten Stationen. Mit diesen
-  Änderungen ist es möglich, Xastir komfortabel mit dem Internet zu
+  Ã„nderungen ist es mÃ¶glich, Xastir komfortabel mit dem Internet zu
   verbinden, auch wenn nur sehr wenig Speicher vorhanden ist.
 
 o Das Laden der Karten wurde verbessert, indem nun nicht mehr bei jeder
-  kleinen Änderung die Karte neu von der Festplatte geladen werden muß.
-  Wetterwarnungen und Änderungen an den Einstellungen für die Darstellung
+  kleinen Ã„nderung die Karte neu von der Festplatte geladen werden muÃŸ.
+  Wetterwarnungen und Ã„nderungen an den Einstellungen fÃ¼r die Darstellung
   und Tracking Optionen erfordern kein Neuladen der Karten, stattdessen
   werden nur die Symbole und die Spuren neu gezeichnet.
 
-o Verschiedene Dialog-Fenster, die früher häufig neu gezeichnet wurden,
+o Verschiedene Dialog-Fenster, die frÃ¼her hÃ¤ufig neu gezeichnet wurden,
   werden nun nur bei Bedarf aktualisiert und sind damit auch auf
-  langsameren Systemen akzeptabel. Dies gilt auch für das Verfolgen einer
+  langsameren Systemen akzeptabel. Dies gilt auch fÃ¼r das Verfolgen einer
   Station (Tracking), wobei die Karte nun nur neu gezeichnet wird, wenn
-  die Station sich dem Rand des Bildschirms nähert.
+  die Station sich dem Rand des Bildschirms nÃ¤hert.
 
-Dank dieser Änderungen kann Xastir problemlos auch auf langsameren
+Dank dieser Ã„nderungen kann Xastir problemlos auch auf langsameren
 Pentium(tm) Rechnern eingesetzt werden.  
   
-Unterstützung für das GeoTIFF Kartenformat ist nun vorhanden und wird
+UnterstÃ¼tzung fÃ¼r das GeoTIFF Kartenformat ist nun vorhanden und wird
 in Xastir einkompiliert, wenn die GeoTiff Bibliotheken auf dem System
-installiert sind. Diese Karten sind von hoher Qualität und besonders für
+installiert sind. Diese Karten sind von hoher QualitÃ¤t und besonders fÃ¼r
 Such- und Rettungsoperationen zu gebrauchen. Karten in diesem Format sind
-vom USGS und kommerziell auf CD-ROM erhältlich. Xastir weiß, wie das
-Datum von NAD-27 in WGS-84 umzurechnen ist, so daß Karten in beiden
-Formaten ohne Genauigkeitsverlust gelesen werden können. Zusätzliche
-Tasten wurden in der Kartenauswahl hinzugefügt, um schnell alle Karten
-einer bestimmten Art auszuwählen.
+vom USGS und kommerziell auf CD-ROM erhÃ¤ltlich. Xastir weiÃŸ, wie das
+Datum von NAD-27 in WGS-84 umzurechnen ist, so daÃŸ Karten in beiden
+Formaten ohne Genauigkeitsverlust gelesen werden kÃ¶nnen. ZusÃ¤tzliche
+Tasten wurden in der Kartenauswahl hinzugefÃ¼gt, um schnell alle Karten
+einer bestimmten Art auszuwÃ¤hlen.
 
-Das oben gesagte gilt in erster Linie für die USA, wo es jede Menge
-Karten gibt. Bei uns gibt es zwar schönere topgraphische Karten, dafür
+Das oben gesagte gilt in erster Linie fÃ¼r die USA, wo es jede Menge
+Karten gibt. Bei uns gibt es zwar schÃ¶nere topgraphische Karten, dafÃ¼r
 gibt es aber so gut wie nichts kostenlos, und damit auch kein
 verbreitetes Standardformat.
   
-Xastir unterstützt nun das Setzen und Löschen von Objekten. Objekte
-können verwendet werden, um Treffen anzuzeigen, Reisenden Hinweise zu
-geben oder Such- und Rettungseinsätze durchzuführen.
+Xastir unterstÃ¼tzt nun das Setzen und LÃ¶schen von Objekten. Objekte
+kÃ¶nnen verwendet werden, um Treffen anzuzeigen, Reisenden Hinweise zu
+geben oder Such- und RettungseinsÃ¤tze durchzufÃ¼hren.
 
 Die amerikanischen County Wetterwarnungs-Karten werden nicht mehr direkt
-auf die Karten gezeichnet, sondern mit der Karte überlagert. Einerseits
-sind die Farben dadurch verfälscht, aber es ist nun möglich, die
-Straßenkarten auch im Warnungsgebiet zu erkennen.
+auf die Karten gezeichnet, sondern mit der Karte Ã¼berlagert. Einerseits
+sind die Farben dadurch verfÃ¤lscht, aber es ist nun mÃ¶glich, die
+StraÃŸenkarten auch im Warnungsgebiet zu erkennen.
 
-Eine neue und nützliche Eigenschaft ist, daß sich die Ausrichtung einiger
-Symbole ändert, je nachdem in welche Richtung sich z.B. ein Fahrzeug
-bewegt. Auch ohne die zurückgelegte Spur kann man die Richtung einer
+Eine neue und nÃ¼tzliche Eigenschaft ist, daÃŸ sich die Ausrichtung einiger
+Symbole Ã¤ndert, je nachdem in welche Richtung sich z.B. ein Fahrzeug
+bewegt. Auch ohne die zurÃ¼ckgelegte Spur kann man die Richtung einer
 Mobilstation mit einem Blick erfassen. Es gibt einige weitere Optionen
 im Menu Darstellung mit denen man genauer festlegen kann, was angezeigt
 werden soll und was nicht.
 
-Das Verschieben und die Kontrolle über den Kartenausschnitt wurde
+Das Verschieben und die Kontrolle Ã¼ber den Kartenausschnitt wurde
 verbessert: Es gibt nun Pfeile oben rechts im Menu, um die Karte mit der
 Maus zu verschieben. Die Karte kann auch mit den Cursortasten verschoben
-werden und die Vergrößerung kann mit den PgUp und PgDn Tasten eingestellt
+werden und die VergrÃ¶ÃŸerung kann mit den PgUp und PgDn Tasten eingestellt
 werden. Im PopUp-Menu der linken Maustaste gibt es neue Optionen um die
 Karte an der aktuellen Position zu zentrieren oder dort ein Pbjekt zu
-platzieren. Die Verschiebemöglichkeiten über dieses Menu wurden zugunsten
+platzieren. Die VerschiebemÃ¶glichkeiten Ã¼ber dieses Menu wurden zugunsten
 der oben genannten entfernt.
 
-Unterstützung für Alternative Netzwerke wurde hinzugefügt, hiermit wird
-es möglich, ein privates APRS(tm) Netzwerk einzurichten für
-Veranstaltungen, für Such- und Rettungseinsätze, Sturmjagd, oder für
+UnterstÃ¼tzung fÃ¼r Alternative Netzwerke wurde hinzugefÃ¼gt, hiermit wird
+es mÃ¶glich, ein privates APRS(tm) Netzwerk einzurichten fÃ¼r
+Veranstaltungen, fÃ¼r Such- und RettungseinsÃ¤tze, Sturmjagd, oder fÃ¼r
 alles wo der Benutzer nicht von Hunderten von APRS(tm)-Stationen um ihn
 herum genervt werden will.
 
-Es gibt viele kleine Änderungen, sichtbar oder unsichtbar für den
+Es gibt viele kleine Ã„nderungen, sichtbar oder unsichtbar fÃ¼r den
 Benutzer. Die Schnittstellen-Steuerung hat nun eine Option, um alle
 Schnittstellen gleichzeitig zu starten oder zu stoppen, um dem Benutzer
-es zu ersparen, dies für jede Schnittstelle einzeln tun zu müssen. Die
-Stationseinstellungen zeigen nun das gewählte Symbol, so daß man das
-Fenster nicht mehr verlassen muß, um es zu sehen. Einige Pufferüberläufe,
-die unvorhersagbares Verhalten oder Programmabstürze hervorgerufen
-hatten, wurden beseitigt. Und viele kleinere Änderungen wurden am
+es zu ersparen, dies fÃ¼r jede Schnittstelle einzeln tun zu mÃ¼ssen. Die
+Stationseinstellungen zeigen nun das gewÃ¤hlte Symbol, so daÃŸ man das
+Fenster nicht mehr verlassen muÃŸ, um es zu sehen. Einige PufferÃ¼berlÃ¤ufe,
+die unvorhersagbares Verhalten oder ProgrammabstÃ¼rze hervorgerufen
+hatten, wurden beseitigt. Und viele kleinere Ã„nderungen wurden am
 Quelltext vorgenommen, damit Xastir auf verschiedenen Systemen fehlerfrei
-übersetzt werden kann.
+Ã¼bersetzt werden kann.
 
 Viel Freude mit dem neuen Xastir!
 

--- a/help/help-Italian.dat
+++ b/help/help-Italian.dat
@@ -5,7 +5,7 @@ HELP-INDEX>Leggimi - Licenza
 Per informazioni sulla versione corrente del programma leggere README.1ST nella 
 cartella di Xastir.
 
-Questo programma Ë sviluppato per essere usato all'interno della comunit‡ 
+Questo programma √® sviluppato per essere usato all'interno della comunit√† 
 radioamatoriale, negli Stati Uniti la FCC non autorizza a trasmettere per radio 
 se non sei radioamatore.
 Gli utenti di altri paesi devono attenersi alle leggi locali in merito.
@@ -17,15 +17,15 @@ XASTIR, Amateur Station Tracking and Information Reporting
 Copyright (C) 1999,2000  Frank Giannandrea
 Copyright (C) 2000-2026 The Xastir Group
 
-Questo programma Ë un software libero; puÚ' essere ridistribuito e modificato
+Questo programma √® un software libero; pu√≤' essere ridistribuito e modificato
 secondo i termini della Licenza GNU GPL, pubblicata dalla Free Software
 Foundation;
-anche la versione 2 della licenza Ë valida, come anche le versioni seguenti.
+anche la versione 2 della licenza √® valida, come anche le versioni seguenti.
 
 ma SENZA ALCUNA GARANZIA; senza la garanzia di COMMERCIABILITA' o ADATTAMENTO
 PER UN PARTICOLARE USO.  Vedere la Licenza GNU GPL per maggiori dettagli.
 
-Dovrebbe essere pervenuta a voi la licenza GNU assieme al programma; se cosÏ
+Dovrebbe essere pervenuta a voi la licenza GNU assieme al programma; se cos√¨
 non fosse segnalate l'evento alla  Free Software Foundation, Inc., 59 Temple
 Place - Suite 330, Boston, MA  02111-1307, USA.
 
@@ -45,12 +45,12 @@ HELP-INDEX>Benvenuti! e note dell'Autore
 
 XASTIR, o X-windows Amateur Station Tracking and Information Reporting.
 
-Ë un programma APRS(tm) sviluppato liberamente e di libero uso, puÚ  essere 
-liberamente distribuito. Attualmente il programma Ë in fase di sviluppo e non 
-deve essere visto come un prodotto finito! Il tuo aiuto servir‡ a renderlo 
+√® un programma APRS(tm) sviluppato liberamente e di libero uso, pu√≤  essere 
+liberamente distribuito. Attualmente il programma √® in fase di sviluppo e non 
+deve essere visto come un prodotto finito! Il tuo aiuto servir√† a renderlo 
 migliore.
-Se sai programmare o vuoi scrivere documentazione, il tuo aiuto mi risulter‡  
-molto gradito! Ho molte idee ma cosÏ poco tempo! Quindi se pensi che manchi 
+Se sai programmare o vuoi scrivere documentazione, il tuo aiuto mi risulter√†  
+molto gradito! Ho molte idee ma cos√¨ poco tempo! Quindi se pensi che manchi 
 qualcosa, fammelo sapere.
 
 73,
@@ -58,8 +58,8 @@ Frank Giannandrea
 
 Traduzione della guida a cura di Alessandro Frigeri, IK0YUP.
 
-APRS[tm] Ë un marchio registrato di Bob Bruninga, 
-la sua pagina Ë "http://web.usna.navy.mil/~bruninga/aprs.html"
+APRS[tm] √® un marchio registrato di Bob Bruninga, 
+la sua pagina √® "http://web.usna.navy.mil/~bruninga/aprs.html"
 
 HELP-INDEX>What's new in Xastir 2.0.9
 
@@ -320,12 +320,12 @@ HELP-INDEX>Avviare Xastir
 La prima volta che si lancia Xastir, dovrebbe essere fatto da un terminale in 
 maniera tale che qualsiasi messaggio di errore salti alla vista.  Nella maggior 
 parte dei sistemi il percorso di ricerca dei file eseguibili comprende la 
-cartella  /usr/local/bin e tutto quello che serve per avviare il programma Ë 
+cartella  /usr/local/bin e tutto quello che serve per avviare il programma √® 
 dare il comando xastir al prompt.  Nei sistemi dove il percorso 
-"/usr/local/bin" non Ë impostato bisogner‡ digitare "/usr/local/bin/xastir" per 
+"/usr/local/bin" non √® impostato bisogner√† digitare "/usr/local/bin/xastir" per 
 avviare il programma.
 
-Si puÚ anche impostare un linguaggio diverso dall'originale.  Per impostare o 
+Si pu√≤ anche impostare un linguaggio diverso dall'originale.  Per impostare o 
 cambiare il linguaggio usato da xastir bisogna utilizzare la seguente sintassi: 
 
 xastir -l
@@ -336,11 +336,11 @@ Attualmente le scelte sono: English Dutch French German Spanish Italian
 
 Questa opzione viene memorizzata nel file di configurazione dell'utente e resa 
 disponibile per i seguenti usi del programma.  Per le nuove installazioni 
-Xastir user‡ l'inglese a meno che non venga specificato un linguaggio 
+Xastir user√† l'inglese a meno che non venga specificato un linguaggio 
 differente con l'opzione -l.
 
 NOTA: Nei menu, le opzioni in grigio sono quelle selezionate, come anche nelle 
-opzioni di on/off, la scelta attivata sar‡ evidenziata dalla colorazione grigia.
+opzioni di on/off, la scelta attivata sar√† evidenziata dalla colorazione grigia.
 
 HELP-INDEX>Informazioni sulla configurazione della stazione
 
@@ -351,11 +351,11 @@ Seleziona Configura la Stazione
 Imposta il tuo nominativo nella apposita casella.
 
 Compila le caselle relative alla posizione (Lat,Long) se non si intende usare 
-Xastir con un GPS. Se la posizione non Ë disponibile Ë possibile individuare la 
+Xastir con un GPS. Se la posizione non √® disponibile √® possibile individuare la 
 posizione sulla mappa e copiare i dati. Latitudine e longitudine potranno 
 essere rilevati nella seconda casella partendo da destra, nella parte bassa 
 della finestra principale.
-Se si intende utilizzare un GPS si puÚ saltare questa sezione e configurare il 
+Se si intende utilizzare un GPS si pu√≤ saltare questa sezione e configurare il 
 GPS in un secondo momento.
 
 Il simbolo o il gruppo della stazione possono essere cambiati in qualsiasi 
@@ -363,7 +363,7 @@ momento, per fare questo si faccia riferimento alla guida ai simboli.
 
 Indicare ora i dati tecnici della stazione: questi dati sono interessanti ma 
 non necessari al corretto funzionamento del programma.
-Utilizzare il seguente codice per indicare la potenza che pi˘ si avvicina a 
+Utilizzare il seguente codice per indicare la potenza che pi√π si avvicina a 
 quella della vostra stazione:
 
 Codice           0  1  2  3   4   5   6   7   8   9
@@ -378,8 +378,8 @@ l'altezza dell'antenna sul terreno.
 Codice             0   1   2   3    4    5    6     7     8     9
 Altitudine (piedi)10  20  40  80  160  320  640  1280  2560  5120
 
-Esempio: se l'altitudine della stazione Ë 1280 piedi, il codice da usare
-         sar‡  "7".
+Esempio: se l'altitudine della stazione √® 1280 piedi, il codice da usare
+         sar√†  "7".
 
 
 Per impostare il guadagno scrivere semplicemente il valore dello stesso 
@@ -391,30 +391,30 @@ espressa in gradi dal Nord.
 Codice           0   1   2    3    4    5    6    7    8        9
 Direzione(gradi) *  45  90  135  180  225  270  315  360  Nessuna
 
-Esempio: Se la vostra antenna Ë omnidirezionale, impostare "0". Se la 
-         direzionalit‡ Ë verso nord, impostare "8".
+Esempio: Se la vostra antenna √® omnidirezionale, impostare "0". Se la 
+         direzionalit√† √® verso nord, impostare "8".
 
 Inserire un commento, non necessario al programma, ma utile agli altri 
 operatori.
 
-L'ambiguit‡ della posizione permette di trasmettere quanto Ë precisa la 
-posizione fornita dalla nostra stazione. Una impostazione con ambiguit‡ nulla 
-permetter‡ di comunicare alle altre stazioni esattamente la posizione che 
+L'ambiguit√† della posizione permette di trasmettere quanto √® precisa la 
+posizione fornita dalla nostra stazione. Una impostazione con ambiguit√† nulla 
+permetter√† di comunicare alle altre stazioni esattamente la posizione che 
 abbiamo impostato o che arriva dal GPS.  Le altre scelte posizioneranno la 
 stazione nel raggio indicato dal codice impostato.
 
 Selezionando OK, verranno applicati tutti i cambiamenti effettuati, mentre il 
-tasto Annulla manterr‡ le opzioni correnti. 
+tasto Annulla manterr√† le opzioni correnti. 
 
-HELP-INDEX>Configurazione delle Unit‡ di Misura
+HELP-INDEX>Configurazione delle Unit√† di Misura
 
-                        Configurazione delle Unit‡ di Misura
+                        Configurazione delle Unit√† di Misura
 
-L'impostazione originale del programma Ë per il sistema metrico, mm, cm, Km/ora 
+L'impostazione originale del programma √® per il sistema metrico, mm, cm, Km/ora 
 ecc.
 Per selezionare il sistema di misura anglosassone (pollici,piedi,miglia/ora) 
-selezionare Configura, Unit‡, quindi il sistema che si vuole usare.  L'opzione 
-attiva Ë quella marcata dal grigio.
+selezionare Configura, Unit√†, quindi il sistema che si vuole usare.  L'opzione 
+attiva √® quella marcata dal grigio.
 
 
 HELP-INDEX>Configurazione delle Operazioni Base
@@ -424,21 +424,21 @@ HELP-INDEX>Configurazione delle Operazioni Base
 Selezionare Configura e quindi Predefinito
 
 Questa scheda imposta una configurazione standard. Le vecchie stazioni saranno 
-visualizzate con un'icona fantasma.  Il "tempo lettura GPS" imposter‡ 
-l'intervallo di tempo per  acquisire nuovi dati dal GPS.  Questa opzione Ë 
+visualizzate con un'icona fantasma.  Il "tempo lettura GPS" imposter√† 
+l'intervallo di tempo per  acquisire nuovi dati dal GPS.  Questa opzione √® 
 disponibile per le stazioni dotate di HSP o di un cavo condiviso con il proprio 
 TNC.
 
 L'opzione "Trasmissioni Stazione" imposta con quali packet la stazione 
-trasmetter‡ i propri dati.    
+trasmetter√† i propri dati.    
 
-L'opzione "Trasmetti codici WX", se selezionato, mander‡ anche un pacchetto di 
-dati provenienti dalla stazione meteo.Questa opzione Ë utile per i tipi di 
-stazioni meteo che trasmettono i dati gi‡ in formato ASCII come le Peet Bros. 
+L'opzione "Trasmetti codici WX", se selezionato, mander√† anche un pacchetto di 
+dati provenienti dalla stazione meteo.Questa opzione √® utile per i tipi di 
+stazioni meteo che trasmettono i dati gi√† in formato ASCII come le Peet Bros. 
 
 Le opzioni Gateway permetteranno di impostare la stazione come un gateway tra 
 internet e la rete radio.  Questa opzione va usata con cautela, come 
-radioamatore ognuno di noi Ë responsabile per i dati che trasmette, e quindi 
+radioamatore ognuno di noi √® responsabile per i dati che trasmette, e quindi 
 anche per quelli che provengono da internet e vengono trasmessi per radio in 
 una simile configurazione.
 
@@ -449,7 +449,7 @@ HELP-INDEX>Configurazione Interfacce
 Selezionare Configura e quindi Interfacce.
 
 Dovrebbe apparire una scheda che indica le "Interfacce installate".  Questa 
-scheda vi permetter‡ di aggiungere, cancellare, e modificare le propriet‡ 
+scheda vi permetter√† di aggiungere, cancellare, e modificare le propriet√† 
 delle varie periferiche che possono essere utilizzate con Xastir.
 
 Le opzioni sono:
@@ -462,7 +462,7 @@ TNC AX25
 GPS in rete (via gpsd)
 WX in rete
 
-Per aggiungere una periferica, selezionare aggiungi.  Apparir‡ la scheda
+Per aggiungere una periferica, selezionare aggiungi.  Apparir√† la scheda
  "Scegli il tipo di interfaccia".  Seleziona il tipo di interfaccia che vuoi 
 aggiungere.
 Appariranno i parametri di quella periferica.  Fornire le impostazioni 
@@ -471,8 +471,8 @@ richieste e selezionare "ok"
 Per eliminare una periferica, selezionarla e in seguito cliccare sul bottone 
 Elimina.
 
-Per modificare le propriet‡ di una periferica, seleziona la periferica e quindi 
-il bottone "Propriet‡".  La scheda con i parametri della periferica appariranno 
+Per modificare le propriet√† di una periferica, seleziona la periferica e quindi 
+il bottone "Propriet√†".  La scheda con i parametri della periferica appariranno 
 e potranno essere modificati a piacere. Per rendere effettive le impostazioni 
 schiacciare il bottone OK dopo aver fatto le modifiche.
  
@@ -487,47 +487,47 @@ Questa sezione tratta l'impostazione di un TNC Seriale o di un TNC seriale con
 un  cavo HSP per il collegamento del GPS.
 
 Se si ha il cavo HSP, che permette di condividere la porta del TNC con quella 
-del GPS, la configurazione da selezionare sar‡ "TNC con GPS".  Il cavo HSP Ë un 
-cavo speciale che puÚ non essere compatibile con tutte le combinazioni 
+del GPS, la configurazione da selezionare sar√† "TNC con GPS".  Il cavo HSP √® un 
+cavo speciale che pu√≤ non essere compatibile con tutte le combinazioni 
 computer/TNC/GPS possibili.  Se si usa questa configurazione, il TNC e il GPS
 devono avere una impostazione dei parametri di comunicazione che in genere 
-prevede: 4800 bps, 8 bit di dati, nessuna parit‡, 1 bit di stop.
+prevede: 4800 bps, 8 bit di dati, nessuna parit√†, 1 bit di stop.
 
 Opzioni della Porta TNC:
 Selezionando "Attivare all'avvio" si indica a Xastir di caricare questa 
 periferica automaticamente all'avvio del programma.
 
 Selezionando "Permetti la Trasmissione", ordina a Xastir che ogni dato inviato 
-all'interfaccia puÚ essere trasmesso.
+all'interfaccia pu√≤ essere trasmesso.
 
-La porta del TNC Ë la porta Unix alla quale Ë collegato il TNC.  In genere sono 
+La porta del TNC √® la porta Unix alla quale √® collegato il TNC.  In genere sono 
 chiamate /dev/ttyS0 (Dos com1), /dev/ttyS1 (Dos com2)
 
-Ora impostare la velocit‡ e il tipo di comunicazione in "Impostazioni porta", e 
+Ora impostare la velocit√† e il tipo di comunicazione in "Impostazioni porta", e 
 i parametri in "Stile porta".  Uno stile di porta 8N1 indica 8 bit di dati, 
-Nessuna parit‡ e 1 bit di stop. 7E1 indica 7 bit di dati, parit‡ e 1 bit di 
-stop.  7O1 indica 7 bit di dati, parit‡ dispari, e 1 bit di stop.  Questi 
+Nessuna parit√† e 1 bit di stop. 7E1 indica 7 bit di dati, parit√† e 1 bit di 
+stop.  7O1 indica 7 bit di dati, parit√† dispari, e 1 bit di stop.  Questi 
 parametri DEVONO essere 
 comuni sia al TNC che al GPS. 
 
 Scegliere ora la corretta impostazione per il Gateway di questa interfaccia. 
-Potresti avere diversi TNC e questa opzione puÚ essere diversa per ogni TNC.
-Se non intendi attivare le funzionalit‡ di gateway lascia l'opzione 
+Potresti avere diversi TNC e questa opzione pu√≤ essere diversa per ogni TNC.
+Se non intendi attivare le funzionalit√† di gateway lascia l'opzione 
 "Disabilitato".
 
 Inserisci ora fino a tre percorsi UNPROTO. Xastir assume la parte XX VIA del 
-percorso UNPROTO. Ë possibile impostare tre percorsi differenti in modo da 
+percorso UNPROTO. √® possibile impostare tre percorsi differenti in modo da 
  avere alternative nel caso le condizioni non siano buone.  Se uno dei percorsi 
-Ë occupato allora Xastir passer‡ al successivo ad ogni trasmissione e cosÏ via.
+√® occupato allora Xastir passer√† al successivo ad ogni trasmissione e cos√¨ via.
 
-Se sei in una condizione di stazioni locali, semplicemente un WIDE2-2 puÚ essere 
+Se sei in una condizione di stazioni locali, semplicemente un WIDE2-2 pu√≤ essere 
 una buona scelta.  Se stai usando poca potenza e/o sei distante dal digipeater 
 allora WIDE1-1,WIDE2-2 potrebbe essere la scelta giusta.  Se conosci il nominativo 
-del tuo pi˘ vicino digipeater allora si potr‡ usare NOMINATIVO_DIGI,WIDE2-2.  La 
-maggior parte di voi avr‡ bisogno di un solo percorso.  Se ci si trova in un 
-area remota e il segnale Ë difficilmente ascoltabile dalle altre stazioni allora 
-potrebbe essere necessario aggiungere dei percorsi.  Una buona norma Ë quella
-di chiedere al gruppo di radioamatori locali quale Ë il miglio percorso per i 
+del tuo pi√π vicino digipeater allora si potr√† usare NOMINATIVO_DIGI,WIDE2-2.  La 
+maggior parte di voi avr√† bisogno di un solo percorso.  Se ci si trova in un 
+area remota e il segnale √® difficilmente ascoltabile dalle altre stazioni allora 
+potrebbe essere necessario aggiungere dei percorsi.  Una buona norma √® quella
+di chiedere al gruppo di radioamatori locali quale √® il miglio percorso per i 
 pacchetti in quella data area. 
 
 File di inizializzazione e di spegnimento del TNC. Questi campi specificano i 
@@ -539,50 +539,50 @@ CONFIGURAZIONE DEL TNC AX.25
 
 Questa sezione descrive l'aggiunta e la modifica di interfacce TNC AX.25.
 Per interfacce AX.25 si intendono tutte quelle periferiche che usano i driver 
-AX.25 di Linux.  Questo driver Ë a livello di kernel e periferiche come i 
+AX.25 di Linux.  Questo driver √® a livello di kernel e periferiche come i 
 Baycom o soundmodem possono essere usati come TNC.  Queste periferiche devono 
 essere rese disponibili (funzionanti) al programma prima del suo avvio.
 
-Selezionando "Attiva all'avvio" si ordiner‡ a Xastir di caricare questa 
+Selezionando "Attiva all'avvio" si ordiner√† a Xastir di caricare questa 
 interfaccia all'avvio.
 
-Selezionando "Permetti la Trasmissione", si permetter‡ che i dati vengano 
+Selezionando "Permetti la Trasmissione", si permetter√† che i dati vengano 
 trasmessi per radio.
 
 Scegliere ora la corretta impostazione per il Gateway di questa interfaccia. 
-Potresti avere diversi TNC AX.25 o TNC Seriali  e questa opzione puÚ essere 
+Potresti avere diversi TNC AX.25 o TNC Seriali  e questa opzione pu√≤ essere 
 diversa per ogni TNC.
-Se non si intende attivare le funzionalit‡ di gateway lascia l'opzione 
+Se non si intende attivare le funzionalit√† di gateway lascia l'opzione 
 "Disabilitato".
 
 Impostare il nome della periferica AX.25 come specificato dal file axports.
 
 Inserisci ora fino a tre percorsi UNPROTO. Xastir assume la parte XX VIA del 
-percorso UNPROTO. Ë possibile impostare tre percorsi differenti in modo da 
-avere alternative nel caso le condizioni non siano buone.  Se uno dei percorsi Ë
-occupato allora Xastir passer‡ al successivo ad ogni trasmissione e cosÏ via.
+percorso UNPROTO. √® possibile impostare tre percorsi differenti in modo da 
+avere alternative nel caso le condizioni non siano buone.  Se uno dei percorsi √®
+occupato allora Xastir passer√† al successivo ad ogni trasmissione e cos√¨ via.
 
-Se sei in una condizione di stazioni locali, semplicemente un WIDE2-2 puÚ essere 
+Se sei in una condizione di stazioni locali, semplicemente un WIDE2-2 pu√≤ essere 
 una buona scelta.  Se stai usando poca potenza e/o sei distante dal digipeater
 allora WIDE1-1,WIDE2-2 potrebbe essere la scelta giusta.  Se conosci il nominativo 
-del tuo pi˘ vicino digipeater allora si potr‡ usare NOMINATIVO_DIGI,WIDE2-2.  La 
-maggior parte di voi avr‡ bisogno di un solo percorso.  Se ci si trova in 
-un'area remota e il segnale Ë difficilmente ascoltabile dalle altre stazioni allora 
-potrebbe essere necessario aggiungere dei percorsi.  Una buona norma Ë quella 
-di chiedere al gruppo di radioamatori locali quale Ë il miglio percorso per i 
+del tuo pi√π vicino digipeater allora si potr√† usare NOMINATIVO_DIGI,WIDE2-2.  La 
+maggior parte di voi avr√† bisogno di un solo percorso.  Se ci si trova in 
+un'area remota e il segnale √® difficilmente ascoltabile dalle altre stazioni allora 
+potrebbe essere necessario aggiungere dei percorsi.  Una buona norma √® quella 
+di chiedere al gruppo di radioamatori locali quale √® il miglio percorso per i 
 pacchetti in quella data area. 
 
 NOTA: Per usare le periferiche AX.25 con Xastir bisogna avere i privilegi di 
 root.
-Se si vuole far eseguire Xastir da un utente qualsiasi, bisogner‡ cambiare il 
-suid del programma Xastir.  Il comando seguente  eseguito da root potr‡ servire 
+Se si vuole far eseguire Xastir da un utente qualsiasi, bisogner√† cambiare il 
+suid del programma Xastir.  Il comando seguente  eseguito da root potr√† servire 
 allo scopo:
 
 chmod a+s /usr/local/bin/xastir
 
 
-Come qualsiasi programma che venga eseguito in questa modalit‡, questo Ë da 
-considerarsi un rischio di sicurezza, visto che il programma ancora non Ë stato 
+Come qualsiasi programma che venga eseguito in questa modalit√†, questo √® da 
+considerarsi un rischio di sicurezza, visto che il programma ancora non √® stato 
 sperimentato per reagire a tentativi di intrusione.
 
 Configurazione del GPS
@@ -593,13 +593,13 @@ Configurazione del GPS
 Imposta la porta seriale che usata dal vostro GPS.  Valori comuni sono 
 /dev/ttyS0 (dos com1) e /dev/ttyS1 (dos com2).
 
-Selezionando "Attiva all'avvio" si ordiner‡ a Xastir di caricare questa 
+Selezionando "Attiva all'avvio" si ordiner√† a Xastir di caricare questa 
 interfaccia all'avvio.
 
-Ora seleziona la velocit‡ di trasmissione espressa in bps e i parametri della 
+Ora seleziona la velocit√† di trasmissione espressa in bps e i parametri della 
 porta sotto il menu "stile".  Uno stile di porta 8N1 significa 8 but di dati, 
-nessuna parit‡ e 1 bit di stop. 7E1 indica 7 bits di dati, parit‡ pari e 1 stop 
-bit. 701 indica 7 bit di dati, parit‡ dispari e 1 stop bit.  Questi parametri 
+nessuna parit√† e 1 bit di stop. 7E1 indica 7 bits di dati, parit√† pari e 1 stop 
+bit. 701 indica 7 bit di dati, parit√† dispari e 1 stop bit.  Questi parametri 
 devono essere gli stessi che usa il GPS.  La maggior parte dei GPS usa 4800 bps
 8N1.
 
@@ -607,8 +607,8 @@ HELP-INDEX>Configurare un GPS in rete
 
                     Configurazione di un GPS in rete.
 
-Questa opzione permette di condividere i dati provenienti dal GPS con pi˘ 
-programmi, e con pi˘ computer in rete.  Xastir puÚ ottenere i dati dal GPS 
+Questa opzione permette di condividere i dati provenienti dal GPS con pi√π 
+programmi, e con pi√π computer in rete.  Xastir pu√≤ ottenere i dati dal GPS 
 attraverso il demone gpsd che permette, attraverso diverse connessioni, di 
 condividere i dati del 
 GPS  con altrettante applicazioni. 
@@ -616,11 +616,11 @@ GPS  con altrettante applicazioni.
 Impostare il nome dell'host (o l'indirizzo IP) e il numero della porta che gpsd 
 utilizza per le connessioni (di solito la 5678).
 
-Selezionando "Attiva all'avvio" si ordiner‡ a Xastir di caricare questa 
+Selezionando "Attiva all'avvio" si ordiner√† a Xastir di caricare questa 
 interfaccia  all'avvio.
 
-Selezionando "Riconnetti su Errore", indicher‡ ad Xastir di riconnettersi una 
-volta che il flusso di dati si Ë per qualche motivo interrotto.
+Selezionando "Riconnetti su Errore", indicher√† ad Xastir di riconnettersi una 
+volta che il flusso di dati si √® per qualche motivo interrotto.
 
 HELP-INDEX>Configurare il Server Internet
 
@@ -629,17 +629,17 @@ HELP-INDEX>Configurare il Server Internet
 I server internet permettono di ricevere ed inviare dati a tutto il mondo 
 attraverso internet.
 
-Selezionando "Attiva all'avvio" si ordiner‡ a Xastir di caricare questa 
+Selezionando "Attiva all'avvio" si ordiner√† a Xastir di caricare questa 
 interfaccia  all'avvio.
 
-Selezionando "Permetti la Trasmissione", indicher‡ che Xastir potr‡ trasmettere 
+Selezionando "Permetti la Trasmissione", indicher√† che Xastir potr√† trasmettere 
 via radio tutti i dati.
 
 Inserisci il nome dell'host (o l'indirizzo IP) e il numero della porta del 
 server internet che vuoi connettere.
 
 Inserisci un codice di accesso valido per attivare la connessione, che 
-permetter‡ ai tuoi dati di essere trasmessi attraverso Internet.  Se non hai 
+permetter√† ai tuoi dati di essere trasmessi attraverso Internet.  Se non hai 
 un codice di accesso puoi spedire un mail a fgiannan@earthlink.net con tutti i 
 tuoi dati e informazioni radio, per ricevere il codice.
 
@@ -652,42 +652,42 @@ HELP-INDEX>Configurare una Stazione Meteo
 
 Configurare una stazione meteo Seriale.
 
-Impostare la porta seriale alla quale Ë connessa l'unit‡ Meteo.  
+Impostare la porta seriale alla quale √® connessa l'unit√† Meteo.  
 Valori comuni sono /dev/ttyS0 (COM1) o /dev/ttyS1 (COM2).
 
-Selezionando "Attiva all'avvio" si ordiner‡ a Xastir di caricare questa 
+Selezionando "Attiva all'avvio" si ordiner√† a Xastir di caricare questa 
 interfaccia  all'avvio.
 
-Ora bisogna selezionare la velocit‡ della porta in bps sotto Configurazione 
+Ora bisogna selezionare la velocit√† della porta in bps sotto Configurazione 
 della Porta, e i parametri sotto 'Stile di Porta'.  Lo 'Stile della Porta' 8N1 
-indica 8 bit di dati, nessuna parit‡ e 1 bit di stop.  7E1 indica 7 bit di 
-dati, parit‡ e 1 bit di stop. 
-7O1 Ë usato per 7 bit di dati, parit‡, un bit di stop.  Questi parametri devono 
+indica 8 bit di dati, nessuna parit√† e 1 bit di stop.  7E1 indica 7 bit di 
+dati, parit√† e 1 bit di stop. 
+7O1 √® usato per 7 bit di dati, parit√†, un bit di stop.  Questi parametri devono 
 essere gli stessi della porta dell'apparecchio meteo.
 L'opzione 'Tipi di dati permette di aggiornare per quale tipo di comunicazione 
-seriale il programma dovr‡ cercare.  La funzione di autoriconoscimento 
-(auto-detect) cercher‡ per primi dei dati in formato binario come quelli della 
+seriale il programma dovr√† cercare.  La funzione di autoriconoscimento 
+(auto-detect) cercher√† per primi dei dati in formato binario come quelli della 
 stazione meteo Radio Shack WX-200.
-Nel caso non vengano rilevati dati binari allora Xastir cercher‡ per dati ASCII 
+Nel caso non vengano rilevati dati binari allora Xastir cercher√† per dati ASCII 
 (utilizzati dalla stazione Peer Bros.).
 
 
 Configurare una stazione Meteo in Rete
 
-Xastir puÚ usare dati meteo reperendoli da server come il wx200d.
-wx200d permette pi˘ connessioni, permettendo di condividere i dati meteo con 
-pi˘ programmi o computer.
+Xastir pu√≤ usare dati meteo reperendoli da server come il wx200d.
+wx200d permette pi√π connessioni, permettendo di condividere i dati meteo con 
+pi√π programmi o computer.
 
 Inserisci il nome dell'host (o l'indirizzo IP) e il numero della porta del 
 server Meteo che si vuole connettere .
 
-Selezionando "Attiva all'avvio" si ordiner‡ a Xastir di caricare questa 
+Selezionando "Attiva all'avvio" si ordiner√† a Xastir di caricare questa 
 interfaccia  all'avvio.
 
-Selezionando "Riconnetti se sconnesso", indicher‡ a Xastir di riconnettersi in 
+Selezionando "Riconnetti se sconnesso", indicher√† a Xastir di riconnettersi in 
 caso di errore.
 
-Come prima, selezionando il "Tipo di dati" si escluder‡ l'auto-riconoscimento.
+Come prima, selezionando il "Tipo di dati" si escluder√† l'auto-riconoscimento.
 
 
 
@@ -698,7 +698,7 @@ HELP-INDEX>Configurzione allarmi Audio
 Selezionare Configurazione, e quindi Suoni.
 
 Per usare questa opzione bisogna avere una scheda sonora e un programma che 
-esegua i file con estensione .wav.  Il "Comando per eseguire i suoni" Ë il 
+esegua i file con estensione .wav.  Il "Comando per eseguire i suoni" √® il 
 programma (e relative opzioni) che si vuole usare per ascoltare i suoni che 
 vengono da Xastir.
 
@@ -713,14 +713,14 @@ Le possibili scelte sono:
 -Esegui un suono quando viene rilevata una stazione (via TNC) con una distanza 
 min/max impostata nei limiti di apertura di banda..
 
-HELP-INDEX>Configurazione delle unit‡ di misura (Inglese/Metrico)
+HELP-INDEX>Configurazione delle unit√† di misura (Inglese/Metrico)
 
-              Configurazione delle unit‡ di misura (Inglese/Metrico)
+              Configurazione delle unit√† di misura (Inglese/Metrico)
 
-Questo seleziona che in che unit‡ le grandezze verranno visualizzate dal 
+Questo seleziona che in che unit√† le grandezze verranno visualizzate dal 
 programma.
-Il programma si configura automaticamente sul sistema metrico ma Ë possibile 
-cambiare questa possibilit‡.
+Il programma si configura automaticamente sul sistema metrico ma √® possibile 
+cambiare questa possibilit√†.
 
 HELP-INDEX>Barra di stato inferiore
 
@@ -731,51 +731,51 @@ messaggi di controllo.
 
 I messaggi di controllo generale sono visualizzati nella paste sinistra.
 
-Nella seconda casella da sinistra Ë visualizzata la posizione sulla mappa del 
+Nella seconda casella da sinistra √® visualizzata la posizione sulla mappa del 
 mouse in lat/lon.
 La terza casella visualizza il numero di stazioni ricevute e presenti nel 
 database.
-La quarta casella visualizza il livello di zoom e visualizzer‡ Tr se
-sulla stazione selezionata Ë attivata la funzione di inseguimento.
+La quarta casella visualizza il livello di zoom e visualizzer√† Tr se
+sulla stazione selezionata √® attivata la funzione di inseguimento.
 L'ultima casella visualizza lo stato di funzionamento delle periferiche, che
 sono visualizzate nell'ordine di inserimento da 0 a 9.
-Il controllo di stato delle interfacce Ë diviso in tre aree, la parte alta 
-indica il tipo di periferica, in mezzo Ë indicato lo stato di flusso di dati e 
-nella parte bassa Ë indicato lo stato operazionale della periferica, blu per i 
+Il controllo di stato delle interfacce √® diviso in tre aree, la parte alta 
+indica il tipo di periferica, in mezzo √® indicato lo stato di flusso di dati e 
+nella parte bassa √® indicato lo stato operazionale della periferica, blu per i 
 vari TNC, verde per i GPS, giallo per per i servizi Internet, arancio per le 
 periferiche Meteo. 
-Nella parte centrale il flusso di dati entrante Ë indicato con una freccia a 
+Nella parte centrale il flusso di dati entrante √® indicato con una freccia a 
 sinistra per dati uscenti e a destra per dati entranti. Nella parte inferiore 
-il verde indica che l'interfaccia Ë collegata e funziona correttamente, il 
-rosso che l'interfaccia Ë collegata ma in uno stato di errore, l'assenza di 
-colore indica che l'interfaccia non Ë collegata.
+il verde indica che l'interfaccia √® collegata e funziona correttamente, il 
+rosso che l'interfaccia √® collegata ma in uno stato di errore, l'assenza di 
+colore indica che l'interfaccia non √® collegata.
 
 
 HELP-INDEX>Spostare la mappa e opzioni.
 
                     Spostare la mappa e Opzioni
 
-Il movimento della mappa Ë molto semplice e la velocit‡ di visualizzazione 
-della stessa Ë dipendente dal tipo di sistema in uso e dalla quantit‡ di 
+Il movimento della mappa √® molto semplice e la velocit√† di visualizzazione 
+della stessa √® dipendente dal tipo di sistema in uso e dalla quantit√† di 
 dettagli visualizzata.
 
 Tutti i movimenti e ingrandimenti sono possibili cliccando il tasto sinistro 
-del mouse (tenendolo premuto) sulla mappa.  Questa azione visualizzer‡ un menu 
+del mouse (tenendolo premuto) sulla mappa.  Questa azione visualizzer√† un menu 
 di Opzioni.
 
-Tutte le funzioni di Zoom sono riferite al punto della mappa dove Ë stato 
-cliccato il bottone sinistro del mouse.  Il menu degli zoom mostrer‡ ulteriori 
+Tutte le funzioni di Zoom sono riferite al punto della mappa dove √® stato 
+cliccato il bottone sinistro del mouse.  Il menu degli zoom mostrer√† ulteriori 
 opzioni: livelli di zoom da 1 a 3 sono per aree locali mentre livelli da 4 a 6 
 sono per aree 
-maggiori, quindi pi˘ il numero Ë piccolo e pi˘ l'area visualizzata Ë stretta.
+maggiori, quindi pi√π il numero √® piccolo e pi√π l'area visualizzata √® stretta.
 
-Dal menu delle opzioni si puÚ anche spostare la vista della mappa con la 
-funzione Pan, che provocher‡ uno spostamento del centro della mappa.
+Dal menu delle opzioni si pu√≤ anche spostare la vista della mappa con la 
+funzione Pan, che provocher√† uno spostamento del centro della mappa.
 
-Le "informazioni della stazione" cerca per la stazione pi˘ vicina al punto 
-selezionato dal click del mouse.  Se pi˘ stazioni sono presenti apparir‡ una 
+Le "informazioni della stazione" cerca per la stazione pi√π vicina al punto 
+selezionato dal click del mouse.  Se pi√π stazioni sono presenti apparir√† una 
 finestra di 
-selezione che permetter‡ di indicare di quale stazione veramente si ha bisogno 
+selezione che permetter√† di indicare di quale stazione veramente si ha bisogno 
 di 
 informazioni.
 
@@ -786,35 +786,35 @@ HELP-INDEX>Map Options and Map Chooser Opzioni della Mappa e Scelta della Mappa
 Opzioni della Mappa:
 
 Mappe Automatiche (Attiva/Disattiva)
-Quando attivato, qualsiasi mappa trovata nella directory delle mappe verr‡ 
+Quando attivato, qualsiasi mappa trovata nella directory delle mappe verr√† 
 visualizzata se nella sua area ricade la visualizzazione corrente.  Questa 
-funzione cercher‡ in tutte le sottocartelle della directory delle mappe.  Se 
-pi˘ mappe sono disponibili allora verranno sovrapposte, in questo caso un
- computer poco veloce puÚ produrre una visualizzazione lenta.
-Tuttavia Ë possibile disattivare questa funzione e selezionare manualmente la 
+funzione cercher√† in tutte le sottocartelle della directory delle mappe.  Se 
+pi√π mappe sono disponibili allora verranno sovrapposte, in questo caso un
+ computer poco veloce pu√≤ produrre una visualizzazione lenta.
+Tuttavia √® possibile disattivare questa funzione e selezionare manualmente la 
 mappa da visualizzare.
 
 Griglia (Attiva/Disattiva)
-Quando Ë attiva, questa funzione visualizza una griglia ogni 10 gradi. Se si 
-effettua uno zoom in avanti la risoluzione della griglia passer‡ ad 1 grado.
+Quando √® attiva, questa funzione visualizza una griglia ogni 10 gradi. Se si 
+effettua uno zoom in avanti la risoluzione della griglia passer√† ad 1 grado.
 
 Livelli della Mappa (Attiva/Disattiva)
 Quando attivata, questa funzione permette di filtrare i dati di mappe su 
 grandi aree.
 Questa opzione funziona solo con le mappe Tiger Line maps reperibili presso 
-http://aprs.rutgers.edu.  CiÚ non velocizzer‡ il caricamento delle mappe ma 
-produrr‡ una visualizzazione di dettagli appropriata alla scala di 
+http://aprs.rutgers.edu.  Ci√≤ non velocizzer√† il caricamento delle mappe ma 
+produrr√† una visualizzazione di dettagli appropriata alla scala di 
 visualizzazione.
 
 Colore in Aree Chiuse (Attiva/Disattiva)
 Questa opzione controlla il colore di riempimento delle mappe vettoriali. 
-In alcuni casi puÚ essere necessario eliminare il riempimento di un'area 
+In alcuni casi pu√≤ essere necessario eliminare il riempimento di un'area 
 per permettere la visualizzazione dei livelli sottostanti.  Le mappe sono 
 caricate in ordine alfabetico e quindi i livelli rispetteranno tale ordine. 
 
 Scelta della mappa.
-Questa funzione visualizza tutte le mappe disponibili.  Si potr‡ selezionare 
-pi˘ di una mappa e poi premere OK per confermare la selezione.  Il bottone 
+Questa funzione visualizza tutte le mappe disponibili.  Si potr√† selezionare 
+pi√π di una mappa e poi premere OK per confermare la selezione.  Il bottone 
 Cancella chiude la finestra di dialogo della scelta delle mappe.
 
 Nota: Xastir utilizza il Datum WGS 1984 per le mappe.
@@ -825,14 +825,14 @@ HELP-INDEX>File di mappe, Dos, Windows, Pixmaps e WX Counties
 
 Tipi di Mappa
 Xastir funziona con vari tipi di mappa.  Tutte le mappe per il programma 
-APRS[TM] Dos,Windows,Mac sono supportate.  Dalla versione 0.3.2 Ë possibile 
-caricare anche mappe in formato Pixmap.  Ë possibile anche caricare le mappe di 
+APRS[TM] Dos,Windows,Mac sono supportate.  Dalla versione 0.3.2 √® possibile 
+caricare anche mappe in formato Pixmap.  √® possibile anche caricare le mappe di 
 supporto per gli Allarmi Meteo Statunitensi.
 
 Dove posizionare le mappe
 Qualsiasi mappa Dos, Windows/Mac o Pixmap deve essere messa nella directory 
 /usr/local/share/xastir/maps.  Si possono creare sottocartelle per oridare il 
-contenuto. Per esempio si puÚ creare una cartella ITALIA per mettere tutte le 
+contenuto. Per esempio si pu√≤ creare una cartella ITALIA per mettere tutte le 
 mappe che comprendono il territorio italiano, oppure si possono dividere le 
 mappe per tipo: Pixmap e Dos.
 
@@ -850,7 +850,7 @@ Esempio
 
 
 Le mappe Pixmap sono una combinazione di due file, un file binario grafico 
-pixmap (.xpm) e un file di dati di locazione (.geo).  Il file .xpm grafico Ë in 
+pixmap (.xpm) e un file di dati di locazione (.geo).  Il file .xpm grafico √® in 
 formato .xpm 
 standard modificabile con qualsiasi programma di grafica che supporti questo 
 formato.  Il 
@@ -867,7 +867,7 @@ Questo semplice file  ha 4 componenti. La prima riga indica il file grafico a
 cui sono riferiti i dati che deve essere nella stessa directory del file di 
 dati.
 La seconda linea imposta un commento alla mappa.  Ogni linea che inizia con un
- # (cancelletto) indica un commento che non verr‡ letto dal programma.
+ # (cancelletto) indica un commento che non verr√† letto dal programma.
 Le ultime due linee connettono un pixel di coordinate x,y ad un punto della 
 terra con coordinate lat/long.  Due punti sono necessari e dovrebbero essere 
 presi in alto a 
@@ -900,7 +900,7 @@ appartiene la mappa chiamate con l'abbreviazione di due lettere dello stato.
 
 
 
-Ecco due siti dove Ë possibile avere questo tipo di mappe:
+Ecco due siti dove √® possibile avere questo tipo di mappe:
 ftp://aprs.rutgers.edu/pub/hamradio/APRS/NWSCounties/
 http://home.att.net/~kg5qd1/Maps.html
 
@@ -908,20 +908,20 @@ HELP-INDEX>Informazioni stazione - Ricerca nel database FCC e RAC
 
                        Informazioni stazione - Ricerca nel database FCC e RAC
 
-Informazioni Stazione mostrer‡ tutti i dati acquisiti da Xastir per quel 
+Informazioni Stazione mostrer√† tutti i dati acquisiti da Xastir per quel 
 determinato nominativo.
 
-Il bottone Annulla Inseguimento toglier‡ tutti i percorsi che sono stati 
+Il bottone Annulla Inseguimento toglier√† tutti i percorsi che sono stati 
 memorizzati nello schermo.
 
-Il bottone Spedisci Messaggio aprir‡ una finestra per spedire un messaggio.
+Il bottone Spedisci Messaggio aprir√† una finestra per spedire un messaggio.
 
-Se si Ë installato il database FCC o RAC si puÚ fare una ricerca dei dati della 
+Se si √® installato il database FCC o RAC si pu√≤ fare una ricerca dei dati della 
 stazione.
 I file di databse RAC e FCC devono essere posizionati in
 /usr/local/share/xastir/fcc.
 
-Questa funzione aggiunger‡ l'indirizzo della stazione alle informazioni 
+Questa funzione aggiunger√† l'indirizzo della stazione alle informazioni 
 ricevute via radio.
 
 Per usare il database FCC bisogna scaricarlo (40Mb) da:
@@ -939,11 +939,11 @@ sort +4 -t \| EN.dat >EN.dat.sorted
 rm EN.dat
 mv EN.dat.sorted EN.dat
 
-Il database RAC si puÚ scaricare da:
+Il database RAC si pu√≤ scaricare da:
 ftp://ftp.rac.ca/pub/cdncaldb.zip
 
-Xastir creer‡ degli indici per ogni database, se un nuovo callsign Ë immesso 
-nel database allora Xastir creer‡ dei nuovi indici e render‡ subito disponibile 
+Xastir creer√† degli indici per ogni database, se un nuovo callsign √® immesso 
+nel database allora Xastir creer√† dei nuovi indici e render√† subito disponibile 
 il nuovo 
 callsign.
 
@@ -961,14 +961,14 @@ Quando attivo, una linea blu di dati appare sopra al nominativo, ad indicare
 l'altitudine della stazione nell'ultima posizione ricevuta.
 
 Direzione (on/off)
-Quando attivo, una linea verde di dati apparir‡ sotto al nominativo. Questa 
-indica la direzione in gradi del movimento della stazione l'ultima volta che Ë 
+Quando attivo, una linea verde di dati apparir√† sotto al nominativo. Questa 
+indica la direzione in gradi del movimento della stazione l'ultima volta che √® 
 stata ascoltata.
 
 
-Velocit‡ Speed (on/off)
-Quando attiva, una linea di dati rossi indica la velocit‡ della stazione 
-l'ultima volta che Ë stata ricevuta.
+Velocit√† Speed (on/off)
+Quando attiva, una linea di dati rossi indica la velocit√† della stazione 
+l'ultima volta che √® stata ricevuta.
 
 Distanza/direzione (on/off)
 Quando attivata, due linee di dati verranno visualizzate alla sinistra
@@ -977,10 +977,10 @@ La linea superiore indica la distanza dalla propria stazione, mentre la linea
 inferiore la direzione dalla propria stazione.
 
 Tracce della Stazione (on/off)
-Quando attiva, qualsiasi stazione in movimento lascer‡ una traccia della 
+Quando attiva, qualsiasi stazione in movimento lascer√† una traccia della 
 posizione precedente fino ad un numero di 100 posizioni.  Quando i dati della 
 stazione diventano vecchi e l'icona della stazione diventa trasparente, la 
-traccia Ë indicata con un tratteggio.
+traccia √® indicata con un tratteggio.
 
 Potenza/Guadagno (on/off)
 Quando attiva, visualizza i cerchi di potenza e guadagno.
@@ -988,17 +988,17 @@ Quando attiva, visualizza i cerchi di potenza e guadagno.
 Insegui stazione
 Questa funzione visualizza una finestra di dialogo simile a quella di 
 localizzazione.
-Si puÚ inserire un nominativo o parte di esso e quindi selezionare "Insegui 
+Si pu√≤ inserire un nominativo o parte di esso e quindi selezionare "Insegui 
 ora!" per centrare lo schermo su quella stazione e mantenerlo centrato per ogni 
 successivo spostamento.
 
-Selezionando "Elimina Inseguimento" si eliminer‡ la funzione.
+Selezionando "Elimina Inseguimento" si eliminer√† la funzione.
 
-Il bottone "Annulla" nasconder‡ la finestra senza apportare cambiamenti.
+Il bottone "Annulla" nasconder√† la finestra senza apportare cambiamenti.
 
 Informazioni Meteo (on/off)
 Quando selezionato, verranno visualizzate le ultime informazioni meteo
-(temperature,velocit‡ del vento/direzione/gust,umidit‡).
+(temperature,velocit√† del vento/direzione/gust,umidit√†).
 
 
 HELP-INDEX>Messaggi
@@ -1007,32 +1007,32 @@ HELP-INDEX>Messaggi
 
 Spedire Messaggi e Apri Gruppo
 
-Queste funzioni sono molto simili. "Spedisci messaggio a" spedir‡ un messaggio 
-solo ad una stazione.  I messaggi di gruppo sono pi˘ generali.
-(ndt: la funzione messaggi di gruppo al momento non Ë completamente funzionante)
+Queste funzioni sono molto simili. "Spedisci messaggio a" spedir√† un messaggio 
+solo ad una stazione.  I messaggi di gruppo sono pi√π generali.
+(ndt: la funzione messaggi di gruppo al momento non √® completamente funzionante)
 
 Ognuna di queste finestre visualizza una scheda di messaggio, una linea per il 
 nominativo/nome gruppo e vari bottoni.
 
 Una volta inserito il nominativo della stazione, tutti i messaggi ricevuti da
 essa verranno visualizzati.  Se non ci sono messaggi allora una nuova finestra
-permetter‡ di inserire un nuovo messaggi da spedire.  La lunghezza massima del
- messaggio Ë di 250 caratteri. "Spedisci ora!" invier‡ il messaggio al 
+permetter√† di inserire un nuovo messaggi da spedire.  La lunghezza massima del
+ messaggio √® di 250 caratteri. "Spedisci ora!" invier√† il messaggio al 
 destinatario.
-Il bottone "Spedisci ora!" rimarr‡ grigio fino a quando il messaggio non sar‡
+Il bottone "Spedisci ora!" rimarr√† grigio fino a quando il messaggio non sar√†
 correttamente inviato.
 
-Qualsiasi messaggio ricevuto sar‡ ordinato secondo la linea # e messo nella
- finestra dei messaggi.  Se si Ë nella funzione Gruppo, la lista dei messaggi
- visualizzer‡ anche il nominativo del mittente.
+Qualsiasi messaggio ricevuto sar√† ordinato secondo la linea # e messo nella
+ finestra dei messaggi.  Se si √® nella funzione Gruppo, la lista dei messaggi
+ visualizzer√† anche il nominativo del mittente.
 
-"Nuovo nominativo" visualizzer‡ i vecchi messaggi della stazione oppure
-permetter‡ la comunicazione con un'altra stazione.  Il bottone "Cancella
- Messaggi" eliminer‡ tutti i messaggi.
+"Nuovo nominativo" visualizzer√† i vecchi messaggi della stazione oppure
+permetter√† la comunicazione con un'altra stazione.  Il bottone "Cancella
+ Messaggi" eliminer√† tutti i messaggi.
 
 Elimina i messaggi in uscita.
 
-Questo eliminer‡ tutti i messaggi che sono stati spediti.
+Questo eliminer√† tutti i messaggi che sono stati spediti.
 
 Risposta automatica
 
@@ -1040,7 +1040,7 @@ Questa funzione attiva la risposta automatica ai messaggi in entrata.
 
 Imposta risposta automatica
 
-Render‡ possibile impostare il messaggio  di risposta automatico.
+Render√† possibile impostare il messaggio  di risposta automatico.
 
 HELP-INDEX>Eliminare i percorsi dallo schermo
 
@@ -1053,7 +1053,7 @@ HELP-INDEX>Ripulire lo schermo dai simboli di stazioni
 
                    Ripulire lo schermo dai simboli di stazioni
 
-Selezionare File e quindi "Elimina tutte le Stazioni". Questo eliminer‡ tutti 
+Selezionare File e quindi "Elimina tutte le Stazioni". Questo eliminer√† tutti 
 dati delle stazioni ricevute fino a quel momento eccetto la vostra.
 
 HELP-INDEX>Rispondere ad un log
@@ -1061,7 +1061,7 @@ HELP-INDEX>Rispondere ad un log
                               Rispondere ad un log
 
 Selezionare "Apri file log" e selezionare un file di log creato dal TNC o dalla 
-rete con la funzione sotto le opzioni di rete. La stazione user‡ il file di log 
+rete con la funzione sotto le opzioni di rete. La stazione user√† il file di log 
 come se 
 fosse direttamente connessa al TNC.
 
@@ -1074,8 +1074,8 @@ di dialogo che permette di inserire un nominativo (completo, non case
 sensitive). Se si vuole cercare un nominativo parziale allora bisogna 
 deselezionare "Nome esatto".  Selezionando "Maius/Minus Esatti" verranno
  osservati anche i criteri di Maiuscole/minuscole.
-Selezionando "Localizza Ora!" il Display verr‡ centrato sulla stazione cercata 
-al livello di zoom corrente.  "Annulla" chiuder‡ la finestra di dialogo.
+Selezionando "Localizza Ora!" il Display verr√† centrato sulla stazione cercata 
+al livello di zoom corrente.  "Annulla" chiuder√† la finestra di dialogo.
 
 
 HELP-INDEX>Creare ed usare i Salti alla Stazione
@@ -1084,10 +1084,10 @@ HELP-INDEX>Creare ed usare i Salti alla Stazione
 
 Selezionare Visualizza e quindi  "Vai alla Stazione" per visualizzare una
 finestra di dialogo.
-La prima volta che si usa questa funzione la finestra di dialogo sar‡ vuota.  
-Si puÚ creare una nuova vista selezionando "Nuova posizione", inserire il nome  
+La prima volta che si usa questa funzione la finestra di dialogo sar√† vuota.  
+Si pu√≤ creare una nuova vista selezionando "Nuova posizione", inserire il nome  
 e quindi Aggiungi.
-Per usare le posizioni registrate baster‡ selezionare la posizione e quindi il 
+Per usare le posizioni registrate baster√† selezionare la posizione e quindi il 
 tasto "Vai!" per centrare la posizione registrata.  E' possibile eliminare una 
 posizione selezionandola e selezionando "Elimina".
 

--- a/help/help-Spanish.dat
+++ b/help/help-Spanish.dat
@@ -1,79 +1,79 @@
-HELP-INDEX>L…AME PRIMERO - Licencia
+HELP-INDEX>L√âAME PRIMERO - Licencia
 
-           L…AME PRIMERO - Licencia
+           L√âAME PRIMERO - Licencia
 
-!!! NOTA: °Este Documento se actualizÛ en Fecha 04/09/02 !!
+!!! NOTA: ¬°Este Documento se actualiz√≥ en Fecha 04/09/02 !!
 
-Para la informaciÛn m·s actualizada por favor
+Para la informaci√≥n m√°s actualizada por favor
 lea el archivo README.1ST en el directorio de Xastir.
 
 Recuerde que este programa es usado por la comunidad HAM, en los EE.UU
 la FCC le restringe de transmitir sobre RF si usted no es un HAM con licencia.
-Usuarios autorizados en otros paÌses fuera de los EE.UU.
+Usuarios autorizados en otros pa√≠ses fuera de los EE.UU.
 Deben buscar sus restricciones gubernamentales locales. 
 
 LICENCIA:
 
-XASTIR, EstaciÛn de Aficionado de Rastreo y Reportes de InformaciÛn.
+XASTIR, Estaci√≥n de Aficionado de Rastreo y Reportes de Informaci√≥n.
 Copyright (C) 1999-2000 Frank Giannandrea
 Copyright (C) 2000-2026 The Xastir Group
 
 Este programa es software libre; usted puedes redistribuirlo y/o
-modificarlo bajo los tÈrminos del GNU Licencia P˙blica General
-como publicado por la FundaciÛn del Software Libre; cualquier versiÛn 2
-de la Licencia, o (a su opciÛn) cualquier versiÛn m·s atrazada.
+modificarlo bajo los t√©rminos del GNU Licencia P√∫blica General
+como publicado por la Fundaci√≥n del Software Libre; cualquier versi√≥n 2
+de la Licencia, o (a su opci√≥n) cualquier versi√≥n m√°s atrazada.
 
-pero SIN NINGUNA GARANTIA; a˙n sin la garantÌa implÌcita de
+pero SIN NINGUNA GARANTIA; a√∫n sin la garant√≠a impl√≠cita de
 COMERCIABILIDAD o APTITUD PARA UN PROPOSITO PARTICULAR.
-Vea el (GNU) Licencia P˙blica General para m·s detalles.
+Vea el (GNU) Licencia P√∫blica General para m√°s detalles.
 
-Usted debes de haber recibido una copia del GNU Licencia P˙blica General
+Usted debes de haber recibido una copia del GNU Licencia P√∫blica General
 junto con este programa; si no, escriba al Software Libre
-FundaciÛn, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, EE.UU..
+Fundaci√≥n, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, EE.UU..
 
-M·s informaciÛn sobre el programa puede encontrarse en:
+M√°s informaci√≥n sobre el programa puede encontrarse en:
 
 http://www.xastir.org/
 http://github.com/Xastir/Xastir
 
-Hay algunos Forum de discusiones disponibles que son especÌficamente sobre Xastir.
-Usted puedes subscribirse en uno o en ambos de ellos para recibir las ˙ltimas
+Hay algunos Forum de discusiones disponibles que son espec√≠ficamente sobre Xastir.
+Usted puedes subscribirse en uno o en ambos de ellos para recibir las √∫ltimas
 informaciones y novedades sobre el desarrollo de Xastir.
-Visite esta direcciÛn para subscribirse en http://www.xastir.org/.
+Visite esta direcci√≥n para subscribirse en http://www.xastir.org/.
 
-Para m·s informaciÛn sobre la Licencia GNU busque en:
+Para m√°s informaci√≥n sobre la Licencia GNU busque en:
 
 http://www.gnu.org/
 
 
 HELP-INDEX>Bienvenido! y Notas de los Autores
 
-                      °Bienvenido! y Notas de los Autores
+                      ¬°Bienvenido! y Notas de los Autores
 
-XASTIR, Significa, X-ventanas EstaciÛn de Aficionado de Rastreo y Reportes de InformaciÛn.
+XASTIR, Significa, X-ventanas Estaci√≥n de Aficionado de Rastreo y Reportes de Informaci√≥n.
 
-               El significado en inglÈs es como sigue:
+               El significado en ingl√©s es como sigue:
 XASTIR, or (X)windows (A)mateur (S)tation (T)racking and (I)nformation (R)eporting.
 
 Es un APRS(tm) como programa que es Fuente Abierta y libre para usarlo y pasarlo a otros. 
-Actualmente este programa est· en desarrollo y no debe verse 
-como un producto finalizado! Su ayuda ser· necesaria para hacer de este 
+Actualmente este programa est√° en desarrollo y no debe verse 
+como un producto finalizado! Su ayuda ser√° necesaria para hacer de este 
 un mejor programa.  
 
-Si usted tienes habilidades programando y/o puede escribir documentaciÛn, 
+Si usted tienes habilidades programando y/o puede escribir documentaci√≥n, 
 su ayuda puede ser necesaria! Yo tengo muchas ideas pero el tiempo muy corto. 
-AsÌ que si usted piensas que usted puedes anexar algo al esfuerzo dÈjemelo saber!
+As√≠ que si usted piensas que usted puedes anexar algo al esfuerzo d√©jemelo saber!
 
 73,
 Frank Giannandrea
 fgiannan@eazy.net
 
 
-APRS[tm] es una Marca de f·brica de Bob Bruninga, 
-su p·gina est· en "http://web.usna.navy.mil/~bruninga/aprs.html" 
-Por favor note que mucha de la informaciÛn sobre APRS(tm) puede encontrarse  
-en la documentaciÛn de APRSdos escrita por Bob Bruninga.  Una adicional  
-fuente de informaciÛn es el APRS(tm) especificaciÛn, disponible en  
+APRS[tm] es una Marca de f√°brica de Bob Bruninga, 
+su p√°gina est√° en "http://web.usna.navy.mil/~bruninga/aprs.html" 
+Por favor note que mucha de la informaci√≥n sobre APRS(tm) puede encontrarse  
+en la documentaci√≥n de APRSdos escrita por Bob Bruninga.  Una adicional  
+fuente de informaci√≥n es el APRS(tm) especificaci√≥n, disponible en  
 http://www.tapr.org
 
 HELP-INDEX>What's new in Xastir 2.0.9
@@ -335,26 +335,26 @@ HELP-INDEX>Iniciando a Xastir por primera vez
 Cuando Xastir se inicie por primera vez, usted debes ejecutarlo en una ventana 
 terminal asi que cualquier mensaje de advertencia o error puedan verse.
 
-En la mayorÌa de los sistemas una ruta es configurada para correr el programa 
+En la mayor√≠a de los sistemas una ruta es configurada para correr el programa 
 en /usr/local/bin y todo lo que usted necesitas hacer es tipear "xastir" 
-en la lÌnea de comando.
+en la l√≠nea de comando.
 
 En sistemas que no tienen este tipo de ruta instalado "/usr/local/bin/xastir" 
 para empezar el programa.
 
-Usted tambiÈn puedes poner la opciÛn del Idioma en este momento. 
-Para poner el idioma o cambiar el idioma actual, use Èsta lÌnea:
+Usted tambi√©n puedes poner la opci√≥n del Idioma en este momento. 
+Para poner el idioma o cambiar el idioma actual, use √©sta l√≠nea:
 
 xastir -l  
 
 
 Los Idomas Actuales son:
 
-Alem·n  (German)
-EspaÒol  (Spanish)
-FrancÈs  (French)
-HolandÈs  (Dutch)
-InglÈs  (English)
+Alem√°n  (German)
+Espa√±ol  (Spanish)
+Franc√©s  (French)
+Holand√©s  (Dutch)
+Ingl√©s  (English)
 Italiano  (Italian)
 ElmerFudd (English)
 MuppetsSwedishChef (English)
@@ -362,211 +362,211 @@ OldeEnglish (English)
 PigLatin (English)
 PirateEnglish (English)
 
-Si Usted quieres correr el Xastir en espaÒol use Èsta lÌnea:
+Si Usted quieres correr el Xastir en espa√±ol use √©sta l√≠nea:
 
 Ej: xastir -lSpanish o xastir -l Spanish
 
-Esta opciÛn ser· guardada en el archivo de  configuraciÛn de usuario 
-para que la prÛxima vez que Xastir se ejecute corra con el idioma EspaÒol. 
+Esta opci√≥n ser√° guardada en el archivo de  configuraci√≥n de usuario 
+para que la pr√≥xima vez que Xastir se ejecute corra con el idioma Espa√±ol. 
 
-En nueva instalaciÛn xastir tendr· como valor predefinido el idioma inglÈs 
-a menos que usted uses Èsta opciÛn de lÌnea de comando.
+En nueva instalaci√≥n xastir tendr√° como valor predefinido el idioma ingl√©s 
+a menos que usted uses √©sta opci√≥n de l√≠nea de comando.
 
-NOTA: En men˙s, se seleccionan artÌculos que son encanecido,
+NOTA: En men√∫s, se seleccionan art√≠culos que son encanecido,
 como en las opciones del ON/OFF, si 'ON' es seleccionado
-se opacar· o se pondr· transparente (encanecido).
+se opacar√° o se pondr√° transparente (encanecido).
 
-HELP-INDEX>Configurando la informaciÛn de la EstaciÛn
+HELP-INDEX>Configurando la informaci√≥n de la Estaci√≥n
 
-           Configure la InformaciÛn de la EstaciÛn   
+           Configure la Informaci√≥n de la Estaci√≥n   
 
-Pulse el botÛn del ratÛn en Archivo luego Configurar despuÈs en EstaciÛn  
+Pulse el bot√≥n del rat√≥n en Archivo luego Configurar despu√©s en Estaci√≥n  
 llene la casilla con su Indicativo de Radioaficionado.
 
-llene su posiciÛn de la estaciÛn si usted no est·s usando Xastir con una unidad de GPS. 
-Si usted no la conoce, usted puedes localizar su posiciÛn general en el mapa 
-con Xastir y puedes usar la posiciÛn dada por colocar el puntero del ratÛn sobre el mapa.
+llene su posici√≥n de la estaci√≥n si usted no est√°s usando Xastir con una unidad de GPS. 
+Si usted no la conoce, usted puedes localizar su posici√≥n general en el mapa 
+con Xastir y puedes usar la posici√≥n dada por colocar el puntero del rat√≥n sobre el mapa.
 
-Esta posiciÛn ser· visible en la barra del fondo de Xastir cuadro 2
-de la izquierda. Si usted tienes un GPS usted puedes saltar esta opciÛn.
+Esta posici√≥n ser√° visible en la barra del fondo de Xastir cuadro 2
+de la izquierda. Si usted tienes un GPS usted puedes saltar esta opci√≥n.
 
-Los sÌmbol/grupo de la estaciÛn pueden configurarse aquÌ. Pulse seleccionar gr·ficamente y  
-escoja un sÌmbolo, o manualmente rellene los campos. Una descripciÛn de texto de cada uno  
-de los sÌmbolos pueden encontrarse en la "Tabla de sÌmbolo" tema de ayuda. Las cubiertas son cumplidas seleccionando un sÌmbolo
+Los s√≠mbol/grupo de la estaci√≥n pueden configurarse aqu√≠. Pulse seleccionar gr√°ficamente y  
+escoja un s√≠mbolo, o manualmente rellene los campos. Una descripci√≥n de texto de cada uno  
+de los s√≠mbolos pueden encontrarse en la "Tabla de s√≠mbolo" tema de ayuda. Las cubiertas son cumplidas seleccionando un s√≠mbolo
  de la tabla alternada, y poniendo el campo de la tabla a  
-el car·cter que usted desea recubrir encima del sÌmbolo. Letras may˙sculas y  
-los n˙meros pueden ser recubierto. El APRS(tm) especificaciÛn sÛlo permite cubiertas sobre  
-sÌmbolos especÌficos; Xastir no forza esto, pero algunos otros programas pueden.  
-Note que no todos los sÌmbolos se han llevado a cabo en el selector gr·fico  
-todavÌa, y algunos de ellos no est·n por el APRS(tm) especificaciÛn todavÌa.  
+el car√°cter que usted desea recubrir encima del s√≠mbolo. Letras may√∫sculas y  
+los n√∫meros pueden ser recubierto. El APRS(tm) especificaci√≥n s√≥lo permite cubiertas sobre  
+s√≠mbolos espec√≠ficos; Xastir no forza esto, pero algunos otros programas pueden.  
+Note que no todos los s√≠mbolos se han llevado a cabo en el selector gr√°fico  
+todav√≠a, y algunos de ellos no est√°n por el APRS(tm) especificaci√≥n todav√≠a.  
 
-Luego, entre en los datos para la potencia/altura/ganancia de su estaciÛn. Esta es  
-una informaciÛn ˙til pero no se requiere; absolutamente seleccione "Desactive PHG"  
-desactivarlo. Estas opciones presentan una representaciÛn granular de su estaciÛn.  
-Seleccione la combinaciÛn de valores cerca a la descripciÛn de su estaciÛn.  
+Luego, entre en los datos para la potencia/altura/ganancia de su estaci√≥n. Esta es  
+una informaci√≥n √∫til pero no se requiere; absolutamente seleccione "Desactive PHG"  
+desactivarlo. Estas opciones presentan una representaci√≥n granular de su estaci√≥n.  
+Seleccione la combinaci√≥n de valores cerca a la descripci√≥n de su estaci√≥n.  
 
-Otra opciÛn serÌa especificar el RNG en el campo de comentario en millas  
-en lugar de usar PHG. Vea el APRS(tm) especificaciÛn para detalles.  
+Otra opci√≥n ser√≠a especificar el RNG en el campo de comentario en millas  
+en lugar de usar PHG. Vea el APRS(tm) especificaci√≥n para detalles.  
   
 Por favor use altura sobre el promedio del  terreno para el valor de altura.  No  
 use el promedio de altura sobre el nivel del mar o altura sobre tierra.  
   
 Para el uso de Ganancia la ganancia de su antena en dBi.   
-ø(CORRIGEME:  dBd? la especificaciÛn no es clara, 
-yo pienso que est· implicando dBi porque dice "en ausencia de cualquier datos,
+¬ø(CORRIGEME:  dBd? la especificaci√≥n no es clara, 
+yo pienso que est√° implicando dBi porque dice "en ausencia de cualquier datos,
 las estaciones son asumida a estar corriendo 10w a un 3dB omni en  20pies.
-Una antena omni tÌpica es sÛlo 3dBi.....)   
-Para Altura, use el HAAT (altura sobre el promedio del terreno) de su estaciÛn,  
+Una antena omni t√≠pica es s√≥lo 3dBi.....)   
+Para Altura, use el HAAT (altura sobre el promedio del terreno) de su estaci√≥n,  
 NO la altura sobre el nivel del mar o altura sobre geo-id.  
 
 Nota: La ganancia puesta es realmente pensada para las antenas verticales; la ganancia  
-puesta para una antena direcional deberÌa ser por debajo de la ganancia hacia delante de una antena direcional.  
-Esto es porque con la direccionabilidad puesta, el cÌrculo de PHG es compensado sÛlo a travÈs de 1/3rd  
-de su tamaÒo hacia la direcciÛn especificada. Poniendo la Ganancia m·s alta agrandar·  
-el cÌrculo entero no-realisticamente, en lugar del aumentado direccionalmente.  
-HabÌa charla hace varios aÒos sobre el enmendando las especificaciones para mejorar  
+puesta para una antena direcional deber√≠a ser por debajo de la ganancia hacia delante de una antena direcional.  
+Esto es porque con la direccionabilidad puesta, el c√≠rculo de PHG es compensado s√≥lo a trav√©s de 1/3rd  
+de su tama√±o hacia la direcci√≥n especificada. Poniendo la Ganancia m√°s alta agrandar√°  
+el c√≠rculo entero no-realisticamente, en lugar del aumentado direccionalmente.  
+Hab√≠a charla hace varios a√±os sobre el enmendando las especificaciones para mejorar  
 trato con antenas direccional, pero nada fue cambiado.  
   
-Entrar un comentario, no requerido pero agregar· visiÛn en su estaciÛn.  
-Una cosa com˙n para entrar aquÌ es su direcciÛn de e-mail preferida.  Que  
-ser· transmitido a lo largo con su postula.  
+Entrar un comentario, no requerido pero agregar√° visi√≥n en su estaci√≥n.  
+Una cosa com√∫n para entrar aqu√≠ es su direcci√≥n de e-mail preferida.  Que  
+ser√° transmitido a lo largo con su postula.  
   
-La ambig¸edad de la posiciÛn permitir· usted controlar que tan exacto usted transmite su  
-posiciÛn. Si usted no pone nada, xastir permitir· a su estaciÛn transmitir la exacta  
-posiciÛn que usted ha entrado o ha recibido de un GPS. Las otras opciones lo pondr·n  
-en alguna parte en el rango de la opciÛn que usted seleccionÛ.  Note que  
-esto puede tirar estaciones dÛciles a alguna no-especificaciÛn para un bucle.  Findu.com  
-no entiende la ambig¸edad de posiciÛn.  
+La ambig√ºedad de la posici√≥n permitir√° usted controlar que tan exacto usted transmite su  
+posici√≥n. Si usted no pone nada, xastir permitir√° a su estaci√≥n transmitir la exacta  
+posici√≥n que usted ha entrado o ha recibido de un GPS. Las otras opciones lo pondr√°n  
+en alguna parte en el rango de la opci√≥n que usted seleccion√≥.  Note que  
+esto puede tirar estaciones d√≥ciles a alguna no-especificaci√≥n para un bucle.  Findu.com  
+no entiende la ambig√ºedad de posici√≥n.  
   
-Pulsando el botÛn "Aceptar" guardar·s sus cambios.
-Pulsando el botÛn en "Cancelar" conservar·s las actuales configuraciones.
+Pulsando el bot√≥n "Aceptar" guardar√°s sus cambios.
+Pulsando el bot√≥n en "Cancelar" conservar√°s las actuales configuraciones.
 
-HELP-INDEX>Configurar OperaciÛn Predefinida
+HELP-INDEX>Configurar Operaci√≥n Predefinida
 
-              Configurar OperaciÛn Predefinida  
+              Configurar Operaci√≥n Predefinida  
   
-Pulse el botÛn en Archivo despuÈs en Configurar luego en Predefinidos
+Pulse el bot√≥n en Archivo despu√©s en Configurar luego en Predefinidos
   
-Esta p·gina prepara algunos valores por defecto normales para el funcionamiento 
-del programa. Viejas estaciones se desplegar·n con un icono fantasma, 
-y el sendero correspondiente se fragmentar·.  
+Esta p√°gina prepara algunos valores por defecto normales para el funcionamiento 
+del programa. Viejas estaciones se desplegar√°n con un icono fantasma, 
+y el sendero correspondiente se fragmentar√°.  
 
 El primer juego de botones de barra especifica el intervalo de desdoblamiento.  El segundo  
-juego de botones que especifica cuando una estaciÛn ser· removida de la pantalla.  
-Las estaciones tambiÈn son removida del banco de datos interno en el doble este tiempo,  
-asÌ si usted lo pusiera durante 6 horas, se anular·n estaciones del banco de datos  
+juego de botones que especifica cuando una estaci√≥n ser√° removida de la pantalla.  
+Las estaciones tambi√©n son removida del banco de datos interno en el doble este tiempo,  
+as√≠ si usted lo pusiera durante 6 horas, se anular√°n estaciones del banco de datos  
 a las 12 horas.  
   
-El tercer juego de botones especifica quÈ a menudo la identificaciÛn de su estaciÛn ser·  
-transmitido.  Para las estaciones fijas una recomendaciÛn buena es cada 30 minutos,  
+El tercer juego de botones especifica qu√© a menudo la identificaci√≥n de su estaci√≥n ser√°  
+transmitido.  Para las estaciones fijas una recomendaci√≥n buena es cada 30 minutos,  
 y definitivamente ninguno menos de 10 minutos.  
-Las estaciones mÛviles pueden desear una m·s r·pida proporciÛn.
+Las estaciones m√≥viles pueden desear una m√°s r√°pida proporci√≥n.
 
-Este intervalo tambiÈn se usa para mandar objetos y artÌculos.  Pruebe  
+Este intervalo tambi√©n se usa para mandar objetos y art√≠culos.  Pruebe  
 mantener este intervalo algo razonable, como transmitir hacia un largo camino,  
-cada 30 segundo realmente subir· mucho el tiempo aÈreo.
+cada 30 segundo realmente subir√° mucho el tiempo a√©reo.
 
-GPS Tiempo pondr· el intervalo de tiempo mirar el GPS por nuevos datos.  
+GPS Tiempo pondr√° el intervalo de tiempo mirar el GPS por nuevos datos.  
 Esto es disponible para estaciones que usan un cable compartido HSP con su TNC.  
   
-La OpciÛn Trasmite EstaciÛn fija el tipo de paquete que su estaciÛn transmitir· sus datos como.
-Transmite datos Raw WX  si seleccionado tambiÈn enviar· un paquete que contiene Datos raw
-de una EstaciÛn MeteorolÛgica. Esto es ˙til en los tipos de ASCII de estaciones WX, como la Peet Bros.
+La Opci√≥n Trasmite Estaci√≥n fija el tipo de paquete que su estaci√≥n transmitir√° sus datos como.
+Transmite datos Raw WX  si seleccionado tambi√©n enviar√° un paquete que contiene Datos raw
+de una Estaci√≥n Meteorol√≥gica. Esto es √∫til en los tipos de ASCII de estaciones WX, como la Peet Bros.
 
-EstaciÛn WX. Las Opciones de IGate preparar·n su estaciÛn como un portal de Internet-RF.
-Esta opciÛn podrÌa ser usada con cuatela, Como un HAM usted es responsable
-por el data que viene vÌa el Internet y es transmitido hacia el Puerto de RF. 
+Estaci√≥n WX. Las Opciones de IGate preparar√°n su estaci√≥n como un portal de Internet-RF.
+Esta opci√≥n podr√≠a ser usada con cuatela, Como un HAM usted es responsable
+por el data que viene v√≠a el Internet y es transmitido hacia el Puerto de RF. 
 
-Usted tambiÈn necesitar·   
-escoger una opciÛn del igate en cada interface para que el igate funcione.  
-Si usted quiere tener su igate envÌe NWS alarmas WX  hacia el RF, usted debe  
-crear un archivo ~/.xastir/data/nws-stations.txt listando cada llamada o estaciÛn de NWS  
-(como "PHISVR") que le gustarÌa transmitir vÌa RF.
+Usted tambi√©n necesitar√°   
+escoger una opci√≥n del igate en cada interface para que el igate funcione.  
+Si usted quiere tener su igate env√≠e NWS alarmas WX  hacia el RF, usted debe  
+crear un archivo ~/.xastir/data/nws-stations.txt listando cada llamada o estaci√≥n de NWS  
+(como "PHISVR") que le gustar√≠a transmitir v√≠a RF.
     
-"Transmitir datos de WX RAW", si seleccionado, tambiÈn enviar· un paquete que contiene crudo (raw)  
-Datos de estaciÛn meteorolÛgica. Esto es ˙til en los tipos de ASCII de estaciones WX,   
-como la Peet Bros. estaciÛn meteorolÛgica.
+"Transmitir datos de WX RAW", si seleccionado, tambi√©n enviar√° un paquete que contiene crudo (raw)  
+Datos de estaci√≥n meteorol√≥gica. Esto es √∫til en los tipos de ASCII de estaciones WX,   
+como la Peet Bros. estaci√≥n meteorol√≥gica.
 
-"Los datos de posiciÛn comprimida pueden ser transmitida"?, si es seleccionado, transmitir· en  
-el m·s nuevo formato comprimido. Este formato reducir· la cantidad de datos en  
-el aire, por eso aumentando la capacidad de la red APRS(tm). La m·xima  
-precisiÛn de la posiciÛn transmitida tambiÈn es m·s alta. Algunos programas m·s viejos,  
-incluyendo las recientes versiones de WinAPRS, no decodificar· este formato todavÌa.  
-Findu.com tambiÈn podrÌan tener problema con el.
+"Los datos de posici√≥n comprimida pueden ser transmitida"?, si es seleccionado, transmitir√° en  
+el m√°s nuevo formato comprimido. Este formato reducir√° la cantidad de datos en  
+el aire, por eso aumentando la capacidad de la red APRS(tm). La m√°xima  
+precisi√≥n de la posici√≥n transmitida tambi√©n es m√°s alta. Algunos programas m√°s viejos,  
+incluyendo las recientes versiones de WinAPRS, no decodificar√° este formato todav√≠a.  
+Findu.com tambi√©n podr√≠an tener problema con el.
 
 Activar Red Alternada ?
-esta opciÛn se usa para desplegar grupos de estaciones que muestran
-en el unproto en el campo '>To' la versiÛn del software como el Xastir
-que muestra la versiÛn en el unproto como esto: HI8GN>APX090.
+esta opci√≥n se usa para desplegar grupos de estaciones que muestran
+en el unproto en el campo '>To' la versi√≥n del software como el Xastir
+que muestra la versi√≥n en el unproto como esto: HI8GN>APX090.
 
-Usted tambiÈn puede seleccionar Altnet y puede escoger una llamada del altnet de este di·logo.
-Altnet le permite tener un privado APRS(tm) red entre las estaciones que tambiÈn  
+Usted tambi√©n puede seleccionar Altnet y puede escoger una llamada del altnet de este di√°logo.
+Altnet le permite tener un privado APRS(tm) red entre las estaciones que tambi√©n  
 tenga altnet configurado, y tiene la misma llamada del altnet entrada.
 
 Si cambiamos el valor por defecto que es XASTIR por ejemplo por APX110
-desplegar· toda las estaciones que tengan versiones de APX11x
+desplegar√° toda las estaciones que tengan versiones de APX11x
 donde valor de 'x' puede ser desde 0-9.
 
 HELP-INDEX>Configurando las Alarmas de Audio
 
                          Configurando las alarmas de Audio
 
-Para usar esta opciÛn usted debes tener una tarjeta de sonido y un programa que 
+Para usar esta opci√≥n usted debes tener una tarjeta de sonido y un programa que 
 reproduzcan los archivos wav. El programa reproductor de Audio debe tener 
 comando el cual usted quieres ejecutar para tocar el audio archivo (y cualquier 
-opciÛn en la lÌnea de comando).
+opci√≥n en la l√≠nea de comando).
 
-Los campos tendr·n el nombre del archivo a reproducir, campos bajo la opciÛn 
-pondr· par·metros para la opciÛn.
+Los campos tendr√°n el nombre del archivo a reproducir, campos bajo la opci√≥n 
+pondr√° par√°metros para la opci√≥n.
 
 Las opciones Actuales son:
 
-  Reproducir mensaje al encontrar una nueva estaciÛn. 
+  Reproducir mensaje al encontrar una nueva estaci√≥n. 
 
   Reproducir mensaje al recibir un nuevo mensaje.
 
-  Reproducir mensaje de datos recibidos de una estaciÛn dentro de la distancia  
+  Reproducir mensaje de datos recibidos de una estaci√≥n dentro de la distancia  
  min/max de su proximidad.
 
-  Reproducir mensaje de datos recibidos de una estaciÛn (vÌa TNC) con la 
+  Reproducir mensaje de datos recibidos de una estaci√≥n (v√≠a TNC) con la 
 distancia de min/max de su banda abrierta.
 
 HELP-INDEX>Configurar el Sintetizador de Voz
 
                          Configurar el Sintetizador de Voz
 
-Para usar esta opciÛn del sintetizador de voz usted debes tener una tarjeta de sonido
+Para usar esta opci√≥n del sintetizador de voz usted debes tener una tarjeta de sonido
 configurada para poder reproducir sonido.
 
-TambiÈn usted necesita tener instalado y corriendo al Servidor Festival m·s
-el Speech_tools con su biblioteca de soporte para el Sistema Festival de Voz SÌntetizada
+Tambi√©n usted necesita tener instalado y corriendo al Servidor Festival m√°s
+el Speech_tools con su biblioteca de soporte para el Sistema Festival de Voz S√≠ntetizada
 
 y asi poder escuchar el sintetizador de voz anunciar
-nuevas estaciones y aperturas de banda proximidad de una estaci·n. 
+nuevas estaciones y aperturas de banda proximidad de una estaci√°n. 
 
-El sistema de alarmas de sonidos ha sido tambiÈn retenido.
+El sistema de alarmas de sonidos ha sido tambi√©n retenido.
 
 Con el Sintetizador de Voz adaptado por Curt Mills (we7u) 
 
 ajuste las casillas en las cuales usted quieres ejecutar el sintetizador para las alarmas
 
-(y cualquier opciÛn en la lÌnea de comando).
+(y cualquier opci√≥n en la l√≠nea de comando).
 
-Los campos tendr·n el nombre del archivo a reproducir, campos bajo la opciÛn 
-pondr· par·metros para la opciÛn.
+Los campos tendr√°n el nombre del archivo a reproducir, campos bajo la opci√≥n 
+pondr√° par√°metros para la opci√≥n.
 
 Las opciones Actuales son:
 
-  Anunciar un mensaje al encontrar una nueva estaciÛn. 
+  Anunciar un mensaje al encontrar una nueva estaci√≥n. 
   Anunciar un mensaje al recibir un nuevo mensaje.
   Anunciar un mensaje al recibir el cuerpo un nuevo mensaje.
-  Anunciar un mensaje de datos recibidos de una estaciÛn dentro de la distancia  
+  Anunciar un mensaje de datos recibidos de una estaci√≥n dentro de la distancia  
   min/max de su proximidad.
 
-  Anunciar un mensaje de datos recibidos de una estaciÛn (vÌa TNC o INET)
+  Anunciar un mensaje de datos recibidos de una estaci√≥n (v√≠a TNC o INET)
   con la distancia de min/max de su banda abierta.
 
-  Anunciar un mensaje al recibir una nueva alerta sobre el tiempo climatolÛgico.
+  Anunciar un mensaje al recibir una nueva alerta sobre el tiempo climatol√≥gico.
 
 Info sobre Festival puede ser obtenida desde: http://www.speech.cs.cmu.edu/festival/
 
@@ -574,273 +574,273 @@ HELP-INDEX>Configurando las Unidades de Medida
 
                     Configure Unidades de Medida  
   
-La selecciÛn predefinida es para el Sistema MÈtrico, mm, cm, KPH, etc. 
-Seleccionar InglÈs, pulgadas, pies, MPH, etc. Pulse el botÛn de Configurar, 
-luego en Unidades, despuÈs la unidad de medida que usted quieres usar.
+La selecci√≥n predefinida es para el Sistema M√©trico, mm, cm, KPH, etc. 
+Seleccionar Ingl√©s, pulgadas, pies, MPH, etc. Pulse el bot√≥n de Configurar, 
+luego en Unidades, despu√©s la unidad de medida que usted quieres usar.
 Recuerde encanecida opciones son selecciona actualmente. 
 
-HELP-INDEX>Salvar ConfiguraciÛn Ahora!
+HELP-INDEX>Salvar Configuraci√≥n Ahora!
 
-                      Salvar ConfiguraciÛn Ahora!
+                      Salvar Configuraci√≥n Ahora!
 
-Este botÛn salvar· todas la configuraciÛn actual al archivo de configuraciÛn.  
-Note que cuando Xastir est· cerrado, tambiÈn salva configuraciÛn al archivo
-de configuraciÛn.
+Este bot√≥n salvar√° todas la configuraci√≥n actual al archivo de configuraci√≥n.  
+Note que cuando Xastir est√° cerrado, tambi√©n salva configuraci√≥n al archivo
+de configuraci√≥n.
 
 HELP-INDEX>Barra de Estado de fondo
 
                          Barra de Estado de fondo  
   
-En el fondo de la ventana varios mensajes de estado est·n disponibles:  
+En el fondo de la ventana varios mensajes de estado est√°n disponibles:  
   
 En la primera parte en la barra de estados general los mensajes son desplegados.
 
-La segunda parte se muestra la posiciÛn lat/long
-actual moviendo el ratÛn sobre el mapa.
+La segunda parte se muestra la posici√≥n lat/long
+actual moviendo el rat√≥n sobre el mapa.
 
 En la tercera parte es usada para mostrar
-cu·ntas estaciones est·n en el banco de datos.
+cu√°ntas estaciones est√°n en el banco de datos.
 
-La cuarta parte de la barra desplegar· el nivel de enfoque actual y desplegar·
-"Tr" si el rastreo de estaciÛn est· encendida (on).   
+La cuarta parte de la barra desplegar√° el nivel de enfoque actual y desplegar√°
+"Tr" si el rastreo de estaci√≥n est√° encendida (on).   
   
-El ˙ltima ·rea desplegar· el estado de dispositivo para cada interf·z. Cada una  
-desplegar· en orden primero hasta el ˙ltimo o de 0 a 9. El estado de la interface est· separado  
-en tres ·reas, tipo de dispositivo cima, datos de centro fluyendo, y interface de fondo  
-estado operacional. El tipo de dispositivo mostrar· quÈ interfaces se configuraron.  
-El color mostrar· quÈ tipo de dispositivo de la interface se configurÛ. Azul  
-es para los varios dispositivos TNC; Verde mostrar· los dispositivos de GPS; Amarillo para los   
-Servidores de Internet; Naranja para las interfaces de WX. El centro mostrar· que los datos fluyen en rx (flecha que apunta a l
-a izquierda) o los datos fluyen fuera tx (flecha que apunta a la derecha) para eso interface. Una caja verde al fondo mostrar· 
+El √∫ltima √°rea desplegar√° el estado de dispositivo para cada interf√°z. Cada una  
+desplegar√° en orden primero hasta el √∫ltimo o de 0 a 9. El estado de la interface est√° separado  
+en tres √°reas, tipo de dispositivo cima, datos de centro fluyendo, y interface de fondo  
+estado operacional. El tipo de dispositivo mostrar√° qu√© interfaces se configuraron.  
+El color mostrar√° qu√© tipo de dispositivo de la interface se configur√≥. Azul  
+es para los varios dispositivos TNC; Verde mostrar√° los dispositivos de GPS; Amarillo para los   
+Servidores de Internet; Naranja para las interfaces de WX. El centro mostrar√° que los datos fluyen en rx (flecha que apunta a l
+a izquierda) o los datos fluyen fuera tx (flecha que apunta a la derecha) para eso interface. Una caja verde al fondo mostrar√° 
 si esa interface es activa.  
-Una caja roja mostrar· si la interface es activa pero en una condiciÛn de error.  
-Por otra parte nada mostrar· si la interface no est· activa.  
+Una caja roja mostrar√° si la interface es activa pero en una condici√≥n de error.  
+Por otra parte nada mostrar√° si la interface no est√° activa.  
 
-Las ˙ltimas dos partes mostrar·n el estado del tnc y de la red. Una "=>" 
-indicar· si el dato est· siendo enviado, y una "<=" si el dato est· entrando 
+Las √∫ltimas dos partes mostrar√°n el estado del tnc y de la red. Una "=>" 
+indicar√° si el dato est√° siendo enviado, y una "<=" si el dato est√° entrando 
 desde la interfaz.
 
   
-HELP-INDEX>Moviendo el Mapa y el Men˙ de Opciones
+HELP-INDEX>Moviendo el Mapa y el Men√∫ de Opciones
 
-                    Moviendo el Mapa y el Men˙ de Opciones  
+                    Moviendo el Mapa y el Men√∫ de Opciones  
   
 Movimiento en el mapa es muy simple, la facilidad y rapidez de movimiento son dependientes de  
 la velocidad de su procesador y la cantidad de detalle que usted carga.  
   
 Subiendo verticalmente:  
-Subiendo verticalmente puede ser logrado por pulsar el botÛn derecho de ratÛn sobre el mapa (y sosteniendo el botÛn abajo). Est
-o plantear· un men˙ de opciones, con opciones para hacer subir verticalmente o fuera a un solo nivel, o para cambiar a uno de l
+Subiendo verticalmente puede ser logrado por pulsar el bot√≥n derecho de rat√≥n sobre el mapa (y sosteniendo el bot√≥n abajo). Est
+o plantear√° un men√∫ de opciones, con opciones para hacer subir verticalmente o fuera a un solo nivel, o para cambiar a uno de l
 os niveles del enfoque prefijado.  
   
-Todas las funciones de enfoque desde el men˙ de opciones har·n acercarse o alejarse al punto  
-en el mapa donde usted pulsÛ el botÛn del ratÛn correcto. El  nivel de enfoque tiene una men˙ en  cascada. Niveles 1-64 son par
-a las ·reas muy locales y niveles 256 y superior es para  
-·reas grandes. El n˙mero m·s bajo del nivel, la ·rea m·s local.  
+Todas las funciones de enfoque desde el men√∫ de opciones har√°n acercarse o alejarse al punto  
+en el mapa donde usted puls√≥ el bot√≥n del rat√≥n correcto. El  nivel de enfoque tiene una men√∫ en  cascada. Niveles 1-64 son par
+a las √°reas muy locales y niveles 256 y superior es para  
+√°reas grandes. El n√∫mero m√°s bajo del nivel, la √°rea m√°s local.  
   
-Una funciÛn de enfoque m·s r·pida es empujar y sostener el botÛn del ratÛn izquierdo, arr·strelo  
-por el ·rea de interÈs y permitida vaya.  El mapa har· subir verticalmente aproximadamente a  
-el tamaÒo del cuadrado usted apenas descrito con el ratÛn la funciÛn de arrastre.  
+Una funci√≥n de enfoque m√°s r√°pida es empujar y sostener el bot√≥n del rat√≥n izquierdo, arr√°strelo  
+por el √°rea de inter√©s y permitida vaya.  El mapa har√° subir verticalmente aproximadamente a  
+el tama√±o del cuadrado usted apenas descrito con el rat√≥n la funci√≥n de arrastre.  
 El programa usa el componente vertical para decidir en el nivel de enfoque, y el  
 componentes verticales y horizontales para computar el nuevo centro del mapa.  El "movimiento"  
 y "medida" que deben desactivarse checkboxes de la bara de herramienta de este rasgo para trabajar.  
   
-El mapa tambiÈn puede acercarse con el teclado las llaves de PageUp/PageDown.  El  
+El mapa tambi√©n puede acercarse con el teclado las llaves de PageUp/PageDown.  El  
 acercar en este caso guarda el mismo centro del mapa.   
   
 Paneando/Centrando:  
-El mapa puede centrarse a una situaciÛn especÌfica por pulsar el botÛn izquierdo del ratÛn.  
-Pulsando el botÛn los enfoques del botÛn medio aleja con un factor de 2, centrando donde usted  
-pulsÛ el botÛn.  
+El mapa puede centrarse a una situaci√≥n espec√≠fica por pulsar el bot√≥n izquierdo del rat√≥n.  
+Pulsando el bot√≥n los enfoques del bot√≥n medio aleja con un factor de 2, centrando donde usted  
+puls√≥ el bot√≥n.  
   
-Paneando tambiÈn es cumplido usando el men˙ de opciones, o usando la flecha  
-botones en la tope de la pantalla. La posiciÛn del mapa cambiar· una porciÛn de  
+Paneando tambi√©n es cumplido usando el men√∫ de opciones, o usando la flecha  
+botones en la tope de la pantalla. La posici√≥n del mapa cambiar√° una porci√≥n de  
 pantalla. Bastantes datos de pantalla anterior deben estar disponibles reorientarlo  
 .  
   
-El mapa tambiÈn puede ser paneado con las llaves de flecha del teclado.  
+El mapa tambi√©n puede ser paneado con las llaves de flecha del teclado.  
   
-M·s Sobre el Men˙ de Opciones:  
-La selecciÛn de "EstaciÛn Info" en el men˙ de opciones buscar· la estaciÛn  
-cerca a donde usted pulsÛ el botÛn derecho del ratÛn. Si m·s de una estaciÛn est·  
-cerca de esa posiciÛn un "escogedor de EstaciÛn" de lista aparecer·, entonces usted puede  
-escoger los datos de quÈ estaciÛn que usted quiere ver. Si sÛlo una estaciÛn es vista entonces el indicador del ratÛn es cerrad
-o y los datos de esa estaciÛn se desplegar·n inmediatamente. Note  
-que expiradas estaciones todavÌa tienen sus datos guardados en el banco de datos de Xastir, y  
-si uno sabe la situaciÛn anterior de una estaciÛn, uno todavÌa puede ver su info de esta  
-manera. TambiÈn es posible desplegar estaciones viejas encendiendo el "el Despliegue  
-de Datos Expirados" opciÛn en el men˙ de las estaciones. CORRIGEME: Si no es completamente verdad.  Esto sÛlo despliega algunos
+M√°s Sobre el Men√∫ de Opciones:  
+La selecci√≥n de "Estaci√≥n Info" en el men√∫ de opciones buscar√° la estaci√≥n  
+cerca a donde usted puls√≥ el bot√≥n derecho del rat√≥n. Si m√°s de una estaci√≥n est√°  
+cerca de esa posici√≥n un "escogedor de Estaci√≥n" de lista aparecer√°, entonces usted puede  
+escoger los datos de qu√© estaci√≥n que usted quiere ver. Si s√≥lo una estaci√≥n es vista entonces el indicador del rat√≥n es cerrad
+o y los datos de esa estaci√≥n se desplegar√°n inmediatamente. Note  
+que expiradas estaciones todav√≠a tienen sus datos guardados en el banco de datos de Xastir, y  
+si uno sabe la situaci√≥n anterior de una estaci√≥n, uno todav√≠a puede ver su info de esta  
+manera. Tambi√©n es posible desplegar estaciones viejas encendiendo el "el Despliegue  
+de Datos Expirados" opci√≥n en el men√∫ de las estaciones. CORRIGEME: Si no es completamente verdad.  Esto s√≥lo despliega algunos
  de los datos que desaparecen como estaciones fantasma,   
 Velocidad/altitud, etc.,  
   
-Para informaciÛn de Objeto y ArtÌculo, por favor vea el tema de ayuda "Objetos y ArtÌculos"  
+Para informaci√≥n de Objeto y Art√≠culo, por favor vea el tema de ayuda "Objetos y Art√≠culos"  
 
-HELP-INDEX>Objetos y ArtÌculos
+HELP-INDEX>Objetos y Art√≠culos
 
-                                Objetos y ArtÌculos
+                                Objetos y Art√≠culos
 
-La opciÛn de crear Objeto/ArtÌculo en el botÛn derecho pulsado el men˙ traear· un di·logo  
-con la posiciÛn de basado objeto en donde usted pulsÛ el botÛn del ratÛn.  
-Usted puede rellenar los detalles, y agregar un objeto/artÌculo desde este men˙.  
+La opci√≥n de crear Objeto/Art√≠culo en el bot√≥n derecho pulsado el men√∫ traear√° un di√°logo  
+con la posici√≥n de basado objeto en donde usted puls√≥ el bot√≥n del rat√≥n.  
+Usted puede rellenar los detalles, y agregar un objeto/art√≠culo desde este men√∫.  
   
-La opciÛn de modificar Objeto/ArtÌculo le traer· un di·logo de modificaciÛn de objeto.  
-Es similar al di·logo de creaciÛn de objeto, excepto por la actual informaciÛn de objeto que  
-ya est·n publicada, y el nombre del objeto y unas de las pocas otras opciones que no pueden ser cambiada.  
+La opci√≥n de modificar Objeto/Art√≠culo le traer√° un di√°logo de modificaci√≥n de objeto.  
+Es similar al di√°logo de creaci√≥n de objeto, excepto por la actual informaci√≥n de objeto que  
+ya est√°n publicada, y el nombre del objeto y unas de las pocas otras opciones que no pueden ser cambiada.  
   
-Los objetos son retransmitido dentro de la proporciÛn de posiciÛn de la estaciÛn reportada, configurada en Archivo|Configurar|P
-redefinidos, y cesar· la retransmisiÛn despuÈs doblar el  
-tiempo de despliegue de la estaciÛn, tambiÈn configurada allÌ. "muerta" los objetos tambiÈn son  
+Los objetos son retransmitido dentro de la proporci√≥n de posici√≥n de la estaci√≥n reportada, configurada en Archivo|Configurar|P
+redefinidos, y cesar√° la retransmisi√≥n despu√©s doblar el  
+tiempo de despliegue de la estaci√≥n, tambi√©n configurada all√≠. "muerta" los objetos tambi√©n son  
 retransmitido de esta manera, hasta que ellos expiren desde la cola.  
   
 Generalmente se usan los objetos para movimiento o cosas inconstantes como tormentas,  
-mientras que los artÌculos generalmente son usando para las cosas m·s inanimadas, como agua,  
-estaciones. Cualquiera puede moverse con el ratÛn si el "Movimiento" el checkbox en la  
-barra de botones se habilita.  Note que los artÌculos no pueden ser descifrados por uno cuantos  programas APRS(tm) .  
+mientras que los art√≠culos generalmente son usando para las cosas m√°s inanimadas, como agua,  
+estaciones. Cualquiera puede moverse con el rat√≥n si el "Movimiento" el checkbox en la  
+barra de botones se habilita.  Note que los art√≠culos no pueden ser descifrados por uno cuantos  programas APRS(tm) .  
   
-Las ·rea de objetos son ˙tiles para una variedad de funcionamientos en lo que usted quiere dibujar  
-o resaltar una ·rea de interÈs en el mapa. Ellos tambiÈn pueden ser personalizados para dibujar  
-rastros/caminos/fronteras, sitios de vijilancia para mal el tiempo, las pistas de aterrizaje, perÌmetros, de una ·rea de b˙sque
-da o de un evento de servicio p˙blico, ·reas de daÒo, ·reas para quedarse fuera de, edificios que no est·n en el mapa, la tabla
- checker/chess para juego por dinero en APRS(tm).: -) Note que las ·rea de objetos no son llevada a cabo en todas las versiones
- de programas APRS(tm), y algunos de los detalles de cÛmo ellos se despliegan tambiÈn pueden  
+Las √°rea de objetos son √∫tiles para una variedad de funcionamientos en lo que usted quiere dibujar  
+o resaltar una √°rea de inter√©s en el mapa. Ellos tambi√©n pueden ser personalizados para dibujar  
+rastros/caminos/fronteras, sitios de vijilancia para mal el tiempo, las pistas de aterrizaje, per√≠metros, de una √°rea de b√∫sque
+da o de un evento de servicio p√∫blico, √°reas de da√±o, √°reas para quedarse fuera de, edificios que no est√°n en el mapa, la tabla
+ checker/chess para juego por dinero en APRS(tm).: -) Note que las √°rea de objetos no son llevada a cabo en todas las versiones
+ de programas APRS(tm), y algunos de los detalles de c√≥mo ellos se despliegan tambi√©n pueden  
 ser diferente en otros programas.  
   
 Nombre  
-…ste es el nombre del objeto o artÌculo. Puede depender de hasta 9 car·cteres. Cuando  
+√âste es el nombre del objeto o art√≠culo. Puede depender de hasta 9 car√°cteres. Cuando  
 modifica un objeto, este no puede ser cambiado. Para renombrar un objeto usted debe  
 anular el original y entonces crear un nuevo objeto. Note que si usted selecciona  
-Signpost/Area Object/DF Objeto que este campo y quiz·s otros ser·n aclarado.  
-Entre en el nombre DESPU…S que usted ha seleccionado el tipo de objeto que volver·.  
+Signpost/Area Object/DF Objeto que este campo y quiz√°s otros ser√°n aclarado.  
+Entre en el nombre DESPU√âS que usted ha seleccionado el tipo de objeto que volver√°.  
   
 Poste indicador  
-Este hace al objeto un poste indicador de objeto. Estas seÒales pueden ser 3 car·cteres,  
-visible en un poste indicador a la locaciÛn cuando el enfoque es acercado. (CORRIGEME: Nosotros no hacemos el despliegue de los
- postes indicadores todavÌa de esta manera).  
+Este hace al objeto un poste indicador de objeto. Estas se√±ales pueden ser 3 car√°cteres,  
+visible en un poste indicador a la locaci√≥n cuando el enfoque es acercado. (CORRIGEME: Nosotros no hacemos el despliegue de los
+ postes indicadores todav√≠a de esta manera).  
   
-Objeto del ·rea  
-Esto hace un objeto del ·rea al objeto, y habilita los mandos de objeto de ·rea  
+Objeto del √°rea  
+Esto hace un objeto del √°rea al objeto, y habilita los mandos de objeto de √°rea  
 descrito debajo.  
   
 Objeto DF  
-…ste es un informe de contrada-direcciÛn. Habilit·ndolo le permite escoger reporte Omni o  
+√âste es un informe de contrada-direcci√≥n. Habilit√°ndolo le permite escoger reporte Omni o  
 direccional, y le permite poner en el especifico para cada uno.  Vea:  
     http://web.usna.navy.mil/~bruninga/dfing.html  
-y la documentaciÛn de APRSdos para los detalles en estas tÈcnicas ˙tiles.  
-(CORRIGEME: la secciÛn Separada en las tÈcnicas de DFing?)  
+y la documentaci√≥n de APRSdos para los detalles en estas t√©cnicas √∫tiles.  
+(CORRIGEME: la secci√≥n Separada en las t√©cnicas de DFing?)  
   
-SÌmbolo EstaciÛn  
-Usted puede seleccionar un sÌmbolo para el objeto. Pulse seleccionar para escoger gr·ficamente,  
-o ver la secciÛn tabla de ayuda de sÌmbolo para las descripciones de cada sÌmbolo. Note  
-que no todos los sÌmbolos se han llevado a cabo todavÌa en el escogedor de gr·ficos,  
-y algunos no est·n por el APRS(tm) especificaciÛn. TambiÈn note esa ·rea de objeto, poste indicador de objetos, y los objetos d
-e DF tienen sÌmbolos fijos especiales y por consiguiente no pueden ser seleccionado aquÌ.  
+S√≠mbolo Estaci√≥n  
+Usted puede seleccionar un s√≠mbolo para el objeto. Pulse seleccionar para escoger gr√°ficamente,  
+o ver la secci√≥n tabla de ayuda de s√≠mbolo para las descripciones de cada s√≠mbolo. Note  
+que no todos los s√≠mbolos se han llevado a cabo todav√≠a en el escogedor de gr√°ficos,  
+y algunos no est√°n por el APRS(tm) especificaci√≥n. Tambi√©n note esa √°rea de objeto, poste indicador de objetos, y los objetos d
+e DF tienen s√≠mbolos fijos especiales y por consiguiente no pueden ser seleccionado aqu√≠.  
   
-LocalizaciÛn  
-La localizaciÛn del objeto se especifica aquÌ. Si usted seleccionara "Crear   
-Objeto/ArtÌculo" pulsando el botÛn derecho del men˙, la locaciÛn que usted pulsado se llenar·  
-. Si usted moviera un objeto con el ratÛn, la nueva posiciÛn estar· en esos campos.  Usted tambiÈn puede teclear en una posiciÛ
+Localizaci√≥n  
+La localizaci√≥n del objeto se especifica aqu√≠. Si usted seleccionara "Crear   
+Objeto/Art√≠culo" pulsando el bot√≥n derecho del men√∫, la locaci√≥n que usted pulsado se llenar√°  
+. Si usted moviera un objeto con el rat√≥n, la nueva posici√≥n estar√° en esos campos.  Usted tambi√©n puede teclear en una posici√≥
 n, por ejemplo usted puede estar poniendo un  
 objeto de un informe de voz sobre el aire.  
   
-Opciones genÈricas  
-Usted puede especificar la velocidad, direcciÛn, y altitud de objetos aquÌ. Algunos tipos de objetos  
-no pueden tener una velocidad o direcciÛn en tales casos los campos son desgrisado  
+Opciones gen√©ricas  
+Usted puede especificar la velocidad, direcci√≥n, y altitud de objetos aqu√≠. Algunos tipos de objetos  
+no pueden tener una velocidad o direcci√≥n en tales casos los campos son desgrisado  
 .  
   
 Objeto del poste indicador  
-Si el objeto es un objeto de poste indicador, usted puede especificar de 1 a 3 car·cter  
-de mensaje que aparece en la seÒal aquÌ.  Note que Xastir no despliega los objetos  
-de poste indicador a propiamente todavÌa.  
+Si el objeto es un objeto de poste indicador, usted puede especificar de 1 a 3 car√°cter  
+de mensaje que aparece en la se√±al aqu√≠.  Note que Xastir no despliega los objetos  
+de poste indicador a propiamente todav√≠a.  
   
-Objeto ·rea  
-Se usan Objetos de ·rea para resaltar partes especÌficas del mapas, o para dibujar excepcionalmente detalle dentro de los mapas
+Objeto √°rea  
+Se usan Objetos de √°rea para resaltar partes espec√≠ficas del mapas, o para dibujar excepcionalmente detalle dentro de los mapas
 .  
   Color luminoso.  
-    Use la versiÛn m·s luminosa de los colores permitidos.  
+    Use la versi√≥n m√°s luminosa de los colores permitidos.  
   Colorido  
-    El ·rea debe llenarse, no sÛlo perfilado. Esto puede ser ˙til para  
-    excluir una ·rea de una b˙squeda u otro evento.  
+    El √°rea debe llenarse, no s√≥lo perfilado. Esto puede ser √∫til para  
+    excluir una √°rea de una b√∫squeda u otro evento.  
   Tipo de objeto  
-    Escoge desde las formas geomÈtricas permitidas.  
+    Escoge desde las formas geom√©tricas permitidas.  
   Color del objeto  
-    Escoge el color en el que el objeto se desplegar·. Esto tambiÈn es afectado  
-    por el "Color Luminoso" la opciÛn anteriormente.  
+    Escoge el color en el que el objeto se desplegar√°. Esto tambi√©n es afectado  
+    por el "Color Luminoso" la opci√≥n anteriormente.  
   El objeto Compensado  
-    En centÈsima de un grado latitud.  Un detalle infortunado de la especificaciÛn,  
-    y duro de calcular f·cilmente.  Basta decir que usted puede cambiar  
-    el tamaÒo del objeto una vez usted lo ponga.  
+    En cent√©sima de un grado latitud.  Un detalle infortunado de la especificaci√≥n,  
+    y duro de calcular f√°cilmente.  Basta decir que usted puede cambiar  
+    el tama√±o del objeto una vez usted lo ponga.  
   El Desplazamiento izquierdo del objeto excepto /  
-    En centÈsima de un grado latitud.  Vea anteriormente.  
+    En cent√©sima de un grado latitud.  Vea anteriormente.  
   Objeto corredor  
-    …ste es el ancho de una lÌnea de ·rea de objeto. Util para las pistas de aterrizaje, tiempo  
-    watchboxes, describiendo una ·rea de interÈs o una ·rea de exclusiÛn, etc.,  
-(CORRIGEME: Escriba esta parte! (el ·rea objeto) La especificaciÛn es incierta a mÌ, el cÛdigo,  
-es incierto a mÌ, pero en el futuro yo lo deducirÈ todos!)  
+    √âste es el ancho de una l√≠nea de √°rea de objeto. Util para las pistas de aterrizaje, tiempo  
+    watchboxes, describiendo una √°rea de inter√©s o una √°rea de exclusi√≥n, etc.,  
+(CORRIGEME: Escriba esta parte! (el √°rea objeto) La especificaci√≥n es incierta a m√≠, el c√≥digo,  
+es incierto a m√≠, pero en el futuro yo lo deducir√© todos!)  
   
-°Siempre anule sus objetos y artÌculos cuando usted halla terminado con ellos!  
+¬°Siempre anule sus objetos y art√≠culos cuando usted halla terminado con ellos!  
 No les permita simplemente expirar desde su escondite, como ellos pueden colgarse  
 alrededor de las pantallas de otras personas por un periodo extendido.  
     
 
-HELP-INDEX>Men˙ Visualizador
+HELP-INDEX>Men√∫ Visualizador
 
-                     Opciones del Men˙ de Visualizar  
+                     Opciones del Men√∫ de Visualizar  
   
-El men˙ de Visualizar presenta varias maneras de ver datos en Xastir.  
+El men√∫ de Visualizar presenta varias maneras de ver datos en Xastir.  
   
 Boletines  
-…ste es el APRS(tm) tabla de anuncios, donde importantes anuncios son puesto.  
-Si usted se conecta con la interf·z del internet, es una buena idea para poner el  
+√âste es el APRS(tm) tabla de anuncios, donde importantes anuncios son puesto.  
+Si usted se conecta con la interf√°z del internet, es una buena idea para poner el  
 rango del campo a unas cientas millas, para ignorar postes de otras porciones del  
-mundo. "0" es el rango del campo, significa el mundo entero. Pulse el botÛn "Cambio de rango"  
-pulse para hacer cambios a este campo eficaz. Xastir actualmente no soporta el envÌo de boletines.  
+mundo. "0" es el rango del campo, significa el mundo entero. Pulse el bot√≥n "Cambio de rango"  
+pulse para hacer cambios a este campo eficaz. Xastir actualmente no soporta el env√≠o de boletines.  
   
 Datos de paquete entrantes  
-Esto despliega los datos entrantes en su TNC o interf·z del internet. Los botones radio  
-debajo selecciona si usted quiere ver sÛlo datos de TNC, sÛlo datos del internet, o  
+Esto despliega los datos entrantes en su TNC o interf√°z del internet. Los botones radio  
+debajo selecciona si usted quiere ver s√≥lo datos de TNC, s√≥lo datos del internet, o  
 ambos.  
   
-Estaciones mÛviles  
-…sta es una lista de estaciones que se est·n moviendo. Las estaciones califican para esta lista si  
-ellas se han movido (m·s de una posiciÛn recibida para ellas), el sÌmbolo de  
-la estaciÛn no es considerada. InformaciÛn mostrada incluyendo curso, velocidad, altitud,  
-posiciÛn, n˙mero de paquetes recibido, n˙mero de satÈlites de GPS visibles, curso,  
-de su estaciÛn, y distancia de su estaciÛn.   
+Estaciones m√≥viles  
+√âsta es una lista de estaciones que se est√°n moviendo. Las estaciones califican para esta lista si  
+ellas se han movido (m√°s de una posici√≥n recibida para ellas), el s√≠mbolo de  
+la estaci√≥n no es considerada. Informaci√≥n mostrada incluyendo curso, velocidad, altitud,  
+posici√≥n, n√∫mero de paquetes recibido, n√∫mero de sat√©lites de GPS visibles, curso,  
+de su estaci√≥n, y distancia de su estaci√≥n.   
   
 Todas las Estaciones  
-Esta opciÛn despliega una tabla de todas las estaciones ordenada alfabÈticamente. Incluyendo  
-el n˙mero de paquetes oÌdo, el tiempo que la estaciÛn fue oÌda ˙ltima vez, el camino   
-m·s reciente paquete tomado, el PHG, y el comentario de la estaciÛn.  
+Esta opci√≥n despliega una tabla de todas las estaciones ordenada alfab√©ticamente. Incluyendo  
+el n√∫mero de paquetes o√≠do, el tiempo que la estaci√≥n fue o√≠da √∫ltima vez, el camino   
+m√°s reciente paquete tomado, el PHG, y el comentario de la estaci√≥n.  
   
 Estaciones locales  
-Esta opciÛn despliega sÛlo estaciones que se oyen vÌa su TNC. Incluye  
-el n˙mero de paquetes oÌdo, el tiempo que la estaciÛn fue oÌda ˙ltima vez, el camino  
-m·s reciente paquete tomado, el PHG, y el comentario de la estaciÛn.  
+Esta opci√≥n despliega s√≥lo estaciones que se oyen v√≠a su TNC. Incluye  
+el n√∫mero de paquetes o√≠do, el tiempo que la estaci√≥n fue o√≠da √∫ltima vez, el camino  
+m√°s reciente paquete tomado, el PHG, y el comentario de la estaci√≥n.  
   
 Ultimas Estaciones  
-Esta opciÛn despliega una tabla de todas las estaciones ordenada recientemente oÌda  
-a menor recientemente escuchada. Incluye el n˙mero de paquetes oÌdo, el tiempo,  
-la estaciÛn fue oÌda ˙ltima vez, el camino que el m·s reciente paquete tomÛ, el PHG,  
-y el comentario de la estaciÛn.  
+Esta opci√≥n despliega una tabla de todas las estaciones ordenada recientemente o√≠da  
+a menor recientemente escuchada. Incluye el n√∫mero de paquetes o√≠do, el tiempo,  
+la estaci√≥n fue o√≠da √∫ltima vez, el camino que el m√°s reciente paquete tom√≥, el PHG,  
+y el comentario de la estaci√≥n.  
   
-EstaciÛn WX  
-Esta opciÛn despliega una tabla de todo el APRS(tm) estaciones del tiempo y sus datos.  
-El datos incluyen curso del viento, velocidad del viento, velocidad de r·faga dle viento, temperatura, humedad, presiÛn baromÈt
-rica, lluvia en la ˙ltima hora, lluvia medianoche subsecuentemente, y lluvia en las ˙ltimas 24 horas.  
+Estaci√≥n WX  
+Esta opci√≥n despliega una tabla de todo el APRS(tm) estaciones del tiempo y sus datos.  
+El datos incluyen curso del viento, velocidad del viento, velocidad de r√°faga dle viento, temperatura, humedad, presi√≥n barom√©t
+rica, lluvia en la √∫ltima hora, lluvia medianoche subsecuentemente, y lluvia en las √∫ltimas 24 horas.  
   
-EstaciÛn MeteorolÛgica Propia  
-Despliega sus datos del tiempo si usted tiene una estaciÛn del tiempo y la ha configurado  
+Estaci√≥n Meteorol√≥gica Propia  
+Despliega sus datos del tiempo si usted tiene una estaci√≥n del tiempo y la ha configurado  
 Xastir para accederla.  
   
 Alerta del Tiempo  
 Los despliegues alarmas recibidas, incluso las banderas de alertas, la alerta fuente/tipo,  
-destino alerta, expiraciÛn, mensaje, y efectuada situaciÛn. Esto datos  
-se usa por el resalto de condado, y no es particularmente humanamente-leÌble.  
-Usted generalmente puede deducir el estado y condado para la mayorÌa de las alarmas.  
+destino alerta, expiraci√≥n, mensaje, y efectuada situaci√≥n. Esto datos  
+se usa por el resalto de condado, y no es particularmente humanamente-le√≠ble.  
+Usted generalmente puede deducir el estado y condado para la mayor√≠a de las alarmas.  
   
-Tr·fico de mensaje  
-Muestras todo el tr·fico de mensaje mientras la ventana est· abierta. Incluye la fuente,  
-destino, interf·z, y mensaje. La opciÛn de rango puede limitar este despliegue  
+Tr√°fico de mensaje  
+Muestras todo el tr√°fico de mensaje mientras la ventana est√° abierta. Incluye la fuente,  
+destino, interf√°z, y mensaje. La opci√≥n de rango puede limitar este despliegue  
 a las estaciones cercanas, mucho como el mando del rango en boletines. Un rango de 0  
 causas todos los mensajes a ser desplegados.  
   
@@ -855,27 +855,27 @@ Mapas Opciones:
 
 Auto mapas (on/off)
  Cuando cualquier mapa es encontrado, en el directorio de mapas
-(o cualquier directorio bajo Èl) ser· desplegado,
-si el cae dentro de la regiÛn de despliegue actual.
+(o cualquier directorio bajo √©l) ser√° desplegado,
+si el cae dentro de la regi√≥n de despliegue actual.
 
-Usted puedes agregar cualquier n˙mero de niveles de directorios bajo
+Usted puedes agregar cualquier n√∫mero de niveles de directorios bajo
 el directorio del mapa principal para sus mapas.
-El Auto mapa pasar· por todos ellos y hallar· que mapa (o parte) debe desplegarse.
+El Auto mapa pasar√° por todos ellos y hallar√° que mapa (o parte) debe desplegarse.
 
-Todos los Mapas se unir·n en el ·rea de visiÛn.
+Todos los Mapas se unir√°n en el √°rea de visi√≥n.
 Si usted tienes una cantidad grandes de mapas, mapas muy detallados
 o una computadora muy lenta, esto puede ser mostrado bastante lento.
 
-Cuando esta opciÛn est· apagada, se desplegar·n mapas seleccionados
+Cuando esta opci√≥n est√° apagada, se desplegar√°n mapas seleccionados
 con el selector de Mapas.
 
 Rejillas sobre Mapa (on/off)
- Cuando estÈ en 'ON', esta opciÛn desplegar· una lÌnea de reja cada 10 grados.
+ Cuando est√© en 'ON', esta opci√≥n desplegar√° una l√≠nea de reja cada 10 grados.
 
  Niveles de mapas (on/off)
- Cuando estÈ en 'ON', esta opciÛn intentar· filtrar fuera los datos cuando el 
-nivel de enfoque muesta grandes ·reas. Esto no trabajar· con todos los mapas 
-pero trabajar· con los mapas generados de 'Tiger line maps'  en el sitio de 
+ Cuando est√© en 'ON', esta opci√≥n intentar√° filtrar fuera los datos cuando el 
+nivel de enfoque muesta grandes √°reas. Esto no trabajar√° con todos los mapas 
+pero trabajar√° con los mapas generados de 'Tiger line maps'  en el sitio de 
 aprs.rutgers.edu.
 
 Areas rellena en colores (on/off)
@@ -885,12 +885,12 @@ Los mapas son cargados en orden alfabertico por tipo, asi que renombrando
 mapas es un segundo pero la via es menos elegante archivar la vista deseada.
 
 Seleccionar Mapas
-Esta se presentar· con una lista de todos los archivos en su directorio de 
-mapas. Cualquier mapa que usted desearÌas incluirlo en los datos desplegados, 
-simplemente tiene que pulsar el botÛn del ratÛn sobre el nombre.
-Esto resaltar· el nombre del mapa, Usted puedes seleccionar cualquier n˙mero de mapas.
-Pulsando en el botÛn "Aceptar"  se desplegar·n los mapas seleccionados.
-Oprimiendo el BotÛn de "Cancelar" abandonarÌa cualquier cambio.
+Esta se presentar√° con una lista de todos los archivos en su directorio de 
+mapas. Cualquier mapa que usted desear√≠as incluirlo en los datos desplegados, 
+simplemente tiene que pulsar el bot√≥n del rat√≥n sobre el nombre.
+Esto resaltar√° el nombre del mapa, Usted puedes seleccionar cualquier n√∫mero de mapas.
+Pulsando en el bot√≥n "Aceptar"  se desplegar√°n los mapas seleccionados.
+Oprimiendo el Bot√≥n de "Cancelar" abandonar√≠a cualquier cambio.
 
 Tambien hay botones de atajo para seleccionar todos de un cierto tipo de mapa,
 o de-seleccionar todos los mapas de una vez.
@@ -898,31 +898,31 @@ o de-seleccionar todos los mapas de una vez.
 Una nota sobre mapas: Muchos de los actuales mapas de vectores disponibles para
 los EE.UU. fueron creado en NAD 1927 datum, mientras Xastir y otros programas de APRS
 usan el WGS 1984 datum. 
-Si es enfocado hacia una ·rea pequeÒa en el mapa la variaci·n del datum
+Si es enfocado hacia una √°rea peque√±a en el mapa la variaci√°n del datum
 puede ser muy notable. Los mapas topo USGS tienen sus datum corregido por Xastir
 como ellos son desplegados,
-asi que la posiciones generalmente ser·n m·s exacta con los mapas topo.
+asi que la posiciones generalmente ser√°n m√°s exacta con los mapas topo.
 
 HELP-INDEX>Archivos Mapas, Dos, Windows, Pixmaps, geoTIFF y Condados WX  
 
              Archivos mapas, Dos, Windows, Pixmaps, geoTIFF y Condados WX  
 
 Tipos de mapas  
-Xastir trabajar· con varios tipos archivos de mapas.
+Xastir trabajar√° con varios tipos archivos de mapas.
 Todo el Dos, Windows/MacAPRS[TM] son archivos de  Mapas que son soportados.
 
-Un nuevo formato de Pixmap se ha agregado en versiÛn 0.3.2.
-Xastir tambiÈn soportar· mapas para las Alertas de condados WX.  
-El ˙ltimo formato de mapa soportado es geoTIFF, tales mapas como son
+Un nuevo formato de Pixmap se ha agregado en versi√≥n 0.3.2.
+Xastir tambi√©n soportar√° mapas para las Alertas de condados WX.  
+El √∫ltimo formato de mapa soportado es geoTIFF, tales mapas como son
 USGS DRG topo mapas.
 
 Locaciones de Mapas 
 Cualquier Dos, Windows/Mac o archivo Pixmap y geoTIFF, deben guardarse en el  
 Directorio de /usr/local/share/xastir/maps en su computadora.
-Usted puedes crear cualquier n˙meros de directorios bajo este directorio
+Usted puedes crear cualquier n√∫meros de directorios bajo este directorio
 para ayudar a separar sus datos.
 Por ejemplo usted puedes querer crear un directorio de USA.
-y despuÈs uno por cada estado bajo el Directorio de USA.
+y despu√©s uno por cada estado bajo el Directorio de USA.
 O tiene un directorio separado para DOS o Pixmaps y geoTIFF.
 
 
@@ -936,14 +936,14 @@ O tiene un directorio separado para DOS o Pixmaps y geoTIFF.
                                                 /pixmaps/NJ/
 
 
-Pixmaps realmente son una combinaciÛn de dos archivos, un archivo de dato con un,  
-pixmap (.xpm), gr·fico y un archivo de locaciÛn (.geo).
-El archivo .xpm es una estructura de gr·fico normal,
+Pixmaps realmente son una combinaci√≥n de dos archivos, un archivo de dato con un,  
+pixmap (.xpm), gr√°fico y un archivo de locaci√≥n (.geo).
+El archivo .xpm es una estructura de gr√°fico normal,
 con una imagen de cualquier tipo.
 
-Usted puedes usar XView para convertir gif, jpg, y tif im·genes en este formato.
-El archivo geo es un archivo de dato que atar· la imagen a una locaciÛn en el mundo.
-AquÌ est· un ejemplo de mi archivo world1.geo
+Usted puedes usar XView para convertir gif, jpg, y tif im√°genes en este formato.
+El archivo geo es un archivo de dato que atar√° la imagen a una locaci√≥n en el mundo.
+Aqu√≠ est√° un ejemplo de mi archivo world1.geo
 
 
 ARCHIVO   world1.xpm
@@ -951,24 +951,24 @@ ARCHIVO   world1.xpm
 TIEPOINT   0          0        -180        90
 TIEPOINT   640        320      180         -90
 
-Este es un archivo simple, con 4 componentes b·sicos.
-La primera lÌnea especifica este archivo data .geo es usado,
+Este es un archivo simple, con 4 componentes b√°sicos.
+La primera l√≠nea especifica este archivo data .geo es usado,
 este archivo debe estar en el mismo directorio como el archivo de .geo.  
 
-La segunda lÌnea muestra un comentario;
-cualquier lÌnea con el car·cter como un "#" ser· ignorado.  
+La segunda l√≠nea muestra un comentario;
+cualquier l√≠nea con el car√°cter como un "#" ser√° ignorado.  
   
-Las ˙ltimas dos lÌneas son para conectar un pixel en la posiciÛn x,y  
-en la imagen a una posiciÛn lat y long en la mundo. Dos puntos unidos  
+Las √∫ltimas dos l√≠neas son para conectar un pixel en la posici√≥n x,y  
+en la imagen a una posici√≥n lat y long en la mundo. Dos puntos unidos  
 son necesitado y debe estar cerca de la esquina izquierda superior 
-y la esquina derecha m·s abajo de la imagen.  
+y la esquina derecha m√°s abajo de la imagen.  
   
 Usar archivo pixmap con xastir, use el selector de mapa y seleccione el archivo .geo
 para incluir la imagen en la vista del mapa actual.  
 
-Por razones de velocidad, otras lÌneas de opciones pueden ser anexada
+Por razones de velocidad, otras l√≠neas de opciones pueden ser anexada
 en el archivo .geo.
-AquÌ algunos ejemplos del formato modificado:
+Aqu√≠ algunos ejemplos del formato modificado:
 
 ARCHIVO         Agnes_Mountain.xpm.gz
 #
@@ -980,32 +980,32 @@ TIEPOINT        1337    1999    -120.87619806   48.24982052
 #EDGES  BOTTOM          TOP             LEFT            RIGHT
 EDGES  48.24982052  48.37481943  -121.00120491  -120.87619806
 
-La lÌnea EDGES especifica el min/max bordes del mapa. El mencionado
-mapa arriba es inclinado ligeramente, el cual es el porquÈ los n˙meros
-no corresponden a la esquina 'tiepoints' exactamente. Xastir usar· esa
-informaciÛn saltar el mapa si no encaja en la vista actual.
+La l√≠nea EDGES especifica el min/max bordes del mapa. El mencionado
+mapa arriba es inclinado ligeramente, el cual es el porqu√© los n√∫meros
+no corresponden a la esquina 'tiepoints' exactamente. Xastir usar√° esa
+informaci√≥n saltar el mapa si no encaja en la vista actual.
 
-Mapas geoTIFF son una combinaciÛn de dos archivos tambiÈn:
+Mapas geoTIFF son una combinaci√≥n de dos archivos tambi√©n:
 un archivo .tif y un .fgd. El archivo .tif es el actual data mapa.
-El archivo .fgd necesita solamente tener cuatro lÌneas como estas:
+El archivo .fgd necesita solamente tener cuatro l√≠neas como estas:
 
 1.5.1.1   WEST BOUNDING COORDINATE:  -122.000000
 1.5.1.2   EAST BOUNDING COORDINATE:  -120.000000
 1.5.1.3   NORTH BOUNDING COORDINATE:  48.000000
 1.5.1.4   SOUTH BOUNDING COORDINATE:  47.000000
 
-Xastir usa esas cuatro lÌneas en su calculaciones para determinar los puntos
+Xastir usa esas cuatro l√≠neas en su calculaciones para determinar los puntos
 de la esquina del mapa, y si o no el mapa vuelve al actual punto de vista
 (asi que el puede decidir si saltarlo). Si su data mapa es un mapa topo USGS,
-el archivo .fgd podrÌa ser leÌdamente disponible a usted.
+el archivo .fgd podr√≠a ser le√≠damente disponible a usted.
 Una forma anexada en Xastir es la abilidad hacer traslaciones datum desde
-NAD 1927 a WGS 84 datum, el cual hace el mapa topo USGS mucho m·s posicionalmente
+NAD 1927 a WGS 84 datum, el cual hace el mapa topo USGS mucho m√°s posicionalmente
 exacto sobre la pantalla en Xastir.
 
 Mapas Condado WX  
 Todos los mapas Condado WX deben guardarse en el directorio de
 /usr/local/share/xastir/Counties.  Hay formatos diferentes para los mapas,
-pero de cualquier modo este directorio tendr· directorios (usted podrÌas
+pero de cualquier modo este directorio tendr√° directorios (usted podr√≠as
 necesitar crearlos) bajo este  para cada estado (2 abreviaciones de letras).
 
                /usr/local/share/xastir/Counties
@@ -1030,8 +1030,8 @@ Aqui estan dos lugares en el Internet donde usted puedes obtener esos mapas:
 ftp://aprs.rutgers.edu/pub/hamradio/APRS/NWSCounties/
 http://home.att.net/~kg5qd1/Maps.html
 
-Como los mensajes NWS son recibidos, diferentes areas obtendr·n un tintado
-hacia las ·reas designadas.
+Como los mensajes NWS son recibidos, diferentes areas obtendr√°n un tintado
+hacia las √°reas designadas.
 Ellas son coloreadas para especificar diferentes tipos de alertas. 
 
 Los colores originales fueron:
@@ -1040,51 +1040,51 @@ Cian para el asesor, amarillo para alerta del tiempo,
 rojo para advertencia, naranja para alerta cancelada, azul real para pruebas,
 y verde para niveles de indeterminadas alarmas.
 
-Con la ˙ltima versiÛn de Xastir los colores pueden ser diferentes
+Con la √∫ltima versi√≥n de Xastir los colores pueden ser diferentes
 debido a un cambio mayor: 
-Las ·reas que ahora son tintadas en lugar de relleno de color,
+Las √°reas que ahora son tintadas en lugar de relleno de color,
 y la dependencia en el tintado debajo los colores.
 
 Este cambio fue hecho asi que los mapas estando debajo de esto pueden
-mantenerse visible debajo en las ·reas de alertas del tiempo. 
-Las alertas del tiempo podrÌan ser fijada en on/off vÌa el men˙ del mapa tambiÈn.
+mantenerse visible debajo en las √°reas de alertas del tiempo. 
+Las alertas del tiempo podr√≠an ser fijada en on/off v√≠a el men√∫ del mapa tambi√©n.
 
 
 HELP-INDEX>Configurar Interfaces
 
                            Configurar Interfaces  
   
-Pulse el botÛn en Configurar luego en Interfaces  
+Pulse el bot√≥n en Configurar luego en Interfaces  
   
-Un di·logo de "Interfaces Instalados" debe aparecer. 
-Este di·logo le permitir·s a usted Agregar, Anular, y modificar las Propiedades 
+Un di√°logo de "Interfaces Instalados" debe aparecer. 
+Este di√°logo le permitir√°s a usted Agregar, Anular, y modificar las Propiedades 
 en varios dispositivos que usted puedes querer usar con Xastir.  
   
 Las opciones actuales son:  
-TNC vÌa el Puerto Serial
-TNC vÌa un Puerto Serial con (GPS m·s cable HSP)
-GPS vÌa un Puerto Serial
-EstaciÛn MeteorolÛgica vÌa Puerto Serial
-ConexiÛn a un Servidor en Internet
-TNC vÌa la Uilidades del AX.25
-GPS Enlazado vÌa el Servidor gpsd
-EstaciÛn MeteorolÛgica Enlazada a una RED
-TNC vÌa un Puerto Serial con (GPS m·s AUX puerto)
+TNC v√≠a el Puerto Serial
+TNC v√≠a un Puerto Serial con (GPS m√°s cable HSP)
+GPS v√≠a un Puerto Serial
+Estaci√≥n Meteorol√≥gica v√≠a Puerto Serial
+Conexi√≥n a un Servidor en Internet
+TNC v√≠a la Uilidades del AX.25
+GPS Enlazado v√≠a el Servidor gpsd
+Estaci√≥n Meteorol√≥gica Enlazada a una RED
+TNC v√≠a un Puerto Serial con (GPS m√°s AUX puerto)
   
-Para agregar un dispositivo, pulse el botÛn de agregar. 
-Un di·logo "Elegir Tipo de Interfaz" aparecer·. 
-Pulse el botÛn en el tipo de dispositivo que le gustarÌa agregar. 
-Luego pulse el botÛn de Agregar en el di·logo "Elegir Tipo de Interfaz". 
-Las propiedades para ese dispositivo aparecer·. 
+Para agregar un dispositivo, pulse el bot√≥n de agregar. 
+Un di√°logo "Elegir Tipo de Interfaz" aparecer√°. 
+Pulse el bot√≥n en el tipo de dispositivo que le gustar√≠a agregar. 
+Luego pulse el bot√≥n de Agregar en el di√°logo "Elegir Tipo de Interfaz". 
+Las propiedades para ese dispositivo aparecer√°. 
 
-Rellene la informaciÛn pedida y pulse el botÛn en Aceptar, anular el dispositivo, 
-pulse el botÛn en el dispositivo usted deseas anular y entonces pulse el botÛn Anular.
+Rellene la informaci√≥n pedida y pulse el bot√≥n en Aceptar, anular el dispositivo, 
+pulse el bot√≥n en el dispositivo usted deseas anular y entonces pulse el bot√≥n Anular.
 Para modificar las propiedades de un dispositivo, 
-pulse el botÛn en el dispositivo usted deseas modificar, 
-luego pulse sobre el botÛn de propiedades. 
+pulse el bot√≥n en el dispositivo usted deseas modificar, 
+luego pulse sobre el bot√≥n de propiedades. 
 
-Las propiedades para ese dispositivo aparecer·.
-Cambie la informaciÛn que usted quieres y pulsar el botÛn en Aceptar.
+Las propiedades para ese dispositivo aparecer√°.
+Cambie la informaci√≥n que usted quieres y pulsar el bot√≥n en Aceptar.
 
 HELP-INDEX>Configurando el Serial sobre un TNC
 
@@ -1092,37 +1092,37 @@ HELP-INDEX>Configurando el Serial sobre un TNC
 
 SERIAL TNC CONFIGURACION
 
-Pulse el botÛn "Configurar" luego en "Interfaces" despuÈs en "Agregar"
-despuÈs en "Serial TNC" luego "Agregar" y por ˙ltimo en "Puerto TNC"
+Pulse el bot√≥n "Configurar" luego en "Interfaces" despu√©s en "Agregar"
+despu√©s en "Serial TNC" luego "Agregar" y por √∫ltimo en "Puerto TNC"
 
 Si usted tienes un TNC y planea usarlo con XASTIR seleccione "Puerto TNC".
 El valor por defecto no, es seleccionado.
 
-Ahora entre en el puerto que el TNC est·, es decir /dev/ttyS0 para com1
+Ahora entre en el puerto que el TNC est√°, es decir /dev/ttyS0 para com1
 
 Seleccione los valores del puerto que se acoplan a su TNCs velocidad del puerto.
 
 Entre en tres rutas de UNPROTO.
 
-Xastir asumir· los XX VIA la parte de la ruta de UNPROTO. Hay tres Rutas 
-permitidas para que su seÒal sea escuchada si las condiciones son mala.
-Si cualquiera de Èstos es llenado en XASTIR ciclar· a travÈs de uno de ellos
+Xastir asumir√° los XX VIA la parte de la ruta de UNPROTO. Hay tres Rutas 
+permitidas para que su se√±al sea escuchada si las condiciones son mala.
+Si cualquiera de √©stos es llenado en XASTIR ciclar√° a trav√©s de uno de ellos
 a cada intervalo de transmision.
 
-Si usted est·s local, sÛlo un WIDE2-2 puede ser una buena opciÛn.
-Si usted est·s usando baja potencia y/o est·s distante de un digi entonces
+Si usted est√°s local, s√≥lo un WIDE2-2 puede ser una buena opci√≥n.
+Si usted est√°s usando baja potencia y/o est√°s distante de un digi entonces
 WIDE1-1,WIDE2-2 puede trabajar mejor.
 
-O si usted conoces el indicativo de su digi m·s cercano que usted
+O si usted conoces el indicativo de su digi m√°s cercano que usted
 puedes usar XXXCALL,WIDE2-2.
-La mayorÌa de ustedes necesitar·n sÛlo una ruta.
+La mayor√≠a de ustedes necesitar√°n s√≥lo una ruta.
 
-Si usted est·s en una ·rea remota y su seÒal es difÌcil de conseguirla
-usted puedes necesitar m·s.
+Si usted est√°s en una √°rea remota y su se√±al es dif√≠cil de conseguirla
+usted puedes necesitar m√°s.
 
-Verifique con un grupo local y preg˙ntele que ruta 
-puede ser mejor para su ·rea. Algunas areas
-usan el flujo de protocolos m·s eficientes, en tales caso usted podrÌa usar
+Verifique con un grupo local y preg√∫ntele que ruta 
+puede ser mejor para su √°rea. Algunas areas
+usan el flujo de protocolos m√°s eficientes, en tales caso usted podr√≠a usar
 WIDE3-3 o WIDE1-1,WIDE3-3.
 
 Los archivos de Inicio y Salida del TNC. Estos campos especifican a nombre
@@ -1131,36 +1131,36 @@ Cada archivo es un archivo de texto estandar conteniendo algunos comandos que
 usted le gustaria enviarle a su TNC a la vez que el dispositivo es activado
 (Archivo de Inicio - Startup file) o de deshabilitar (shut down).
 
-Pulsando el botÛn "Aceptar" guardar·s sus cambios.
-Pulsando el botÛn en "Cancelar" guardar· la configuracion actual.
+Pulsando el bot√≥n "Aceptar" guardar√°s sus cambios.
+Pulsando el bot√≥n en "Cancelar" guardar√° la configuracion actual.
 
 HELP-INDEX>Opciones del TNC
 
                    Opciones del TNC
 
-Permitir TransmisiÛn (on/off)
- Esto controla la transmisiÛn de datos a travÈs del TNC. Usted puedes querer
+Permitir Transmisi√≥n (on/off)
+ Esto controla la transmisi√≥n de datos a trav√©s del TNC. Usted puedes querer
 Simplemente escuchar en RF o si usted no es un HAM y no debes transmitir. Con
-Esta opciÛn (el cual est· apagado por defecto) usted puedes controlar 
-transmisiÛn de cualquier datos vÌa RF. 
+Esta opci√≥n (el cual est√° apagado por defecto) usted puedes controlar 
+transmisi√≥n de cualquier datos v√≠a RF. 
 
-Bit·cora (log) del TNC (on/off)
- Si est· en 'ON', un archivo de log (Bit·cora) se crear· en el directorio logs. 
-El archivo se llamar· tnc.log y se aÒadir· con toda la informaciÛn oÌda vÌa RF.
+Bit√°cora (log) del TNC (on/off)
+ Si est√° en 'ON', un archivo de log (Bit√°cora) se crear√° en el directorio logs. 
+El archivo se llamar√° tnc.log y se a√±adir√° con toda la informaci√≥n o√≠da v√≠a RF.
 
 Transmitir Ahora!
- Este transmitir· su position/info de su estacion cuando usted pulses el botÛn 
-en esta selecciÛn. No transmitir· si la opciÛn "Serial TNC" no est· seleccionada
-(en la secciÛn Configurar/Interfaces/Agregar/Serial TNC/Adregar/Puerto TNC)
-o si la opciÛn arriba mencionada permitir transmisiÛn est· fijada en off.
+ Este transmitir√° su position/info de su estacion cuando usted pulses el bot√≥n 
+en esta selecci√≥n. No transmitir√° si la opci√≥n "Serial TNC" no est√° seleccionada
+(en la secci√≥n Configurar/Interfaces/Agregar/Serial TNC/Adregar/Puerto TNC)
+o si la opci√≥n arriba mencionada permitir transmisi√≥n est√° fijada en off.
 
 HELP-INDEX>Configurar TNC via Serial c/GPS en HSP cable o AUX puerto
 
             Configurar TNC via Serial c/GPS en HSP cable o AUX puerto
 
-Esos tipos de interfaces hÌbridos implementan las opciones de ambos serial TNCs
-y GPSs. Por favor consulte la configuraciÛn de ayuda para ambos serial TNCs y
-serial GPSs para m·s detalles de informaciÛn sobre la configuraciÛn
+Esos tipos de interfaces h√≠bridos implementan las opciones de ambos serial TNCs
+y GPSs. Por favor consulte la configuraci√≥n de ayuda para ambos serial TNCs y
+serial GPSs para m√°s detalles de informaci√≥n sobre la configuraci√≥n
 de esos dispositivos.
 
 HELP-INDEX>Configurando el AX.25 TNC
@@ -1169,61 +1169,61 @@ HELP-INDEX>Configurando el AX.25 TNC
 
 AX.25 TNC CONFIGURACION    
     
-Esta secciÛn cubre agregando o modificando AX.25 TNC dispositivos.
+Esta secci√≥n cubre agregando o modificando AX.25 TNC dispositivos.
 AX.25 dispositivos pueden sea cualquier dispositivo que use controladores AX.25
 en Linux.
 
-…ste es un controlador de nivel del n˙cleo (kernel),
-y el dispositivo como un Baycom o una tarjeta de sonido como mÛdem 
+√âste es un controlador de nivel del n√∫cleo (kernel),
+y el dispositivo como un Baycom o una tarjeta de sonido como m√≥dem 
 puede usarse como un TNC.
 Estos dispositivos deben ser configurado y correrlo
  antes de que Xastir pueda usarlos.    
     
-Seleccionando Activar en Inicio, le dir· a Xastir que busque este dispositivo
-y fije las comunicaciones con Èl cuando el programa de su primer inicio.
+Seleccionando Activar en Inicio, le dir√° a Xastir que busque este dispositivo
+y fije las comunicaciones con √©l cuando el programa de su primer inicio.
     
-Seleccionando Permite Transmitir, le dir· a Xastir que cualquier
-salida de datos de RF puede ser enviado a este dispositivo para la transmisiÛn.
+Seleccionando Permite Transmitir, le dir√° a Xastir que cualquier
+salida de datos de RF puede ser enviado a este dispositivo para la transmisi√≥n.
     
-Escoja la operaciÛn correcta de IGate para este dispositivo.
-Usted puedes tener varios dispositivos TNC, y esta opciÛn puede ser diferente 
-por cada dispositivo. Si usted no est·s ejecutando un IGate 
-usted puedes dejar Èsta opciÛn predefinida de "Desactivar todo el tr·fico".    
+Escoja la operaci√≥n correcta de IGate para este dispositivo.
+Usted puedes tener varios dispositivos TNC, y esta opci√≥n puede ser diferente 
+por cada dispositivo. Si usted no est√°s ejecutando un IGate 
+usted puedes dejar √©sta opci√≥n predefinida de "Desactivar todo el tr√°fico".    
     
 Entre el nombre del Dispositivo AX.25 
-que usted especificÛ en el archivo del axports para este dispositivo.
+que usted especific√≥ en el archivo del axports para este dispositivo.
     
-Entre en tres rutas de UNPROTO. Xastir asumir· el XX VIA parte de la ruta
-del UNPROTO. Hay tres rutas permitidas para que su seÒal sea escuchada
+Entre en tres rutas de UNPROTO. Xastir asumir√° el XX VIA parte de la ruta
+del UNPROTO. Hay tres rutas permitidas para que su se√±al sea escuchada
 si las condiciones son mala.
 
-Si cualquiera de Èsas son llenada en XASTIR ciclar· a travÈs de uno de ellos 
-en cada momento de la transmisiÛn. Si usted es local, sÛlo un
-WIDE2-2 puede ser una buena opciÛn.
+Si cualquiera de √©sas son llenada en XASTIR ciclar√° a trav√©s de uno de ellos 
+en cada momento de la transmisi√≥n. Si usted es local, s√≥lo un
+WIDE2-2 puede ser una buena opci√≥n.
 
-Si usted est·s usando baja potencia y/o est·s distante de un digi
+Si usted est√°s usando baja potencia y/o est√°s distante de un digi
 entonces WIDE1-1,WIDE2-2 pueden trabajar mejor.
-O si usted sabes el indicativo de su digi m·s cercano
-a usted puedes usar XXXCALL,WIDE2-2. La mayorÌa de ustedes necesitar·n sÛlo una ruta.
+O si usted sabes el indicativo de su digi m√°s cercano
+a usted puedes usar XXXCALL,WIDE2-2. La mayor√≠a de ustedes necesitar√°n s√≥lo una ruta.
 
-Si usted est·s en una ·rea remota y su seÒal es difÌcil de conseguir usted puedes 
-necesitar m·s. Verifique con un grupo local y preg˙ntele quÈ 
-ruta puede ser mejor para su ·rea. Algunas areas
-usan el flujo de protocolos m·s eficientes, en tales caso usted podrÌa usar
+Si usted est√°s en una √°rea remota y su se√±al es dif√≠cil de conseguir usted puedes 
+necesitar m√°s. Verifique con un grupo local y preg√∫ntele qu√© 
+ruta puede ser mejor para su √°rea. Algunas areas
+usan el flujo de protocolos m√°s eficientes, en tales caso usted podr√≠a usar
 WIDE3-3 o WIDE1-1,WIDE3-3.
 
     
-NOTA: Para usar dispositivos AX.25 con Xastir usted necesitar·s ejecutar el programa como "raÌz" ("root").
+NOTA: Para usar dispositivos AX.25 con Xastir usted necesitar√°s ejecutar el programa como "ra√≠z" ("root").
 
-Si usted quieres ejecutar Xastir como otro usuario usted necesitar·s
+Si usted quieres ejecutar Xastir como otro usuario usted necesitar√°s
 fijar el suid en ON  en el archivo de programa de xastir.
-El orden siguiente como raÌz debe fijar esto para usted. chmod a+s /usr/local/bin/xastir.
+El orden siguiente como ra√≠z debe fijar esto para usted. chmod a+s /usr/local/bin/xastir.
 
 como con cualquier programa que este corriendo de esta forma, por favor note que
 esto puede ser considerado como una seguridad de riesgo, como el programa no ha sido
 probado para explotar. Uselo en este modo en un multi-usuarios en su propio riesgo!
 
-HELP-INDEX>CÛmo uso yo mi GPS con Xastir?  
+HELP-INDEX>C√≥mo uso yo mi GPS con Xastir?  
   
                              Usando UN GPS con Xastir  
   
@@ -1235,114 +1235,114 @@ o a un serial GPS con un TNC y cable HSP.
   
 La ventaja de usar un GPS conectado a una red
 es que usted puedes compartir el GPS con otros programas.   
-Xastir usa un programa llamado gpsd para hacer una connexiÛn a una red.   
+Xastir usa un programa llamado gpsd para hacer una connexi√≥n a una red.   
   
-Este programa entrega datos de GPS normales en un sÛcalo de conexiÛn de redes.
-Algunas versiones tambiÈn permiten correcciÛn de GPS vÌa un servidor de Internet.   
+Este programa entrega datos de GPS normales en un s√≥calo de conexi√≥n de redes.
+Algunas versiones tambi√©n permiten correcci√≥n de GPS v√≠a un servidor de Internet.   
   
-Una vez que usted tengas bajado e Instalado el gpsd en su m·quina
-(u otra m·quina), usted puedes fijar el Xastir
-para conectar a Èl creando una interfaz.   
+Una vez que usted tengas bajado e Instalado el gpsd en su m√°quina
+(u otra m√°quina), usted puedes fijar el Xastir
+para conectar a √©l creando una interfaz.   
   
-Pulse el botÛn en "Configurar" y despuÈs en "Interfaces".
-Cuando el di·logo de Interfaces aparezca Pulse el botÛn de "Agregar".   
-Un nuevo di·logo aparecer· con los tipos de Interfaces,
-Elegir en "Enlazado GPS (via el gpsd)", y luego pulse el botÛn en Agregar.
+Pulse el bot√≥n en "Configurar" y despu√©s en "Interfaces".
+Cuando el di√°logo de Interfaces aparezca Pulse el bot√≥n de "Agregar".   
+Un nuevo di√°logo aparecer√° con los tipos de Interfaces,
+Elegir en "Enlazado GPS (via el gpsd)", y luego pulse el bot√≥n en Agregar.
 
 Hay 4 opciones a elegir.
-Primero entre el nombre del servidor del programa gpsd que est· ejecutando.   
-Si est· en el mismo computador que Xastir entonces  entre localhost.   
+Primero entre el nombre del servidor del programa gpsd que est√° ejecutando.   
+Si est√° en el mismo computador que Xastir entonces  entre localhost.   
   
 Luego entre en el puerto que usted puso el programa gpsd para escuchar.
-Si usted seleccionas "Activar en Inicio", Xastir tratar· de conectar
+Si usted seleccionas "Activar en Inicio", Xastir tratar√° de conectar
 al programa gpsd tan pronto se inicia y tan pronto usted hagas click
-en el botÛn "Aceptar". La ˙ltima opciÛn, si seleccionado,
-intentar· hacer la reconexiÛn al gpsd si un fallo fuÈ encontrado.  
+en el bot√≥n "Aceptar". La √∫ltima opci√≥n, si seleccionado,
+intentar√° hacer la reconexi√≥n al gpsd si un fallo fu√© encontrado.  
   
 Serial GPS: Un serial GPS es cualquier unidad de GPS normal 
 que conecte al puerto serial y transmita datos en el NMEA normal. 
-Permitir a Xastir a usar este tipo de GPS pulse el botÛn
-de "Configurar" luego en "Interfaces". Cuando el di·logo
-de Interfaces aparezca pulse el botÛn de "Agregar".
+Permitir a Xastir a usar este tipo de GPS pulse el bot√≥n
+de "Configurar" luego en "Interfaces". Cuando el di√°logo
+de Interfaces aparezca pulse el bot√≥n de "Agregar".
 
-Un di·logo con los tipos de Interfaces aparecer·,
-Pulse sobre el "Serial GPS" y despuÈs en el botÛn Agregar.   
+Un di√°logo con los tipos de Interfaces aparecer√°,
+Pulse sobre el "Serial GPS" y despu√©s en el bot√≥n Agregar.   
   
                Unas pocas opciones para fijar.
                
 Primero entre el puerto serial en donde el dispositivo
-est· conectado (como "/dev/ttyS1 (COM2)"). 
-PrÛximo si usted seleccionas "Activar en Inicio",
-Xastir intentar· inicializar el "serial GPS" cuando Èl se
-inicie y cuando usted pulses el botÛn "Aceptar".
-Las prÛximas opciones pondr·n la velocidad del puerto serial y modo.   
+est√° conectado (como "/dev/ttyS1 (COM2)"). 
+Pr√≥ximo si usted seleccionas "Activar en Inicio",
+Xastir intentar√° inicializar el "serial GPS" cuando √©l se
+inicie y cuando usted pulses el bot√≥n "Aceptar".
+Las pr√≥ximas opciones pondr√°n la velocidad del puerto serial y modo.   
   
-Para la mayorÌa de las unidades de GPS los valores predefinidos est·n bien.
-Pero Chequee usted el manual del GPS sÛlo en caso de dudas.
+Para la mayor√≠a de las unidades de GPS los valores predefinidos est√°n bien.
+Pero Chequee usted el manual del GPS s√≥lo en caso de dudas.
 
 HSP TNC/GPS: 
-Mire en "CÛmo uso yo mi TNC con Xastir?"  
+Mire en "C√≥mo uso yo mi TNC con Xastir?"  
 
 
 HELP-INDEX>Configurando el Puerto/GPS
 
               Configurando el Puerto/GPS
 
-Pulse el botÛn en "Configurar" luego en "Interfaces" luego en "Agregar" 
-elija "Serial GPS" luego "Agregar" despuÈs ajuste los par·metros del Puerto/GPS.
+Pulse el bot√≥n en "Configurar" luego en "Interfaces" luego en "Agregar" 
+elija "Serial GPS" luego "Agregar" despu√©s ajuste los par√°metros del Puerto/GPS.
 
-Para usar una posiciÛn "Serial GPS" en el puerto serial,
-pulse el botÛn en PosiciÛn Serial GPS.
-Este puerto puede especificarse en la PosiciÛn "SÛlo el puerto de GPS".
+Para usar una posici√≥n "Serial GPS" en el puerto serial,
+pulse el bot√≥n en Posici√≥n Serial GPS.
+Este puerto puede especificarse en la Posici√≥n "S√≥lo el puerto de GPS".
 Usted puedes usar un dispositivo serial como /dev/ttyS1 (COM2).
 
 Si usted tienes un cable de HSP que le permitas compartir el Serial TNC con una 
-unidad GPS usted puedes seleccionar "Serial TNC c/GPS m·s (Cable HSP).
-…ste es un cable especial y el mÌo no trabaja en todas las combinaciones
+unidad GPS usted puedes seleccionar "Serial TNC c/GPS m√°s (Cable HSP).
+√âste es un cable especial y el m√≠o no trabaja en todas las combinaciones
 de computadores/GPS/TNC.
 
-Ahora usted puedes escoger un GPS muestreo y TNC relaciÛn, Recuerde usarlo con 
-precauciÛn aqui, que sean amigables por sus estaciones cercanas.
+Ahora usted puedes escoger un GPS muestreo y TNC relaci√≥n, Recuerde usarlo con 
+precauci√≥n aqui, que sean amigables por sus estaciones cercanas.
 
-øActivar el uso de los datos de GPS seleccione el "Uso PosiciÛn GPS?" opciÛn.
-Con esta selecciÛn hecha la unidad de GPS pondr· al dÌa su posiciÛn.
-Si esto no se selecciona la posiciÛn actual vendr· desde la locaciÛn 
-en configuraciÛn informaciÛn de la EstaciÛn.
+¬øActivar el uso de los datos de GPS seleccione el "Uso Posici√≥n GPS?" opci√≥n.
+Con esta selecci√≥n hecha la unidad de GPS pondr√° al d√≠a su posici√≥n.
+Si esto no se selecciona la posici√≥n actual vendr√° desde la locaci√≥n 
+en configuraci√≥n informaci√≥n de la Estaci√≥n.
 
-Cuando active los datos de GPS tambiÈn pondr·s al dÌa 
-la posiciÛn en configuraciÛn de informaciÛn de la EstaciÛn.
+Cuando active los datos de GPS tambi√©n pondr√°s al d√≠a 
+la posici√≥n en configuraci√≥n de informaci√≥n de la Estaci√≥n.
 
-Cuando use el GPS sus paquetes cambian, usted obtendr·s una estaciÛn mÛvil con 
-curso y velocidad a˙n cuando la suya no estÈ moviendose (yo puedo cambiar esto 
-despuÈs a una opciÛn).
+Cuando use el GPS sus paquetes cambian, usted obtendr√°s una estaci√≥n m√≥vil con 
+curso y velocidad a√∫n cuando la suya no est√© moviendose (yo puedo cambiar esto 
+despu√©s a una opci√≥n).
 
-El tiempo del GPS le permitir· seleccionar proporciones de la relaciÛn
+El tiempo del GPS le permitir√° seleccionar proporciones de la relaci√≥n
 de muestra  para el GPS y sobre pasar el tiempo del paquete normal 
-por transmitir su estaciÛn.
+por transmitir su estaci√≥n.
 
-Si usted est·s estacionado entonces use 10 minutos.
-Si usted est·s haciendo alg˙n especial/rastreo etc..
-use la selecciÛn que encajar·n mejor los datos que usted necesitas.
-Por favor no haga sobre transmisiÛn, si usted no lo necesitas hacer. 
+Si usted est√°s estacionado entonces use 10 minutos.
+Si usted est√°s haciendo alg√∫n especial/rastreo etc..
+use la selecci√≥n que encajar√°n mejor los datos que usted necesitas.
+Por favor no haga sobre transmisi√≥n, si usted no lo necesitas hacer. 
 
 
-Pulsando el botÛn "Aceptar" guardar·s sus cambios.
-Pulsando el botÛn en "Cancelar" guardar·s las configuraciones actuales.
+Pulsando el bot√≥n "Aceptar" guardar√°s sus cambios.
+Pulsando el bot√≥n en "Cancelar" guardar√°s las configuraciones actuales.
 
-HELP-INDEX>CÛmo uso yo mi TNC con Xastir?  
+HELP-INDEX>C√≥mo uso yo mi TNC con Xastir?  
   
                 Usando UN TNC con Xastir  
   
 Para usar un TNC con Xastir usted tienes tres opciones,
-un "serial TNC" o un "Serial TNC c/GPS m·s (cable HSP)"
+un "serial TNC" o un "Serial TNC c/GPS m√°s (cable HSP)"
 o un TNC Conectado a una red "AX.25 TNC".
 
 AX.25 o un TNC en una red:
-Este tipo de tnc le permitir· compartir el TNC con otros programas.
-Al usarlo usted debes tener la librerÌa AX.25 , y el
-HamRadio soporte instalado en el n˙cleo (kernel) de su Linux OS.
+Este tipo de tnc le permitir√° compartir el TNC con otros programas.
+Al usarlo usted debes tener la librer√≠a AX.25 , y el
+HamRadio soporte instalado en el n√∫cleo (kernel) de su Linux OS.
 
-Ellos son un poco m·s difÌciles de configurar para usarlo 
+Ellos son un poco m√°s dif√≠ciles de configurar para usarlo 
 pero hay muy buenas opciones y ventajas en su uso. 
 
 Usando el soporte del "AX.25 TNC", usted tienes varios
@@ -1350,392 +1350,392 @@ dispositivos que usted puedes usar con Xastir.
 Algunos de ellos son serial TNC que usan AX.25,
 tarjetas de sonidos como TNC's, Baycom, etc.  
   
-SERIAL TNC: SERIAL TNC con (GPS m·s cable HSP):
+SERIAL TNC: SERIAL TNC con (GPS m√°s cable HSP):
 
-HELP-INDEX>Configurando la conexiÛn de Internet
+HELP-INDEX>Configurando la conexi√≥n de Internet
 
-             Configurando la conexiÛn de Internet
+             Configurando la conexi√≥n de Internet
 
 La conexion a los Servicios de Internet le permite a usted enviar
 y recibir datos desde y hacia todo el mundo.
 
-Para configurar el Internet usted necesitar·s conocer un host y un n˙mero de 
+Para configurar el Internet usted necesitar√°s conocer un host y un n√∫mero de 
 puerto. El host predefinido es www.aprs.net y el puerto es 10151. Usted puedes 
-escoger otros pero este debe trabajar. Una Palabra de paso v·lida le permitir·
-a su estaciÛn transmitir por el Internet.
+escoger otros pero este debe trabajar. Una Palabra de paso v√°lida le permitir√°
+a su estaci√≥n transmitir por el Internet.
 
-Permitir· a su estaciÛn salir de una I-Gate y conseguir retransmitir vÌa RF.
-Para conseguir un cÛdigo de paso usted necesitar·s contactar con Frank, 
+Permitir√° a su estaci√≥n salir de una I-Gate y conseguir retransmitir v√≠a RF.
+Para conseguir un c√≥digo de paso usted necesitar√°s contactar con Frank, 
 email fgiannan@earthlink.net, Enviarle su nombre, Indicativo, etc.
 
-Una vez Èl verifique su estado como un HAM Èl puede enviarle su cÛdigo. 
-Usted puedes mantenerse recibiendo y transmitiendo datos vÌa el 
-Internet aunque usted no tengas un passcode. Pero sin el cÛdigo de paso sus 
-datos no ser·n directamente retransmitido vÌa RF.
-Cualquiera que estÈ conectado al Internet directamente conseguir· su mensaje.
+Una vez √©l verifique su estado como un HAM √©l puede enviarle su c√≥digo. 
+Usted puedes mantenerse recibiendo y transmitiendo datos v√≠a el 
+Internet aunque usted no tengas un passcode. Pero sin el c√≥digo de paso sus 
+datos no ser√°n directamente retransmitido v√≠a RF.
+Cualquiera que est√© conectado al Internet directamente conseguir√° su mensaje.
 
-Host1 y Host2 son servidores opcionales que ser·n contactado si el servidor 
-primario est· fuera. Cada servidor ser· intentado dos veces, siguiendo al 
-prÛximo si la conexiÛn fracasa.
+Host1 y Host2 son servidores opcionales que ser√°n contactado si el servidor 
+primario est√° fuera. Cada servidor ser√° intentado dos veces, siguiendo al 
+pr√≥ximo si la conexi√≥n fracasa.
 
-Si usted quieres que XASTIR reconecte despuÈs de una conexiÛn perdida
-en el net entonces seleccione la opciÛn "Reconecte en fracaso de la RED?"
-en la que por defecto est· en ON.
+Si usted quieres que XASTIR reconecte despu√©s de una conexi√≥n perdida
+en el net entonces seleccione la opci√≥n "Reconecte en fracaso de la RED?"
+en la que por defecto est√° en ON.
 
-Las ˙ltimas opciones son para preparar su estaciÛn para ser un IGate. Esto 
-permite a su estaciÛn con su cÛdigo de paso simplemente actuar como una puerta 
-(gateway), pero en lugar de otra banda sus datos atravesar·n el Internet.
-Esta opciÛn no debe ser tomada ligeramente.
+Las √∫ltimas opciones son para preparar su estaci√≥n para ser un IGate. Esto 
+permite a su estaci√≥n con su c√≥digo de paso simplemente actuar como una puerta 
+(gateway), pero en lugar de otra banda sus datos atravesar√°n el Internet.
+Esta opci√≥n no debe ser tomada ligeramente.
 
 Primero usted debes coordinar con otros 
-en su ·rea para que usted puedas agregar verdadera informaciÛn que puede estar 
-perdiendo. Usted tambiÈn debes avisar a Steve sobre esto. Esta versiÛn puede 
-enviar informaciÛn recibida desde su TNC hacia el Internet y transmitir· 
-cualquier mensaje procedente de Internet a travÈs de su estaciÛn via RF.
+en su √°rea para que usted puedas agregar verdadera informaci√≥n que puede estar 
+perdiendo. Usted tambi√©n debes avisar a Steve sobre esto. Esta versi√≥n puede 
+enviar informaci√≥n recibida desde su TNC hacia el Internet y transmitir√° 
+cualquier mensaje procedente de Internet a trav√©s de su estaci√≥n via RF.
 
-Enviar· sÛlo datos vÌa RF si usted tienes el opciÛn seleccionada de transmisiÛn 
-de mensajes. SÛlo estaciones que usted has oÌdo (vÌa RF) en las ˙ltimas horas 
-tendr·n mensajes enviados a ellos en Èsta vÌa.
+Enviar√° s√≥lo datos v√≠a RF si usted tienes el opci√≥n seleccionada de transmisi√≥n 
+de mensajes. S√≥lo estaciones que usted has o√≠do (v√≠a RF) en las √∫ltimas horas 
+tendr√°n mensajes enviados a ellos en √©sta v√≠a.
 
-Note tambiÈn usted es responsable por los datos transmitidos
-por su estaciÛn asi que tenga cuidado con esta 
-opciÛn (otros pueden enviarle mensajes que usted no quieres transmitir).
+Note tambi√©n usted es responsable por los datos transmitidos
+por su estaci√≥n asi que tenga cuidado con esta 
+opci√≥n (otros pueden enviarle mensajes que usted no quieres transmitir).
 
-Si usted quieres ver que su I-Gate esta haciendo encienda la opciÛn Log I-Gate 
-de transacciones. esto construir· un archivo de igate.log en su "logs" los 
-directorios  mostrar·n todos los datos pasados de RF local hacia la red con 
-lÌnea que tiene "IGATE-RF->NET": y conteniendo todo los datos.
+Si usted quieres ver que su I-Gate esta haciendo encienda la opci√≥n Log I-Gate 
+de transacciones. esto construir√° un archivo de igate.log en su "logs" los 
+directorios  mostrar√°n todos los datos pasados de RF local hacia la red con 
+l√≠nea que tiene "IGATE-RF->NET": y conteniendo todo los datos.
 
-TambiÈn mostrar· todo el tr·fico entrante desde la red con "NET->RF-IGATE:".
-Note aquÌ usted no ver·s la completa salida de paquetes, como su estaciÛn y ruta son 
-asumida. Solamente mostrar· el data como un mensaje de tercera persona.
-
-
-Pulsando el botÛn "Aceptar" guardar·s sus cambios.
-Pulsando el botÛn en "Cancelar" guardar·s los cambios actuales.
+Tambi√©n mostrar√° todo el tr√°fico entrante desde la red con "NET->RF-IGATE:".
+Note aqu√≠ usted no ver√°s la completa salida de paquetes, como su estaci√≥n y ruta son 
+asumida. Solamente mostrar√° el data como un mensaje de tercera persona.
 
 
-APRS[tm] es una Marca de f·brica de Bob Bruninga, 
-su p·gina est· en "http://web.usna.navy.mil/~bruninga/aprs.html"
+Pulsando el bot√≥n "Aceptar" guardar√°s sus cambios.
+Pulsando el bot√≥n en "Cancelar" guardar√°s los cambios actuales.
+
+
+APRS[tm] es una Marca de f√°brica de Bob Bruninga, 
+su p√°gina est√° en "http://web.usna.navy.mil/~bruninga/aprs.html"
 
 
 HELP-INDEX>Opciones de RED
 
                    Opciones de RED
 
-Permitir TransmisiÛn (on/off)
-Esto controla la transmisiÛn de datos a travÈs del Internet.
+Permitir Transmisi√≥n (on/off)
+Esto controla la transmisi√≥n de datos a trav√©s del Internet.
 El valor por defecto es apagado.
-Con esto en (off) apagado ning˙n dato ser· enviado al Internet.
+Con esto en (off) apagado ning√∫n dato ser√° enviado al Internet.
 
-Bit·cora de Internet (on/off)
- Si esto est· en 'ON', un archivo log se crear· en el directorio logs. El archivo
-se llamar· net.log y se aÒadir· con toda la informaciÛn oÌda vÌa el Internet.
+Bit√°cora de Internet (on/off)
+ Si esto est√° en 'ON', un archivo log se crear√° en el directorio logs. El archivo
+se llamar√° net.log y se a√±adir√° con toda la informaci√≥n o√≠da v√≠a el Internet.
 
 Transmitir Ahora!
- Esto transmitir· su position/info de la estaciÛn cuando usted pulses el 
-botÛn en esta selecciÛn. No transmitir· si la opciÛn est· apagada en Permitir 
-transmisiÛn.
+ Esto transmitir√° su position/info de la estaci√≥n cuando usted pulses el 
+bot√≥n en esta selecci√≥n. No transmitir√° si la opci√≥n est√° apagada en Permitir 
+transmisi√≥n.
 
-HELP-INDEX>Configurando una EstaciÛn MeteorolÛgica sobre un Puerto Serial.
+HELP-INDEX>Configurando una Estaci√≥n Meteorol√≥gica sobre un Puerto Serial.
 
-Configurando una EstaciÛn MeteorolÛgica sobre un Puerto Serial.
+Configurando una Estaci√≥n Meteorol√≥gica sobre un Puerto Serial.
 
-Configurar el puerto serial para su estaciÛn MeteorolÛgica. A los valores 
+Configurar el puerto serial para su estaci√≥n Meteorol√≥gica. A los valores 
 comunes de /dev/ttyS0 (COM1) o /dev/ttyS1 (COM2) pueden ser usado.
 
-Seleccionado "Activar en Inicio" le dir·s a Xastir buscar este dispositivo y
+Seleccionado "Activar en Inicio" le dir√°s a Xastir buscar este dispositivo y
 fijar comunicanciones con el cuando el programa se inicie primero.
 
-Ahora fije el bps bajo el puerto de configuraciÛn, y los par·metros bajo el
+Ahora fije el bps bajo el puerto de configuraci√≥n, y los par√°metros bajo el
 puerto estilo. El seteo del puerto estilo 8N1, es usado para 8 bitios de datos,
 No paridad y 1 bitio de parada (stop bit). 7E1 es usado para 7 bitios de datos,
 even paridad y 1 bitio de parada. 7O1 es usado para 7 bitios de datos, odd paridad
-y 1 bitio de parada. Esos par·metros deben de machar con su estaciÛn MeteorolÛgica.
-El tipo de opciÛn de data le perimitir· sobrepasar que tipo de serial data el progrma
-ver·. La forma de auto-detecciÛn primero buscar· datos del tiempo en un modo binario
+y 1 bitio de parada. Esos par√°metros deben de machar con su estaci√≥n Meteorol√≥gica.
+El tipo de opci√≥n de data le perimitir√° sobrepasar que tipo de serial data el progrma
+ver√°. La forma de auto-detecci√≥n primero buscar√° datos del tiempo en un modo binario
 como lo usa el Radio Shack WX-200. Si no dato binario es encontrado,
-Xastir buscar· un tipo ASCII de estaciÛn MeteorolÛgica (como la Peet Bros.)
+Xastir buscar√° un tipo ASCII de estaci√≥n Meteorol√≥gica (como la Peet Bros.)
 
-HELP-INDEX>Configurando una EstaciÛn MeteorlÛgica en la RED
+HELP-INDEX>Configurando una Estaci√≥n Meteorl√≥gica en la RED
 
-Configurando una EstaciÛn MeteorlÛgica en la RED
+Configurando una Estaci√≥n Meteorl√≥gica en la RED
 
-Xastir puede usar servicios de dato de una estaciÛn MeteorolÛgica
-tales como la wx200d. La wx200d le permitir·s varias conexiones de redes,
+Xastir puede usar servicios de dato de una estaci√≥n Meteorol√≥gica
+tales como la wx200d. La wx200d le permitir√°s varias conexiones de redes,
 asi compartiendo el informe del tiempo con varios programas o computadores.
 
-Entre el nombre del host (o la direcciÛn numÈrica IP) y el n˙mero del puerto
-de la estaciÛn MeteorolÛgica servidora que usted quieres contactar.
+Entre el nombre del host (o la direcci√≥n num√©rica IP) y el n√∫mero del puerto
+de la estaci√≥n Meteorol√≥gica servidora que usted quieres contactar.
 
-Seleccionado "Activar en Inicio" le dir·s a Xastir buscar este dispositivo y
+Seleccionado "Activar en Inicio" le dir√°s a Xastir buscar este dispositivo y
 fijar comunicanciones con el cuando el programa se inicie primero.
 
-Seleccionado "Reconectar en fallo de la RED" le dir· a Xastir tratar de reconectar cuando
-el data conexiÛn haya fracasado.
-Como antes el tipo de data sobrepasar· el auto-detecciÛn.
+Seleccionado "Reconectar en fallo de la RED" le dir√° a Xastir tratar de reconectar cuando
+el data conexi√≥n haya fracasado.
+Como antes el tipo de data sobrepasar√° el auto-detecci√≥n.
 
-HELP-INDEX>Di·logo info estaciÛn - b˙squeda FCC y RAC  
+HELP-INDEX>Di√°logo info estaci√≥n - b√∫squeda FCC y RAC  
   
-                  Di·logo info estaciÛn - b˙squeda FCC y RAC  
+                  Di√°logo info estaci√≥n - b√∫squeda FCC y RAC  
   
-Info estaciÛn desplegar· cualquier dato descifrado por Xastir.
-Actualmente dos o tres botones aparecen aquÌ adem·s del botÛn Cerrar.
+Info estaci√≥n desplegar√° cualquier dato descifrado por Xastir.
+Actualmente dos o tres botones aparecen aqu√≠ adem√°s del bot√≥n Cerrar.
 
-Los botones de Anular Rastro anular·n cualquier lÌnea de rastro para esa estaciÛn 
+Los botones de Anular Rastro anular√°n cualquier l√≠nea de rastro para esa estaci√≥n 
 que es actualmente guardada o en el despliegue de mapa.
 
-EnvÌe mensaje abrir· la ventana de mensaje y le permitir· enviar a mensje a esta estaciÛn.
-El llenar· en el indicativo por usted. 
+Env√≠e mensaje abrir√° la ventana de mensaje y le permitir√° enviar a mensje a esta estaci√≥n.
+El llenar√° en el indicativo por usted. 
 
 Si el banco de datos de FCC se instala,
-un botÛn de B˙squeda en el Banco de datos FCC aparecer· en este Di·logo.
-Si el RAC (RadioAficionados de Canad·) banco de datos se instala, 
-un botÛn de b˙squeda RAC Banco de datos aparecer· para indicativo 
+un bot√≥n de B√∫squeda en el Banco de datos FCC aparecer√° en este Di√°logo.
+Si el RAC (RadioAficionados de Canad√°) banco de datos se instala, 
+un bot√≥n de b√∫squeda RAC Banco de datos aparecer√° para indicativo 
 que empiezan con una "V".  
 
 El archivo FCC y  RAC deben colocarse en el directorio
 /usr/local/share/xastir/fcc, y el caso es importante!  
   
-Usted puedes usar este botÛn para agregar los nombres de estaciones
-y dirÌjase al Di·logo de EstaciÛn Info. 
+Usted puedes usar este bot√≥n para agregar los nombres de estaciones
+y dir√≠jase al Di√°logo de Estaci√≥n Info. 
 
-Para usar la b˙squeda de FCC bajelo de aqui:
+Para usar la b√∫squeda de FCC bajelo de aqui:
 ftp://ftp.fcc.gov/pub/XFS_AlphaTest/amateur/appl.zip
 
  o el Nuevo banco de datos en:
 ftp://ftp.fcc.gov/pub/Bureaus/Wireless/Databases/uls/complete/l_amat.zip  
   
-(El ˙nico archivo necesitado forma este 40Meg zip es el archivo EN.dat)  
+(El √∫nico archivo necesitado forma este 40Meg zip es el archivo EN.dat)  
   
 * * * * NOTA para usar el NUEVO archivo base de datos debe ordenarse primero!!! * * * *
 
-°Aseg˙rese que usted tienes espacio en el disco suficiente 
+¬°Aseg√∫rese que usted tienes espacio en el disco suficiente 
 para esto como el archivo es GRANDE!  
 
 Para ordenar el archivo: sort +4 -t \ | EN.dat >EN.dat.ordenado  
 rm EN.dat  
 mv EN.dat.ordenado EN.dat  
   
-Para usar la b˙squeda de RAC b·jelo de: ftp://ftp.rac.ca/pub/cdncaldb.zip  
-Xastir crear· archivos Ìndice por cada archivo del banco de datos en el inicio.  
+Para usar la b√∫squeda de RAC b√°jelo de: ftp://ftp.rac.ca/pub/cdncaldb.zip  
+Xastir crear√° archivos √≠ndice por cada archivo del banco de datos en el inicio.  
   
-Si un archivo de indicativo es eliminado mientras Xastir est· corriendo,
-crear· o reconstruir· el Ìndice en la prÛxima b˙squeda. No se manejan prefijos especiales.
+Si un archivo de indicativo es eliminado mientras Xastir est√° corriendo,
+crear√° o reconstruir√° el √≠ndice en la pr√≥xima b√∫squeda. No se manejan prefijos especiales.
 
 HELP-INDEX>Opciones de Despliegue
 
                         Opciones de Despliegue
 
-Estas opciones le permitir·n desplegar datos sobre la estaciÛn alrededor del 
-Ìcono de las estaciones en el mapa.
+Estas opciones le permitir√°n desplegar datos sobre la estaci√≥n alrededor del 
+√≠cono de las estaciones en el mapa.
 
 Indicativo (on/off)
- Cuando estÈ en 'ON', todo los indicativos de las estaciones se desplegar·n.  
-Si este esta en 'OFF' los indicativos no se desplegar·n sobre el mapa.
+ Cuando est√© en 'ON', todo los indicativos de las estaciones se desplegar√°n.  
+Si este esta en 'OFF' los indicativos no se desplegar√°n sobre el mapa.
 
-Para viejas estaciones el sÌmbolo es dibujado
-como fantasma y en su orientaciÛn estandar.
+Para viejas estaciones el s√≠mbolo es dibujado
+como fantasma y en su orientaci√≥n estandar.
 
-Corespondiendo al arrastre que son subrayado m·s que sÛlido y todo el data
+Corespondiendo al arrastre que son subrayado m√°s que s√≥lido y todo el data
 excepto el indicativo desaparece de la pantalla.
 
 Callsign (on/off)
 Determines if the callsign is displayed on the right side of the symbol.
 
 Altura (on/off)
- Cuando estÈ en 'ON', una lÌnea azul de datos aparecer·  sobre el indicativo.  
-Este desplegar· la ˙ltima altitud conocida de la estaciÛn.
+ Cuando est√© en 'ON', una l√≠nea azul de datos aparecer√°  sobre el indicativo.  
+Este desplegar√° la √∫ltima altitud conocida de la estaci√≥n.
 
 Curso (on/off)
- Cuando estÈ en 'ON', una lÌnea verde de dato aparecer· debajo del indicativo. 
-Esto desplegar· el ˙ltimo curso conocido (en grados) de la estaciÛn que est· en 
+ Cuando est√© en 'ON', una l√≠nea verde de dato aparecer√° debajo del indicativo. 
+Esto desplegar√° el √∫ltimo curso conocido (en grados) de la estaci√≥n que est√° en 
 movimiento.
 
 Velocidad (on/off)
- Cuando estÈ en 'ON', una lÌnea roja aparecer· debajo del indicativo (o curso). 
-Esto despliegar· la ˙ltima velocidad conocida de la estaciÛn que est· en 
+ Cuando est√© en 'ON', una l√≠nea roja aparecer√° debajo del indicativo (o curso). 
+Esto despliegar√° la √∫ltima velocidad conocida de la estaci√≥n que est√° en 
 movimiento.
 
 Dist/curso (on/off)
- Cuando estÈ en 'ON', se desplegar·n dos lÌneas de informaciÛn en el lado 
-izquierdo del Ìcono de la estaciÛn. La lÌnea de arriba tendr· la distancia 
-de su estaciÛn hacia esta estaciÛn. La lÌnea de abajo tendr· el curso desde su 
-estaciÛn hacia esta estaciÛn. 
+ Cuando est√© en 'ON', se desplegar√°n dos l√≠neas de informaci√≥n en el lado 
+izquierdo del √≠cono de la estaci√≥n. La l√≠nea de arriba tendr√° la distancia 
+de su estaci√≥n hacia esta estaci√≥n. La l√≠nea de abajo tendr√° el curso desde su 
+estaci√≥n hacia esta estaci√≥n. 
 
 Rastros de estaciones (on/off)
- Cuando estÈ en 'ON', cualquier estaciÛn en movimiento arrastrar· una lÌnea 
-coloreada con las ˙ltimas 100+ localizaciones. Cuando la estaciÛn se pone vieja 
-el Ìcono es opaco la lÌnea de rastro se volver· intermitente en lugar de la 
-lÌnea contÌnua.
+ Cuando est√© en 'ON', cualquier estaci√≥n en movimiento arrastrar√° una l√≠nea 
+coloreada con las √∫ltimas 100+ localizaciones. Cuando la estaci√≥n se pone vieja 
+el √≠cono es opaco la l√≠nea de rastro se volver√° intermitente en lugar de la 
+l√≠nea cont√≠nua.
 
 
-EstaciÛn Potencia/Ganancia (on/off)
- Cuando estÈ en 'ON', se desplegar·n CÌrculos de Poder/Ganancia.
- Sobrepasando los cÌrculos indicado que las estaciones est·n teÛricamente
+Estaci√≥n Potencia/Ganancia (on/off)
+ Cuando est√© en 'ON', se desplegar√°n C√≠rculos de Poder/Ganancia.
+ Sobrepasando los c√≠rculos indicado que las estaciones est√°n te√≥ricamente
  con simple rango uno del otro.
- Esto es aproximandaemnte exacto, especialmente in ·reas de terreno variable.
+ Esto es aproximandaemnte exacto, especialmente in √°reas de terreno variable.
  
-Rastreo EstaciÛn
- Traer· una caja abierta similar a la opciÛn localizar estaciÛn. Usted puedes 
+Rastreo Estaci√≥n
+ Traer√° una caja abierta similar a la opci√≥n localizar estaci√≥n. Usted puedes 
 entrar  todos o parte del indicativo. Al seleccionar "Rastrear Ahora!" El 
-despliegue saltar· a la posiciÛn de la estaciÛn (si es encuentrada). Cuando 
-nuevos datos para esa estaciÛn son encuentrados el despliegar· el rastro a lo largo 
-de esa estaciÛn.
+despliegue saltar√° a la posici√≥n de la estaci√≥n (si es encuentrada). Cuando 
+nuevos datos para esa estaci√≥n son encuentrados el despliegar√° el rastro a lo largo 
+de esa estaci√≥n.
 
- El botÛn "Borrar Rastro" limpiar· todo el rastro.
+ El bot√≥n "Borrar Rastro" limpiar√° todo el rastro.
 
- El botÛn de "Cancelar" terminar· sin cambios realizados.
+ El bot√≥n de "Cancelar" terminar√° sin cambios realizados.
 
 Informe del Tiempo (on/off)
-Cuando estÈ en 'ON', los ˙ltimos datos del tiempo 
-(velocidad/curso/r·faga,Humedad,temperatura,viento) 
+Cuando est√© en 'ON', los √∫ltimos datos del tiempo 
+(velocidad/curso/r√°faga,Humedad,temperatura,viento) 
  son desplegados.
 
-SÌmbolos (on/off)
-Determina si los sÌmbolos podrÌan ser dibujado en el mapa.
+S√≠mbolos (on/off)
+Determina si los s√≠mbolos podr√≠an ser dibujado en el mapa.
 
-Rotar SÌmbolos (on/off)
-Si 'ON', algunos sÌmbolos deberÌan cambiar su orientaciÛn y mostrar la
-direcciÛn en la cual una estaciÛn mÛvil se est· moviendo.
+Rotar S√≠mbolos (on/off)
+Si 'ON', algunos s√≠mbolos deber√≠an cambiar su orientaci√≥n y mostrar la
+direcci√≥n en la cual una estaci√≥n m√≥vil se est√° moviendo.
 
 HELP-INDEX>Mensajes
 
                         Mensajes
 
 Enviar mensaje a y Mensajes De grupo abierto
-…stos son muy similares. El "Enviar mensaje a" enviar· sus mensajes a una 
-estaciÛn y recibir· sÛlo forma de datos de la estaciÛn. Los mensajes de grupo 
-son m·s en general usted puedes recibir cualquier mensaje para el grupo y usted 
-enviar·s sus mensajes a ese nombre de grupo. Los mensajes de grupo no pueden 
+√âstos son muy similares. El "Enviar mensaje a" enviar√° sus mensajes a una 
+estaci√≥n y recibir√° s√≥lo forma de datos de la estaci√≥n. Los mensajes de grupo 
+son m√°s en general usted puedes recibir cualquier mensaje para el grupo y usted 
+enviar√°s sus mensajes a ese nombre de grupo. Los mensajes de grupo no pueden 
 trabajar mejor por el momento hay varios problemas que necesitan ser 
-solucionado. Sin embargo, volviendo atr·s al
+solucionado. Sin embargo, volviendo atr√°s al
 uso de estas pantallas. 
 
-Cada una de estas pantallas contienen una caja de mensaje, una lÌnea de 
-llamada, una lÌnea de mensaje, y varios botones. Usted debes primero entrar  la 
-llamada del grupo o estaciÛn que usted quieres avisar. Una vez que eso se hace 
-cualquier nuevo mensaje que ha entrado de esa estaciÛn hacia usted ser·s 
-desplegado. Si la estaciÛn est· envi·ndole informaciÛn y ninguna ventana de 
-mensaje est· abierta Èl abrir· autom·ticamente a una nueva ventana (hasta 10) 
+Cada una de estas pantallas contienen una caja de mensaje, una l√≠nea de 
+llamada, una l√≠nea de mensaje, y varios botones. Usted debes primero entrar  la 
+llamada del grupo o estaci√≥n que usted quieres avisar. Una vez que eso se hace 
+cualquier nuevo mensaje que ha entrado de esa estaci√≥n hacia usted ser√°s 
+desplegado. Si la estaci√≥n est√° envi√°ndole informaci√≥n y ninguna ventana de 
+mensaje est√° abierta √©l abrir√° autom√°ticamente a una nueva ventana (hasta 10) 
 con esos indicativos de estaciones para usted. Usted puedes ahora entrar un 
-mensaje en la lÌnea de mensaje. El mensaje puede ser m·s largo que la lÌnea de 
-mensaje, y la m·xima salida es aproximadamente 250+ car·cteres. Una vez su 
-mensaje es entrado, pulsando el botÛn "Enviar Ahora!" mandar· su mensaje.
+mensaje en la l√≠nea de mensaje. El mensaje puede ser m√°s largo que la l√≠nea de 
+mensaje, y la m√°xima salida es aproximadamente 250+ car√°cteres. Una vez su 
+mensaje es entrado, pulsando el bot√≥n "Enviar Ahora!" mandar√° su mensaje.
 
-El botÛn "Enviar Ahora!" se pondr· opaco hasta que su mensaje sea completamente Reconocido.
-Cualquier mensaje que usted recibas ser· ordenado por la lÌnea # y ser· puesto 
-en la ventana de mensaje. Si usted est·s en un modo de grupo cada lÌnea 
-desplegar· el indicativo de donde el mensaje se enviÛ seguido por el propio 
-mensaje. Los mensajes de grupos actuales son ordenados por llamada y despuÈs   
-la lÌnea #. Cuando usted hayas enviado el mensaje pulsando el botÛn de "Cerrar" 
-cerrar· la ventana.
+El bot√≥n "Enviar Ahora!" se pondr√° opaco hasta que su mensaje sea completamente Reconocido.
+Cualquier mensaje que usted recibas ser√° ordenado por la l√≠nea # y ser√° puesto 
+en la ventana de mensaje. Si usted est√°s en un modo de grupo cada l√≠nea 
+desplegar√° el indicativo de donde el mensaje se envi√≥ seguido por el propio 
+mensaje. Los mensajes de grupos actuales son ordenados por llamada y despu√©s   
+la l√≠nea #. Cuando usted hayas enviado el mensaje pulsando el bot√≥n de "Cerrar" 
+cerrar√° la ventana.
 
-Dos otros botones son tambiÈn disponible. El botÛn "Nuevo Indicativo" 
-le permitir· mirar datos viejos que una estaciÛn ha enviado.
-Teclee el indicativo y pulse en este botÛn, cualquier 
-informaciÛn vieja ser· desplegada.
-Usted tambiÈn puedes usar este botÛn para cambiar el indicativo de la estaciÛn
-con la que usted est·s hablando.
-Entre el nuevo indicativo y pulse el botÛn. El botÛn de "Borrar Mensajes"
-limpiar· cualquier mensaje desplegado en la ventana de mensajes.
+Dos otros botones son tambi√©n disponible. El bot√≥n "Nuevo Indicativo" 
+le permitir√° mirar datos viejos que una estaci√≥n ha enviado.
+Teclee el indicativo y pulse en este bot√≥n, cualquier 
+informaci√≥n vieja ser√° desplegada.
+Usted tambi√©n puedes usar este bot√≥n para cambiar el indicativo de la estaci√≥n
+con la que usted est√°s hablando.
+Entre el nuevo indicativo y pulse el bot√≥n. El bot√≥n de "Borrar Mensajes"
+limpiar√° cualquier mensaje desplegado en la ventana de mensajes.
 
 
 Borrar todos los mensajes salientes
- Esto limpiar· todo los mensajes no-conocidos que usted has enviado.
+ Esto limpiar√° todo los mensajes no-conocidos que usted has enviado.
 
-Auto ContestaciÛn de Msj
-Esto encender· una contestaciÛn autom·tica
+Auto Contestaci√≥n de Msj
+Esto encender√° una contestaci√≥n autom√°tica
 cuando un mensaje entrante se recibe.
 
-Fijar Mensaje en  contestaciÛn Autom·tica
- Esto fijar· un mensaje que se enviar· en ausencia autom·ticamente.
+Fijar Mensaje en  contestaci√≥n Autom√°tica
+ Esto fijar√° un mensaje que se enviar√° en ausencia autom√°ticamente.
 
-HELP-INDEX>Limpiando el despliegue de lÌnea de rastros
+HELP-INDEX>Limpiando el despliegue de l√≠nea de rastros
 
-            Limpiando el despliegue de lÌnea de rastros
+            Limpiando el despliegue de l√≠nea de rastros
 
-Pulse el botÛn en "Archivo" y despuÈs "Borrar Todo rastro". Esto limpiar· 
-todo el dato de la lÌnea de rastreo del banco de datos de la estaciÛn y 
+Pulse el bot√≥n en "Archivo" y despu√©s "Borrar Todo rastro". Esto limpiar√° 
+todo el dato de la l√≠nea de rastreo del banco de datos de la estaci√≥n y 
 actualiza la pantalla.
 
 HELP-INDEX>Limpiando el despliegue de estaciones
 
              Limpiando el despliegue de estaciones
 
-Pulse el botÛn en "Archivo" y luego el botÛn "Borrar Toda las Estaciones". Esto 
-limpiar· todo los datos del banco de datos de las estaciones excepto la suya.
+Pulse el bot√≥n en "Archivo" y luego el bot√≥n "Borrar Toda las Estaciones". Esto 
+limpiar√° todo los datos del banco de datos de las estaciones excepto la suya.
 
-HELP-INDEX>Reenviando un log (Bit·cora) 
+HELP-INDEX>Reenviando un log (Bit√°cora) 
 
-                     Reenviando una Bit·cora
+                     Reenviando una Bit√°cora
 
-Pulse el botÛn en "Archivo" y despuÈs en "Abrir Bit·cora"
-una ventana de selecciÛn de archivo se desplegar·.
+Pulse el bot√≥n en "Archivo" y despu√©s en "Abrir Bit√°cora"
+una ventana de selecci√≥n de archivo se desplegar√°.
 
 Usted puedes usarlo hojear su unidad de disco duro y seleccionar cualquier archivo
-que contenga un TNC datos raw  como aquÈllos creados por el TNC y opciones de red.
+que contenga un TNC datos raw  como aqu√©llos creados por el TNC y opciones de red.
 
-Su estaciÛn todavÌa funcionar· de la misma manera, recibiendo y transmitiendo.
-Y debe haber una palabra de advertencia aquÌ, si su dato contiene una sessiÛn 
-de mensaje y usted tienes su estaciÛn lista para transmitir, responder· al 
-archivo como si el dato fuÈ recibido sobre el TNC o Internet. 
+Su estaci√≥n todav√≠a funcionar√° de la misma manera, recibiendo y transmitiendo.
+Y debe haber una palabra de advertencia aqu√≠, si su dato contiene una sessi√≥n 
+de mensaje y usted tienes su estaci√≥n lista para transmitir, responder√° al 
+archivo como si el dato fu√© recibido sobre el TNC o Internet. 
 
-HELP-INDEX>Localizando una EstaciÛn
+HELP-INDEX>Localizando una Estaci√≥n
 
-                  Localizando una EstaciÛn
+                  Localizando una Estaci√≥n
 
-Pulse el botÛn sobre "Visualizador" luego en, "Localizar EstaciÛn"
-o sobre el botÛn de "Desplegar" luego en "EstaciÛn Rastreo" una ventana se abrir·.
-Usted puedes ahora entrar una estaciÛn o parte de una estaciÛn. Por 
-defecto buscar· un macheo exacto (llamada completa, no parcial) y no es caso 
-sensible. Si usted est·s buscando un macheo parcial, "Macheo Exacto" podrÌa no 
+Pulse el bot√≥n sobre "Visualizador" luego en, "Localizar Estaci√≥n"
+o sobre el bot√≥n de "Desplegar" luego en "Estaci√≥n Rastreo" una ventana se abrir√°.
+Usted puedes ahora entrar una estaci√≥n o parte de una estaci√≥n. Por 
+defecto buscar√° un macheo exacto (llamada completa, no parcial) y no es caso 
+sensible. Si usted est√°s buscando un macheo parcial, "Macheo Exacto" podr√≠a no 
 ser seleccionado.
 
-Realmente usted puedes usar esto para localizar una estaciÛn o un objeto. QuÈ es
-donde nosotros venimos a la opciÛn "Macheo Sensible". Yo he notado que algunos 
-objetos est·n en caso mixto o min˙scula. Con "Macheo Sensible" seleccionado, 
-el localizador buscar· may˙scula y min˙scula cuando usted la entrÛ. Si
-"Macheo Sensible" no se selecciona, el localizador asumir· cualquier caso que usted 
-teclees es may˙scula y investigar· en eso. Pulsando el botÛn "Localizar Ahora!"
-centrar· la primera estaciÛn encontrada en el centro de su pantalla
-al nivel del enfoque actual. Pulsando el botÛn "Cancelar" cerrar· la ventana.
+Realmente usted puedes usar esto para localizar una estaci√≥n o un objeto. Qu√© es
+donde nosotros venimos a la opci√≥n "Macheo Sensible". Yo he notado que algunos 
+objetos est√°n en caso mixto o min√∫scula. Con "Macheo Sensible" seleccionado, 
+el localizador buscar√° may√∫scula y min√∫scula cuando usted la entr√≥. Si
+"Macheo Sensible" no se selecciona, el localizador asumir√° cualquier caso que usted 
+teclees es may√∫scula y investigar√° en eso. Pulsando el bot√≥n "Localizar Ahora!"
+centrar√° la primera estaci√≥n encontrada en el centro de su pantalla
+al nivel del enfoque actual. Pulsando el bot√≥n "Cancelar" cerrar√° la ventana.
 
 HELP-INDEX>Creando y usando Salto a Localizaciones  
   
                      Creando y usando Salto a Localizaciones  
   
-Pulse el botÛn "Visualizador", luego en "Saltar a la posiciÛn" una ventana aparecer·.
-Si Èsta es la primera vez usted has usado este di·logo no tendr·s ninguna entrada en Èl.
-Agregar una posiciÛn en la lista de posiciÛn vaya al ·rea del mapa principal 
+Pulse el bot√≥n "Visualizador", luego en "Saltar a la posici√≥n" una ventana aparecer√°.
+Si √©sta es la primera vez usted has usado este di√°logo no tendr√°s ninguna entrada en √©l.
+Agregar una posici√≥n en la lista de posici√≥n vaya al √°rea del mapa principal 
 y enfoque el nivel que usted quieres usar.
 
-Entre un ˙nico nombre en el ·rea "Nombre de Nueva localizaciÛn",
-luego pulse el botÛn agregar.
-Su entrada se agregar· a la lista (en orden alfabÈtico).
-Usted puedes agregar tantas locaciÛn de mapas que usted quieras de esta manera.
+Entre un √∫nico nombre en el √°rea "Nombre de Nueva localizaci√≥n",
+luego pulse el bot√≥n agregar.
+Su entrada se agregar√° a la lista (en orden alfab√©tico).
+Usted puedes agregar tantas locaci√≥n de mapas que usted quieras de esta manera.
 
-Para usar uno de la posiciÛn pulsar el botÛn en el nombre de la posiciÛn 
-y pulsar el botÛn  "IR!", el mapa principal entonces mostrar· esa posiciÛn. 
+Para usar uno de la posici√≥n pulsar el bot√≥n en el nombre de la posici√≥n 
+y pulsar el bot√≥n  "IR!", el mapa principal entonces mostrar√° esa posici√≥n. 
 
-Usted puedes anular una posiciÛn similarmente pulsando el botÛn 
-sobre el nombre de la posiciÛn y luego el botÛn "Anular".
+Usted puedes anular una posici√≥n similarmente pulsando el bot√≥n 
+sobre el nombre de la posici√≥n y luego el bot√≥n "Anular".
 
-HELP-INDEX>Rastreando una EstaciÛn  
+HELP-INDEX>Rastreando una Estaci√≥n  
   
-Rastreando una EstaciÛn  
+Rastreando una Estaci√≥n  
   
-Pulse sobre el botÛn de "Desplegar" luego en "Rastreo EstaciÛn".
-Entre en el indicativo para rastrear (todos o parte) luego pulse el botÛn "Rastrear Ahora!".
-Como la estaciÛn lo mueve ser· centrado en la ventana del mapa principal.
-Dejar de rastrear esta estaciÛn pulsar el botÛn  "Anular Rastro".
+Pulse sobre el bot√≥n de "Desplegar" luego en "Rastreo Estaci√≥n".
+Entre en el indicativo para rastrear (todos o parte) luego pulse el bot√≥n "Rastrear Ahora!".
+Como la estaci√≥n lo mueve ser√° centrado en la ventana del mapa principal.
+Dejar de rastrear esta estaci√≥n pulsar el bot√≥n  "Anular Rastro".
 
-HELP-INDEX>Tr·fico de mensajes
+HELP-INDEX>Tr√°fico de mensajes
   
-    Tr·fico de todos los mensajes
+    Tr√°fico de todos los mensajes
     
-Pulse sobre la opciÛn de "Tr·fico de Mensajes"
-luego un di·logo se abrir· e iniciar· el Monitoreo
+Pulse sobre la opci√≥n de "Tr√°fico de Mensajes"
+luego un di√°logo se abrir√° e iniciar√° el Monitoreo
 de todas las estaciones alrededor del mundo, en chat o enviando
 mensaje de prueba etc.
   
@@ -1743,61 +1743,61 @@ HELP-INDEX>Imprimiendo
   
               Imprimiendo la Pantalla del Mapa  
   
-Xastir puede imprimir el ·rea de dibujo en cualquier blanco y negro o color.  Hace  
+Xastir puede imprimir el √°rea de dibujo en cualquier blanco y negro o color.  Hace  
 esto primero descargando la imagen a un archivo XPixmap en disco, entonces usando una  
-herramienta externa para convertirlo al posdata, balancearlo, rotarlo, prevista, entonces la impresiÛn  
-.  Usted debe tener su sistema que configure la impresiÛn para manejar posdata (normalmente  
-esto requiere Ghostscript y un filtro de impresiÛn instalados, asÌ como lp o lpr  
-imprime spoolers). Usted tambiÈn debe tener las herramientas siguientes instaladas para esta  
-capacidad:  Herramientas de ImageMagick (especÌficamente "convertido"), "Ghostscript",  
+herramienta externa para convertirlo al posdata, balancearlo, rotarlo, prevista, entonces la impresi√≥n  
+.  Usted debe tener su sistema que configure la impresi√≥n para manejar posdata (normalmente  
+esto requiere Ghostscript y un filtro de impresi√≥n instalados, as√≠ como lp o lpr  
+imprime spoolers). Usted tambi√©n debe tener las herramientas siguientes instaladas para esta  
+capacidad:  Herramientas de ImageMagick (espec√≠ficamente "convertido"), "Ghostscript",  
 Conjuntos de caracteres de Ghostscript, y "gv". Una vez todos esos paquetes son instalando y  
-funcional, usted debe una "gv" ventana sobre salte brevemente despuÈs que usted le diga a  
-Xastir crear un archivo de impresiÛn.  De allÌ usted puede ver la imagen impresa, y  
+funcional, usted debe una "gv" ventana sobre salte brevemente despu√©s que usted le diga a  
+Xastir crear un archivo de impresi√≥n.  De all√≠ usted puede ver la imagen impresa, y  
 si aceptable, diga a "gv" imprimirlo.  Note que algunas veces cambiando a un blanco  
-el fondo predefinido para los mapas se recomienda, dependiendo de quÈ mapas usted tienen  
+el fondo predefinido para los mapas se recomienda, dependiendo de qu√© mapas usted tienen  
 visualizable.  Esto puede ahorrar le grandemente la tinta.  
   
-HELP-INDEX>Creando Captura Instant·nea Autom·ticamente
+HELP-INDEX>Creando Captura Instant√°nea Autom√°ticamente
 
-             Creando Captura Instant·nea Autom·ticamente
+             Creando Captura Instant√°nea Autom√°ticamente
   
-Xastir tiene la capacidad para crear captura instant·nea autom·ticamente en pantalla del mapa  
-recurriendo al algo b·sico.  Este periodo de tiempo es actualmente fijado por cinco  
+Xastir tiene la capacidad para crear captura instant√°nea autom√°ticamente en pantalla del mapa  
+recurriendo al algo b√°sico.  Este periodo de tiempo es actualmente fijado por cinco  
 minutos.  Asumiendo que usted tiene "convertir" de la herramienta de ImageMagick  
-instalado, Xastir crear· un archivo de formato XPM en /var/tmp, entonces lo converte,  
-al archivo de PNG /var/tmp/xastir_snap.png. Este archivo es ˙til para ponerlo  
-en p·ginas web para mostrar una imagen viva de lo que est· en su pantalla de Xastir.  Habilite  
-este rasgo vÌa el "Archivo->Activar PNG Instant·nea".  
+instalado, Xastir crear√° un archivo de formato XPM en /var/tmp, entonces lo converte,  
+al archivo de PNG /var/tmp/xastir_snap.png. Este archivo es √∫til para ponerlo  
+en p√°ginas web para mostrar una imagen viva de lo que est√° en su pantalla de Xastir.  Habilite  
+este rasgo v√≠a el "Archivo->Activar PNG Instant√°nea".  
   
 
-HELP-INDEX>Tabla de SÌmbolo
+HELP-INDEX>Tabla de S√≠mbolo
 
-Eso son los sÌmbolos que usted puedes selecionar para su estaciÛn bajo la
-"InformaciÛn de la EstaciÛn" men˙ de configuraciÛn.
+Eso son los s√≠mbolos que usted puedes selecionar para su estaci√≥n bajo la
+"Informaci√≥n de la Estaci√≥n" men√∫ de configuraci√≥n.
 
 La lista actual puede ser encontrada en el APRS Referencia en el cual usted
 puedes obtenerlo desde http://www.tapr.org/
 
-                   Tabla de sÌmbolo
+                   Tabla de s√≠mbolo
 
-SÌmbolo Grupo/                          Grupo/
+S√≠mbolo Grupo/                          Grupo/
 
-!       Tri·ngulo w/!                   Tri·ngulo w/!
+!       Tri√°ngulo w/!                   Tri√°ngulo w/!
 "       Lluvia Nube                     Lluvia Nube
 #       Digi                            DIGI         
-$       SÌmbolo  telefÛnico             $ SÌmbolo
+$       S√≠mbolo  telef√≥nico             $ S√≠mbolo
 %       DX                              DX 
 &       GATE-HF                         GATE
-'       AviÛn pequeÒo                   AviÛn CaÌdo
+'       Avi√≥n peque√±o                   Avi√≥n Ca√≠do
 (       Nube                            nube
 )       TBD                           
 *       NIEVE Hojuela                   NIEVE Hojuela  
 +       Cruz roja                     
 ,       Inverso  L
 -       w/omni casa                  
-.       X pequeÒa
+.       X peque√±a
 /       Punto rojo                       
-0       0 en una caja                    CÌrculo
+0       0 en una caja                    C√≠rculo
 1       1 en una caja
 2       2 en una caja
 3       3 en una caja
@@ -1809,70 +1809,70 @@ $       SÌmbolo  telefÛnico             $ SÌmbolo
 9       9 en un GAS de la caja
 :       Bombero                         ?
 ;       Tienda                          tienda
-<       motocicleta                     BanderÌn
-=       M·quina de tren                  
->       AutomÛvil                       automÛvil 
+<       motocicleta                     Bander√≠n
+=       M√°quina de tren                  
+>       Autom√≥vil                       autom√≥vil 
 ?       Antena POS                      ? en una caja
 @       HURRICAN/TORMENTA               HURRICAN/TORMENTA 
 A       Primero auxilio                 Caja
 B       BBS                             Blowing Nieve 
 C       Canoa                         
-D       D en un cÌrculo                 
+D       D en un c√≠rculo                 
 E       E en un circulo                 Pila de Humo
-F       F en un cÌrculo                 
+F       F en un c√≠rculo                 
 G       Reja Antena Cuadrada            ?
 H       Hotel/Cama                     
 I       TCP/IP                          ?
-J       J en un cÌrculo                 descarga
+J       J en un c√≠rculo                 descarga
 K       Escuela                  
 L       Casa Iluminada                  Casa Iluminada
 M       Mac                           
 N       NTS                             ?
 O       Globo                       
 P       Carro  de  Patrulla             Rx
-Q       Circle con CÌrculos             CÌrculo con CÌrculos
+Q       Circle con C√≠rculos             C√≠rculo con C√≠rculos
 R       RV                              Restaurante
-S       Transbordador                   SatÈlite
+S       Transbordador                   Sat√©lite
 T       Tormenta (cloud/bolt)           Tormenta (cloud/bolt)
-U       Autob˙s escolar                 Sol
-V       VOR TAC                         VOR TAC SÌmbolo
+U       Autob√∫s escolar                 Sol
+V       VOR TAC                         VOR TAC S√≠mbolo
 W       Servicio  del Tiempo Nacional   NWS-Digi
-X       HelicÛptero
+X       Helic√≥ptero
 Y       Velero                     
 Z       Windows
 [       corredor                        WC
-\       DF Tri·ngulo
+\       DF Tri√°ngulo
 ]       Packet Mail Box
-^       AviÛn grande                    AviÛn Grande
-_       EstaciÛn MeteorolÛgica          WS-Digi
-`       Plato de satÈlite              
+^       Avi√≥n grande                    Avi√≥n Grande
+_       Estaci√≥n Meteorol√≥gica          WS-Digi
+`       Plato de sat√©lite              
 a       Ambulancia
 b       Bicicleta                       vuela nube
 c       antena de DX                     
 d       depto de bombero.               Antena de DX
 e       Caballo                         Aguanieve nube 
-f       CamiÛn de bombero               FC Nube
-g       planeador                       BanderÌn (2)
+f       Cami√≥n de bombero               FC Nube
+g       planeador                       Bander√≠n (2)
 h       Hospital                        HAM
 i       Isla                            Isla
 j       Jeep                            Jeep
-k       CamiÛn                          CamiÛn 
-l       Punto pequeÒo                   Punto pequeÒo
+k       Cami√≥n                          Cami√≥n 
+l       Punto peque√±o                   Punto peque√±o
 m       MIC                             Milla Poste
-n       N                               Tri·ngulo PequeÒo
-o       EOC                             Punto en CÌrculos 
-p       Cachorro                        Punto en CÌrculos 
+n       N                               Tri√°ngulo Peque√±o
+o       EOC                             Punto en C√≠rculos 
+p       Cachorro                        Punto en C√≠rculos 
 q       GS Antena                       Antena de GS
 r       Antena Torre                    Antena Torre
 s       Bote                            Barco
 t       TS                              ?
-u       18 Rueda de CamiÛn
-v       Carro de mudanzas               Punto en CÌrculos 
+u       18 Rueda de Cami√≥n
+v       Carro de mudanzas               Punto en C√≠rculos 
 w       H20                             Diluvio
 x       X Windows                       Punto Rojo
 y       Casa w/Yagi                     Casa w/yagi 
 z                                       X Windows
 {       NIEBLA                          NIEBLA
-|       LÌnea Negra                     LÌnea negra
+|       L√≠nea Negra                     L√≠nea negra
 }       TCP                             TCP
 ~       Velero                          Velero

--- a/src/lang.c
+++ b/src/lang.c
@@ -61,7 +61,7 @@
  * Because every multi-byte UTF-8 sequence is longer than its decoded form,
  * the output is always <= the input length, making in-place conversion safe.
  */
-static void utf8_to_latin1_inplace(char *buf)
+void utf8_to_latin1_inplace(char *buf)
 {
   unsigned char *in  = (unsigned char *)buf;
   unsigned char *out = (unsigned char *)buf;

--- a/src/lang.c
+++ b/src/lang.c
@@ -50,6 +50,65 @@
 
 
 
+/*
+ * Convert a UTF-8 encoded string to ISO-8859-1 in-place.
+ * Characters in the range U+0080..U+00FF are preserved as their single-byte
+ * Latin-1 equivalents.  Any codepoint above U+00FF (not representable in
+ * Latin-1) is replaced with '?'.  Invalid UTF-8 byte sequences are passed
+ * through as-is so that legacy ISO-8859-1 files that were never re-encoded
+ * continue to work unchanged.
+ *
+ * Because every multi-byte UTF-8 sequence is longer than its decoded form,
+ * the output is always <= the input length, making in-place conversion safe.
+ */
+static void utf8_to_latin1_inplace(char *buf)
+{
+  unsigned char *in  = (unsigned char *)buf;
+  unsigned char *out = (unsigned char *)buf;
+
+  while (*in)
+  {
+    if (*in < 0x80)
+    {
+      /* Plain ASCII byte — copy as-is */
+      *out++ = *in++;
+    }
+    else if ((*in & 0xE0) == 0xC0 && (in[1] & 0xC0) == 0x80)
+    {
+      /* 2-byte sequence: U+0080 .. U+07FF */
+      unsigned int cp = (unsigned int)((*in & 0x1F) << 6) | (in[1] & 0x3F);
+      *out++ = (cp <= 0xFF) ? (unsigned char)cp : (unsigned char)'?';
+      in += 2;
+    }
+    else if ((*in & 0xF0) == 0xE0
+             && (in[1] & 0xC0) == 0x80
+             && (in[2] & 0xC0) == 0x80)
+    {
+      /* 3-byte sequence: U+0800 .. U+FFFF — outside Latin-1 */
+      *out++ = '?';
+      in += 3;
+    }
+    else if ((*in & 0xF8) == 0xF0
+             && (in[1] & 0xC0) == 0x80
+             && (in[2] & 0xC0) == 0x80
+             && (in[3] & 0xC0) == 0x80)
+    {
+      /* 4-byte sequence: U+10000 and above — outside Latin-1 */
+      *out++ = '?';
+      in += 4;
+    }
+    else
+    {
+      /* Not valid UTF-8 — pass the byte through unchanged so that a
+       * legacy file that was never re-encoded still works. */
+      *out++ = *in++;
+    }
+  }
+  *out = '\0';
+}
+
+
+
 char lang_code[MAX_LANG_ENTRIES][MAX_LANG_CODE+1];
 char *lang_code_ptr[MAX_LANG_ENTRIES];
 char lang_buffer[MAX_LANG_BUFFER];
@@ -205,6 +264,11 @@ int load_language_file(char *filename)
                         temp_ptr=strtok(NULL,"|");         /* get string */
                         if (temp_ptr!=NULL)
                         {
+                          /* Convert UTF-8 → ISO-8859-1 so that language
+                           * files saved by modern editors (which default to
+                           * UTF-8) work correctly with Motif/Xlib, which
+                           * expects Latin-1 bytes. */
+                          utf8_to_latin1_inplace(temp_ptr);
                           data_len=(int)strlen(temp_ptr);
                           if ((buffer_len+data_len+1)< MAX_LANG_BUFFER)
                           {

--- a/src/lang.h
+++ b/src/lang.h
@@ -32,6 +32,7 @@
 extern int load_language_file(char *filename);
 extern char *langcode(char *code);
 extern char langcode_hotkey(char *code);
+extern void utf8_to_latin1_inplace(char *buf);
 
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -151,6 +151,7 @@ char *xastir_version=VERSION;
 
 #include "x_spider.h"
 #include "map_cache.h"
+#include "lang.h"
 
 #include <Xm/XmAll.h>
 #include <X11/cursorfont.h>
@@ -20411,6 +20412,7 @@ void help_view( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSED
         while(!feof(f))
         {
           (void)get_line(f,temp2,200);
+          utf8_to_latin1_inplace(temp2);
           if (strncmp(temp2,"HELP-INDEX>",11)==0)
           {
             if(strcmp((temp2+11),temp)==0)
@@ -20588,6 +20590,7 @@ void Help_Index( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPointer UNUSE
       while (!feof(f))
       {
         (void)get_line(f,temp,600);
+        utf8_to_latin1_inplace(temp);
         if (strncmp(temp,"HELP-INDEX>",11)==0)
         {
           XmListAddItem(help_list, str_ptr = XmStringCreateLocalized((temp+11)),n++);


### PR DESCRIPTION
## lang: convert language files to UTF-8, decode to Latin-1 at load time

### Problem

`config/language-*.sys` were stored in ISO-8859-1. Modern editors default to UTF-8 and will sometimes silently re-encode files on save. AI tools will use blind "replacements" ignoring file encoding. This caused accented characters in French, German, Spanish, Italian, Dutch, and Portuguese translations to be stored as multi-byte UTF-8 sequences while the loader copied the raw bytes straight into Motif widget labels — producing mojibake with no warning.

### Solution

**Two-part, minimal change:**

1. **One-time conversion** — all 12 `language-*.sys` files converted from ISO-8859-1 to UTF-8 via `iconv`. Files are now safe to edit and commit from any modern editor.

2. **Translation layer in `lang.c`** — added `utf8_to_latin1_inplace()`, called on each translated string immediately after it is parsed from the file, before it enters `lang_buffer`. Motif and the rest of the app continue to receive Latin-1 bytes unchanged. No other files were modified.

### Properties of the converter

| Input | Output |
|---|---|
| ASCII (U+0000–U+007F) | copied as-is |
| Latin-1 supplement (U+0080–U+00FF) | decoded from 2-byte UTF-8 → single Latin-1 byte |
| Outside Latin-1 (U+0100+) | replaced with `?` (safe, visible fallback) |
| Invalid UTF-8 bytes | passed through unchanged (legacy file safety) |

### Testing

- `make lang.o` — clean compile, zero warnings.
- `file config/language-*.sys` — all report `Unicode text, UTF-8 text`.
- Verified round-trip: a French string containing `é` (U+00E9) is stored as `0xC3 0xA9` in the file and arrives in `lang_buffer` as `0xE9`, identical to the original ISO-8859-1 encoding.

### Scope

No behaviour changes outside `lang.c`. No new dependencies. No changes to the `.sys` file format — the pipe-delimited structure is identical.

Screenshot of the spanish language translation after this change:

<img width="203" height="402" alt="image" src="https://github.com/user-attachments/assets/8b835a0f-a7c3-464e-85a2-e620ce4243bc" />

fixes #365 