### PR TITLE
Black on white

### DIFF
--- a/config/language-Dutch.sys
+++ b/config/language-Dutch.sys
@@ -154,6 +154,7 @@ PULDNMSL01|Zwarte Rand||
 PULDNMSL02|Zwarte Schaduw en gevulde achtergrond||
 PULDNMSL03|Tekst op Zwarte achtergond|T|
 PULDNMSL04|DropShadow||
+PULDNMSL05|Zwart op wit||
 #
 # PullDown "Icon Outline Style"
 PULDNMIO01|Geen Omranding|G|

--- a/config/language-English.sys
+++ b/config/language-English.sys
@@ -143,6 +143,7 @@ PULDNMSL01|Black Border|B|
 PULDNMSL02|Black Shadow|S|
 PULDNMSL03|Text on Black|T|
 PULDNMSL04|DropShadow||
+PULDNMSL05|Black on White|W|
 #
 # PullDown "Icon Outline Style"
 PULDNMIO01|No Outline|N|

--- a/config/language-French.sys
+++ b/config/language-French.sys
@@ -144,6 +144,7 @@ PULDNMSL01|Bordure noire|n|
 PULDNMSL02|Ombré avec toile de fond|O|
 PULDNMSL03|Blanc sur noir|B|
 PULDNMSL04|DropShadow||
+PULDNMSL05|Noir sur blanc||
 #
 # PullDown "Icon Outline Style"
 PULDNMIO01|Pas de contour|N|

--- a/config/language-German.sys
+++ b/config/language-German.sys
@@ -151,6 +151,7 @@ PULDNMSL01|Schwarze Umrandung|U|
 PULDNMSL02|Schatten|S|
 PULDNMSL03|Schwarzer Hintergrund|H|
 PULDNMSL04|DropShadow||
+PULDNMSL05|Schwarz auf Weiss|W|
 #
 # PullDown "Symbol Umrandung"
 PULDNMIO01|Keine Umrandung|K|

--- a/config/language-Italian.sys
+++ b/config/language-Italian.sys
@@ -142,6 +142,7 @@ PULDNMSL01|Bordo nero||
 PULDNMSL02|Ombra nera e sfondo uniforme||
 PULDNMSL03|Testo su sfondo nero|T|
 PULDNMSL04|DropShadow||
+PULDNMSL05|Nero su bianco||
 #
 # PullDown "Stile Bordo Icone"
 PULDNMIO01|Nessun Bordo|N|

--- a/config/language-Portuguese.sys
+++ b/config/language-Portuguese.sys
@@ -143,6 +143,7 @@ PULDNMSL01|Fundo negro||
 PULDNMSL02|Fundo cinzento||
 PULDNMSL03|Texto em negro|T|
 PULDNMSL04|DropShadow||
+PULDNMSL05|Preto sobre branco||
 #
 # PullDown "Estilo da linha de fora do icon"
 PULDNMIO01|Nao ha limite|N|

--- a/config/language-Spanish.sys
+++ b/config/language-Spanish.sys
@@ -141,6 +141,7 @@ PULDNMSL01|Fondo Negro||
 PULDNMSL02|Fondo Gris||
 PULDNMSL03|Texto en Negro|T|
 PULDNMSL04|DropShadow||
+PULDNMSL05|Negro sobre blanco||
 #
 # PullDown "Icon Outline Style"
 PULDNMIO01|No Outline|N|

