### PR TITLE
Work around ugly UTF-8 map label display

### DIFF
--- a/src/map_shp.c
+++ b/src/map_shp.c
@@ -82,6 +82,7 @@
 #include "rotated.h"
 #include "color.h"
 #include "xa_config.h"
+#include "lang.h"
 
 #ifdef HAVE_LIBSHP
   #include "awk.h"
@@ -1322,6 +1323,7 @@ void draw_shapefile_map (Widget w,
               // the symbol and aligned nicely.
               if (map_labels && !skip_label)
               {
+                utf8_to_latin1_inplace(temp);
                 draw_nice_string(w, pixmap, 0, x+10, y+5, (char*)temp, 0xf, 0x10, strlen(temp));
               }
             }
@@ -1410,6 +1412,7 @@ void draw_shapefile_map (Widget w,
                    && map_labels
                    && !skip_label )
               {
+                utf8_to_latin1_inplace(temp);
                 x=points[0].x;
                 y=points[0].y;
 
@@ -1610,6 +1613,7 @@ void draw_shapefile_map (Widget w,
             }
             ok = 1;
 
+            utf8_to_latin1_inplace(name);
             /* TODO:  consider other label point options */
             /* for now, this function just gives us the center of the
              * bounding box


### PR DESCRIPTION
Issue #343 pointed out that many new shapefiles are getting produced with UTF-8 encoded accented characters, and these display as mojibake in Xastir's map window because Motif doesn't grok UTF-8 without a great deal of coding support that we're not really interested in persuing.

A recent change done in PR #366 implemented a simple utf8_to_latin1_inplace function that provides an immediate workaround for this map display issue.

This PR applies that function to all shapefile map labels before they're used for anything (which includes displaying them, but also storing them in or accessing them from hashes for decluttering purposes).

After application, maps with UTF-8 encoded fields used for labeling are now rendered nicely in Xastir.

Closes #343