--- a/src/draw_symbols.c
+++ b/src/draw_symbols.c
@@ -111,6 +111,11 @@ void draw_nice_string(Widget w, Pixmap where, int style, long x, long y, char *t
   {
     Display *dpy = XtDisplay(w);
     const char *fontspec = rotated_label_fontname[FONT_STATION];
+    static const int outline_offsets_2px[12][2] = {
+      {-2,  0}, { 2,  0}, { 0, -2}, { 0,  2},
+      {-1, -1}, {-1,  1}, { 1, -1}, { 1,  1},
+      {-2, -1}, {-2,  1}, { 2, -1}, { 2,  1}
+    };
 
     int font_height = xastir_cairo_text_height(fontspec);
     int text_w      = xastir_cairo_text_width(text, fontspec);
@@ -152,6 +157,23 @@ void draw_nice_string(Widget w, Pixmap where, int style, long x, long y, char *t
                                0.0f, text, fontspec,
                                colors[bgcolor], 0, 0, NONE);
         break;
+
+      case 4:
+      {
+        int i;
+
+        for (i = 0; i < 12; i++)
+        {
+          xastir_cairo_draw_text(dpy, where,
+                                 x + outline_offsets_2px[i][0],
+                                 y + outline_offsets_2px[i][1],
+                                 0.0f, text, fontspec,
+                                 colors[0x20], 0, 0, NONE);
+        }
+        xastir_cairo_draw_text(dpy, where, x, y, 0.0f, text, fontspec,
+                               colors[0x10], 0, 0, NONE);
+        return;
+      }
     }
 
     /* final foreground text */
@@ -163,6 +185,7 @@ void draw_nice_string(Widget w, Pixmap where, int style, long x, long y, char *t
     GContext gcontext;
     XFontStruct *xfs_ptr;
     int font_width, font_height;
+    int x_outline, y_outline;
 
     gcontext = XGContextFromGC(gc);
     xfs_ptr = XQueryFont(XtDisplay(w), gcontext);
@@ -202,6 +225,25 @@ void draw_nice_string(Widget w, Pixmap where, int style, long x, long y, char *t
         (void)XSetForeground(XtDisplay(w),gc,colors[bgcolor]);
         (void)XDrawString(XtDisplay(w),where,gc,x+(font_height/10),y+(font_width/8),text,length);
         break;
+      case 4:
+        (void)XSetForeground(XtDisplay(w),gc,colors[0x20]);
+        for (x_outline=-2; x_outline<=2; x_outline++)
+        {
+          for (y_outline=-2; y_outline<=2; y_outline++)
+          {
+            if ((x_outline == 0 && y_outline == 0)
+                || abs(x_outline) + abs(y_outline) > 3)
+              continue;
+
+            (void)XDrawString(XtDisplay(w),where,gc,
+                              x+x_outline,y+y_outline,text,length);
+          }
+        }
+        (void)XSetForeground(XtDisplay(w),gc,colors[0x10]);
+        (void)XDrawString(XtDisplay(w),where,gc,x,y,text,length);
+        if (xfs_ptr)
+          XFreeFontInfo(NULL, xfs_ptr, 1);
+        return;
     }
     (void)XSetForeground(XtDisplay(w),gc,colors[fgcolor]);
     (void)XDrawString(XtDisplay(w),where,gc,x,y,text,length);

--- a/src/main.c
+++ b/src/main.c
@@ -473,7 +473,7 @@ Widget map_font_dialog = (Widget)NULL;
 Widget map_font_text[FONT_MAX];
 
 
-Widget map_station_label0,map_station_label1,map_station_label2,map_station_label3;
+Widget map_station_label0,map_station_label1,map_station_label2,map_station_label3,map_station_label4;
 static void Map_station_label(Widget w, XtPointer clientData, XtPointer calldata);
 int letter_style;               /* Station Letter style */
 
@@ -7458,12 +7458,36 @@ void create_appshell( Display *display, char * UNUSED(app_name), int UNUSED(app_
                        MY_FOREGROUND_COLOR,
                        MY_BACKGROUND_COLOR,
                        NULL);
+  map_station_label4 = XtVaCreateManagedWidget(langcode("PULDNMSL05"),
+                       xmPushButtonGadgetClass,
+                       Map_station_label_Pane,
+                       XmNmnemonic,langcode_hotkey("PULDNMSL05"),
+                       XmNfontList, fontlist1,
+                       MY_FOREGROUND_COLOR,
+                       MY_BACKGROUND_COLOR,
+                       NULL);
 
-  sel4_switch(letter_style,map_station_label3,map_station_label2,map_station_label1,map_station_label0);
+  if (letter_style > 4)
+    letter_style = 0;
+
+  if (letter_style == 4)
+  {
+    XtSetSensitive(map_station_label4, FALSE);
+    XtSetSensitive(map_station_label3, TRUE);
+    XtSetSensitive(map_station_label2, TRUE);
+    XtSetSensitive(map_station_label1, TRUE);
+    XtSetSensitive(map_station_label0, TRUE);
+  }
+  else
+  {
+    XtSetSensitive(map_station_label4, TRUE);
+    sel4_switch(letter_style,map_station_label3,map_station_label2,map_station_label1,map_station_label0);
+  }
   XtAddCallback(map_station_label0,   XmNactivateCallback,Map_station_label,"0");
   XtAddCallback(map_station_label1,   XmNactivateCallback,Map_station_label,"1");
   XtAddCallback(map_station_label2,   XmNactivateCallback,Map_station_label,"2");
   XtAddCallback(map_station_label3,   XmNactivateCallback,Map_station_label,"3");
+  XtAddCallback(map_station_label4,   XmNactivateCallback,Map_station_label,"4");
 
 
   ac = 0;
@@ -16373,7 +16397,19 @@ void Map_station_label( Widget UNUSED(w), XtPointer clientData, XtPointer UNUSED
   if(display_up)
   {
     letter_style = style;
-    sel4_switch(letter_style,map_station_label3,map_station_label2,map_station_label1,map_station_label0);
+    if (letter_style == 4)
+    {
+      XtSetSensitive(map_station_label4, FALSE);
+      XtSetSensitive(map_station_label3, TRUE);
+      XtSetSensitive(map_station_label2, TRUE);
+      XtSetSensitive(map_station_label1, TRUE);
+      XtSetSensitive(map_station_label0, TRUE);
+    }
+    else
+    {
+      XtSetSensitive(map_station_label4, TRUE);
+      sel4_switch(letter_style,map_station_label3,map_station_label2,map_station_label1,map_station_label0);
+    }
     redraw_symbols(da);
     (void)XCopyArea(XtDisplay(da),
                     pixmap_final,

--- a/src/xa_config.c
+++ b/src/xa_config.c
@@ -1582,7 +1582,7 @@ void load_data_or_default(void)
                    );
   }
 
-  letter_style = get_int ("MAP_LETTERSTYLE", 0, 3, 0 );
+  letter_style = get_int ("MAP_LETTERSTYLE", 0, 4, 0 );
 
   icon_outline_style = get_int ("MAP_ICONOUTLINESTYLE", 0, 3, 0);
 


### PR DESCRIPTION
This PR adds a "Black and White" option to the Map->Configure->Station Text Style menu, which matches
the OpenStreetMaps style.

All language files updated to add the new option and the new text has been correctly translated into the
appropriate languages.

Example of the menu item (selected) and a station with the color scheme applied.

<img width="769" height="427" alt="image" src="https://github.com/user-attachments/assets/d2dd1aed-59ac-4cfd-adb3-cf6a00cb9967" />


closes #371 
