### PR TITLE
Extract popup dialog logic into popup_controller

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -1,0 +1,96 @@
+# Xastir Presentation/Logic Separation — Migration Plan
+
+This plan operationalizes Phase 2 of the Qt migration: extract domain logic
+from Motif callbacks into testable controllers, one `*_gui.c` file at a time.
+The Qt port itself is downstream of this work; success here is measured by
+shrinking the global `Widget` table and growing the unit-test suite, not by
+toolkit changes.
+
+## Guiding constraints (carried over from prior decisions)
+
+- **De-spaghetti first.** Each migrated file ends with logic in a controller,
+  not in callbacks. Toolkit swap is a later concern.
+- **C compiled as C++** is the agreed language strategy. New controllers stay
+  in C-style structs and free functions for now — no STL, no RAII rewrites.
+- **Map canvas (`maps.c`, `draw_symbols.c`, `map_*.c`) is out of scope.** Don't
+  refactor map rendering as part of this work.
+- **No new Cairo surface area.** Cairo retires when Qt arrives.
+- **Tests are the safety net.** Every migrated file gets at least one new
+  `test_<feature>_controller.c` covering its extracted logic, wired into the
+  existing Autotest harness in `tests/`.
+
+## The pattern (apply to every file)
+
+For each `src/<feature>_gui.c`:
+
+1. **Inventory.** List every global the file reads or writes — `Widget`
+   handles, dialog flags, current selections, transient buffers — and every
+   non-trivial helper that doesn't directly call Motif. The result is the
+   future controller's state and methods.
+2. **Create `src/<feature>_controller.{h,c}`.** Define a struct that owns the
+   non-Widget state. Move the pure-logic helpers in as functions taking a
+   `<feature>_controller_t *` first argument. No `<Xm/*.h>` includes here.
+3. **Thin out `<feature>_gui.c`.** Callbacks now do three things only: pull
+   values out of widgets, call into the controller, push results back into
+   widgets. The `Widget` handles can stay as file-scope statics for this pass
+   — the goal is to drain *logic*, not to redesign Motif ownership yet.
+4. **Stubs file.** Add `tests/test_<feature>_controller_stubs.c` for any
+   external symbols the controller's `.c` pulls in transitively but the test
+   doesn't exercise. Pattern: see `tests/test_util_stubs.c`.
+5. **Test file.** Add `tests/test_<feature>_controller.c` exercising the
+   extracted logic directly. Use `tests/test_framework.h` macros.
+6. **Autotest wiring.** Add `tests/<feature>_controller_tests.at` and
+   `m4_include` it from `testsuite.at`. Add a `check_PROGRAMS` entry plus
+   `_SOURCES`/`_CPPFLAGS` block in `tests/Makefile.am`.
+7. **Build & run.** `./bootstrap.sh && ./configure && make && make check`
+   must pass before the file is marked done.
+8. **Tick the tracker.** Update `MIGRATION_PROGRESS.md` — set the row to
+   "done", record LOC moved, and note any globals still left behind for
+   later passes.
+
+## What "done" means for one file
+
+A file is migrated when:
+
+- All non-Motif logic from `<feature>_gui.c` lives in
+  `<feature>_controller.{h,c}`.
+- `<feature>_gui.c` no longer contains business rules — only widget
+  marshalling.
+- At least one unit test exercises the new controller via the Autotest
+  harness, and `make check` passes.
+- The `MIGRATION_PROGRESS.md` row is updated with the actual outcome
+  (LOC moved, globals retired, tests added, surprises encountered).
+
+Partial migrations are allowed and expected for the larger files
+(`db_gui.c`, `objects_gui.c`, `interface_gui.c`); the tracker records what
+got done in each pass.
+
+## Ordering principle
+
+Files are tackled smallest-and-simplest first to refine the controller
+pattern on cheap targets before paying for it on the expensive ones. The
+ranking in `MIGRATION_PROGRESS.md` is by lines of code combined with
+widget/callback density (proxies for coupling).
+
+## What this plan deliberately does *not* do
+
+- It does not consolidate the global `Widget` handle table in `main.c`.
+  That is a follow-up pass after enough controllers exist to know the right
+  ownership shape.
+- It does not introduce a new event loop, threading model, or signal/slot
+  layer. Those belong to the Qt port.
+- It does not rewrite `maps.c`, `draw_symbols.c`, or `map_*.c`.
+- It does not change the on-disk config format or the wire protocol.
+
+## When to revisit this plan
+
+After the first three files (`popup_gui.c`, `location_gui.c`,
+`view_message_gui.c`) are done, the controller pattern will be concrete.
+At that point:
+
+- If the per-file cost is materially higher than expected, stop and
+  redesign the pattern before continuing.
+- If a recurring shape emerges (e.g. most dialogs need the same lifecycle
+  hooks), promote it to a small shared header rather than copy-pasting.
+- Re-rank the remaining files in `MIGRATION_PROGRESS.md` if the metrics
+  turned out to mis-predict difficulty.

--- a/MIGRATION_PROGRESS.md
+++ b/MIGRATION_PROGRESS.md
@@ -1,0 +1,84 @@
+# Migration Progress Tracker
+
+Tracks the per-file controller-extraction work described in
+`MIGRATION_PLAN.md`. Files are ordered easiest → hardest based on lines of
+code, Widget references, and callback count. Re-rank after each file if
+reality disagrees with the metric.
+
+Status legend: ☐ todo · ◧ in progress · ☑ done · ⊘ skipped
+
+## Ranking metrics (snapshot, master @ start of migration)
+
+| # | File                  | LOC   | Widget refs | Callbacks | Status |
+|---|-----------------------|-------|-------------|-----------|--------|
+| 1 | `popup_gui.c`         |   417 |           9 |         1 | ☑      |
+| 2 | `location_gui.c`      |   672 |          12 |         4 | ☐      |
+| 3 | `view_message_gui.c`  |   830 |          14 |         6 | ☐      |
+| 4 | `bulletin_gui.c`      |   890 |          12 |         3 | ☐      |
+| 5 | `track_gui.c`         |  1088 |          21 |         6 | ☐      |
+| 6 | `geocoder_gui.c`      |  1179 |          32 |        17 | ☐      |
+| 7 | `locate_gui.c`        |  1292 |          32 |         7 | ☐      |
+| 8 | `wx_gui.c`            |  2421 |          54 |         4 | ☐      |
+| 9 | `list_gui.c`          |  2808 |          42 |        18 | ☐      |
+|10 | `messages_gui.c`      |  2872 |          53 |        22 | ☐      |
+|11 | `db_gui.c`            |  4978 |          62 |        21 | ☐      |
+|12 | `objects_gui.c`       |  6181 |          48 |        88 | ☐      |
+|13 | `interface_gui.c`     |  9998 |         228 |        95 | ☐      |
+
+The first three (popup, location, view_message) are the pattern-shakedown
+batch. After they're done, revisit this file before continuing.
+
+## Per-file log
+
+Append a short entry below as each file is migrated. Keep it terse:
+what got moved, what got tested, what got left behind.
+
+### Template
+
+```
+#N <file>.c — <yyyy-mm-dd>
+  Controller:  src/<feature>_controller.{h,c}  (~NNN LOC)
+  Tests:       tests/test_<feature>_controller.c (M cases)
+  Globals retired:  <list of names>, or "none"
+  Globals deferred: <names that should still be drained later>
+  Notes:       <surprises, deviations from the plan, follow-ups>
+```
+
+### Entries
+
+```
+#1 popup_gui.c — 2026-04-26
+  Controller:  src/popup_controller.{h,c}  (80 + 147 LOC)
+  Tests:       tests/test_popup_controller.c  (11 cases, all green;
+               full suite: 241/241 ok)
+  Globals retired:
+    - popup_time_out_check_last  (file-scope time_t, zero external users)
+       → moved into popup_controller_t.last_timeout_check
+  Globals deferred (intentional, future passes):
+    - pw[MAX_POPUPS]             — Widget bag; stays in popup_gui.c
+    - pwb (Popup_Window)         — DEAD: written by clear_popup_message_windows,
+                                    never read anywhere. Out of scope for this pass.
+    - popup_message_dialog_lock  — mutex; threading/Motif concern
+    - id_font (popup_ID_message) — X11 font cache
+  Behavior preserved:
+    - "all slots full" still silently drops the new popup (legacy i=0 fallback
+      kept in popup_message_always).
+    - popup_ID_message (rotated ATV ID text) untouched — pure X11 graphics, no
+      logic kernel worth extracting.
+  Surprises:
+    - popup_controller.c has zero Xastir-side dependencies, so the test binary
+      needs *no* stubs file. First validation that "self-contained controller
+      header" is the right rule for this codebase.
+    - Slot occupancy now tracked in two places (Widget != NULL and
+      controller.slots[i].active). Kept lockstep at 4 mutation sites; acceptable
+      for v1, candidate for unification once a few more dialogs are migrated.
+```
+
+## Aggregate counters
+
+Update after each file lands.
+
+- Files migrated:        1 / 13
+- Total LOC reviewed:    417
+- Globals retired:       1
+- New unit tests added:  11

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -63,6 +63,7 @@ XASTIR_SRC = \
     objects_gui.c objects_gui.h \
     object_utils.h object_utils.c \
     popup.h \
+    popup_controller.c popup_controller.h \
     popup_gui.c \
     rac_data.c rac_data.h \
     rotated.c rotated.h \

--- a/src/popup_controller.c
+++ b/src/popup_controller.c
@@ -1,0 +1,147 @@
+/*
+ *
+ * XASTIR, Amateur Station Tracking and Information Reporting
+ * Copyright (C) 1999,2000  Frank Giannandrea
+ * Copyright (C) 2000-2026 The Xastir Group
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * Look at the README for more information on the program.
+ */
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+#include "popup_controller.h"
+
+void popup_controller_init(popup_controller_t *pc)
+{
+  if (pc == NULL)
+  {
+    return;
+  }
+  memset(pc, 0, sizeof(*pc));
+}
+
+void popup_controller_clear(popup_controller_t *pc)
+{
+  int i;
+
+  if (pc == NULL)
+  {
+    return;
+  }
+  for (i = 0; i < POPUP_MAX_SLOTS; i++)
+  {
+    pc->slots[i].active = 0;
+    pc->slots[i].sec_opened = 0;
+  }
+}
+
+int popup_controller_find_free_slot(const popup_controller_t *pc)
+{
+  int i;
+
+  if (pc == NULL)
+  {
+    return -1;
+  }
+  for (i = 0; i < POPUP_MAX_SLOTS; i++)
+  {
+    if (!pc->slots[i].active)
+    {
+      return i;
+    }
+  }
+  return -1;
+}
+
+int popup_controller_slot_is_active(const popup_controller_t *pc, int idx)
+{
+  if (pc == NULL || idx < 0 || idx >= POPUP_MAX_SLOTS)
+  {
+    return 0;
+  }
+  return pc->slots[idx].active ? 1 : 0;
+}
+
+void popup_controller_open_slot(popup_controller_t *pc, int idx, time_t now)
+{
+  if (pc == NULL || idx < 0 || idx >= POPUP_MAX_SLOTS)
+  {
+    return;
+  }
+  pc->slots[idx].active = 1;
+  pc->slots[idx].sec_opened = now;
+}
+
+void popup_controller_close_slot(popup_controller_t *pc, int idx)
+{
+  if (pc == NULL || idx < 0 || idx >= POPUP_MAX_SLOTS)
+  {
+    return;
+  }
+  pc->slots[idx].active = 0;
+  pc->slots[idx].sec_opened = 0;
+}
+
+int popup_controller_should_run_timeout_check(const popup_controller_t *pc, time_t now)
+{
+  if (pc == NULL)
+  {
+    return 0;
+  }
+  return (pc->last_timeout_check + POPUP_TIMEOUT_CHECK_INTERVAL < now) ? 1 : 0;
+}
+
+void popup_controller_mark_timeout_check(popup_controller_t *pc, time_t now)
+{
+  if (pc == NULL)
+  {
+    return;
+  }
+  pc->last_timeout_check = now;
+}
+
+int popup_controller_slot_expired(const popup_controller_t *pc, int idx, time_t now)
+{
+  if (pc == NULL || idx < 0 || idx >= POPUP_MAX_SLOTS)
+  {
+    return 0;
+  }
+  if (!pc->slots[idx].active)
+  {
+    return 0;
+  }
+  return ((now - pc->slots[idx].sec_opened) > POPUP_MAX_AGE_SECONDS) ? 1 : 0;
+}
+
+int popup_controller_message_valid(const char *banner, const char *message)
+{
+  return (banner != NULL && message != NULL) ? 1 : 0;
+}
+
+void popup_controller_format_slot_name(int idx, char *out, size_t outsz)
+{
+  if (out == NULL || outsz == 0)
+  {
+    return;
+  }
+  snprintf(out, outsz, "%9d", idx % 1000);
+}

--- a/src/popup_controller.h
+++ b/src/popup_controller.h
@@ -1,0 +1,80 @@
+/*
+ *
+ * XASTIR, Amateur Station Tracking and Information Reporting
+ * Copyright (C) 1999,2000  Frank Giannandrea
+ * Copyright (C) 2000-2026 The Xastir Group
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * Look at the README for more information on the program.
+ */
+
+/*
+ * Presentation/logic separation: this header is intentionally free of
+ * Motif/X11 dependencies so the controller can be unit-tested standalone.
+ * Do NOT include popup.h, xastir.h, or any Xt/Xm header from here.
+ */
+
+#ifndef XASTIR_POPUP_CONTROLLER_H
+#define XASTIR_POPUP_CONTROLLER_H
+
+#include <time.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define POPUP_MAX_SLOTS               30
+#define POPUP_MAX_AGE_SECONDS        600   /* slot auto-closes after this */
+#define POPUP_TIMEOUT_CHECK_INTERVAL 120   /* sweep cadence */
+#define POPUP_SLOT_NAME_SIZE          10   /* matches Popup_Window.name[10] */
+
+typedef struct
+{
+  int    active;       /* 1 if slot currently holds a popup, 0 otherwise */
+  time_t sec_opened;   /* wall-clock seconds at which the popup was opened */
+} popup_slot_t;
+
+typedef struct
+{
+  popup_slot_t slots[POPUP_MAX_SLOTS];
+  time_t       last_timeout_check;
+} popup_controller_t;
+
+/* Lifecycle */
+void popup_controller_init(popup_controller_t *pc);
+void popup_controller_clear(popup_controller_t *pc);
+
+/* Slot bookkeeping */
+int  popup_controller_find_free_slot(const popup_controller_t *pc);
+int  popup_controller_slot_is_active(const popup_controller_t *pc, int idx);
+void popup_controller_open_slot(popup_controller_t *pc, int idx, time_t now);
+void popup_controller_close_slot(popup_controller_t *pc, int idx);
+
+/* Timeout sweep */
+int  popup_controller_should_run_timeout_check(const popup_controller_t *pc, time_t now);
+void popup_controller_mark_timeout_check(popup_controller_t *pc, time_t now);
+int  popup_controller_slot_expired(const popup_controller_t *pc, int idx, time_t now);
+
+/* Pure helpers */
+int  popup_controller_message_valid(const char *banner, const char *message);
+void popup_controller_format_slot_name(int idx, char *out, size_t outsz);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* XASTIR_POPUP_CONTROLLER_H */

--- a/src/popup_gui.c
+++ b/src/popup_gui.c
@@ -34,6 +34,7 @@
 #include "xastir.h"
 #include "main.h"
 #include "popup.h"
+#include "popup_controller.h"
 #include "main.h"
 #include "lang.h"
 #include "rotated.h"
@@ -44,10 +45,18 @@
 #include "leak_detection.h"
 
 
+/* Sanity: popup.h's MAX_POPUPS must agree with the controller's slot count. */
+#if MAX_POPUPS != POPUP_MAX_SLOTS
+#  error "MAX_POPUPS (popup.h) and POPUP_MAX_SLOTS (popup_controller.h) disagree"
+#endif
+
+
 extern XmFontList fontlist1;    // Menu/System fontlist
 
 static Popup_Window pw[MAX_POPUPS];
 static Popup_Window pwb;
+
+static popup_controller_t popup_ctrl;
 
 static xastir_mutex popup_message_dialog_lock;
 
@@ -58,6 +67,7 @@ static xastir_mutex popup_message_dialog_lock;
 void popup_gui_init(void)
 {
   init_critical_section( &popup_message_dialog_lock );
+  popup_controller_init(&popup_ctrl);
 }
 
 
@@ -77,6 +87,8 @@ void clear_popup_message_windows(void)
     pw[i].popup_message_dialog=(Widget)NULL;
     pw[i].popup_message_data=(Widget)NULL;
   }
+
+  popup_controller_clear(&popup_ctrl);
 
   end_critical_section(&popup_message_dialog_lock, "popup_gui.c:clear_popup_message_windows" );
 
@@ -102,6 +114,7 @@ static void popup_message_destroy_shell(Widget UNUSED(w),
   XtDestroyWidget(pw[i].popup_message_dialog);
   pw[i].popup_message_dialog = (Widget)NULL;
   pw[i].popup_message_data = (Widget)NULL;
+  popup_controller_close_slot(&popup_ctrl, i);
 
   end_critical_section(&popup_message_dialog_lock, "popup_gui.c:popup_message_destroy_shell" );
 
@@ -111,36 +124,33 @@ static void popup_message_destroy_shell(Widget UNUSED(w),
 
 
 
-time_t popup_time_out_check_last = (time_t)0l;
-
 void popup_time_out_check(int curr_sec)
 {
   int i;
+  time_t now = (time_t)curr_sec;
 
   // Check only every two minutes or so
-  if (popup_time_out_check_last + 120 < curr_sec)
+  if (!popup_controller_should_run_timeout_check(&popup_ctrl, now))
   {
-    popup_time_out_check_last = curr_sec;
+    return;
+  }
+  popup_controller_mark_timeout_check(&popup_ctrl, now);
 
-    for (i=0; i<MAX_POPUPS; i++)
+  for (i=0; i<MAX_POPUPS; i++)
+  {
+    if (pw[i].popup_message_dialog != NULL
+        && popup_controller_slot_expired(&popup_ctrl, i, now))
     {
-      if (pw[i].popup_message_dialog!=NULL)
-      {
-        if ((sec_now()-pw[i].sec_opened)>MAX_POPUPS_TIME)
-        {
-          XtPopdown(pw[i].popup_message_dialog);
+      XtPopdown(pw[i].popup_message_dialog);
 
-          begin_critical_section(&popup_message_dialog_lock, "popup_gui.c:popup_time_out_check" );
+      begin_critical_section(&popup_message_dialog_lock, "popup_gui.c:popup_time_out_check" );
 
-          XtDestroyWidget(pw[i].popup_message_dialog);
-          pw[i].popup_message_dialog = (Widget)NULL;
-          pw[i].popup_message_data = (Widget)NULL;
+      XtDestroyWidget(pw[i].popup_message_dialog);
+      pw[i].popup_message_dialog = (Widget)NULL;
+      pw[i].popup_message_data = (Widget)NULL;
+      popup_controller_close_slot(&popup_ctrl, i);
 
-          end_critical_section(&popup_message_dialog_lock, "popup_gui.c:popup_time_out_check" );
-
-        }
-
-      }
+      end_critical_section(&popup_message_dialog_lock, "popup_gui.c:popup_time_out_check" );
     }
   }
 }
@@ -152,7 +162,7 @@ void popup_time_out_check(int curr_sec)
 void popup_message_always(char *banner, char *message)
 {
   XmString msg_str;
-  int j,i;
+  int i;
   Atom delw;
 
 
@@ -161,110 +171,106 @@ void popup_message_always(char *banner, char *message)
     return;
   }
 
-  if (banner == NULL || message == NULL)
+  if (!popup_controller_message_valid(banner, message))
   {
     return;
   }
 
-  i=0;
-  for (j=0; j<MAX_POPUPS; j++)
+  i = popup_controller_find_free_slot(&popup_ctrl);
+  if (i < 0)
   {
-    if (!pw[j].popup_message_dialog)
-    {
-      i=j;
-      j=MAX_POPUPS+1;
-    }
+    // No free slot — fall back to slot 0 to preserve legacy behavior
+    // (the original code defaulted to i=0 if MAX_POPUPS was full and
+    // then bailed out at the !pw[0].popup_message_dialog check below).
+    i = 0;
   }
 
   if(!pw[i].popup_message_dialog)
   {
-    if (banner!=NULL && message!=NULL)
-    {
+    begin_critical_section(&popup_message_dialog_lock, "popup_gui.c:popup_message" );
 
-      begin_critical_section(&popup_message_dialog_lock, "popup_gui.c:popup_message" );
-
-      pw[i].popup_message_dialog = XtVaCreatePopupShell(banner,
-                                   xmDialogShellWidgetClass, appshell,
-                                   XmNdeleteResponse, XmDESTROY,
-                                   XmNdefaultPosition, FALSE,
-                                   XmNtitleString,banner,
+    pw[i].popup_message_dialog = XtVaCreatePopupShell(banner,
+                                 xmDialogShellWidgetClass, appshell,
+                                 XmNdeleteResponse, XmDESTROY,
+                                 XmNdefaultPosition, FALSE,
+                                 XmNtitleString,banner,
 // An half-hearted attempt at fixing the problem where a popup
 // comes up extremely small.  Setting a minimum size for the popup.
-                                   XmNminWidth, 220,
-                                   XmNminHeight, 80,
-                                   XmNfontList, fontlist1,
-                                   NULL);
-
-      pw[i].pane = XtVaCreateWidget("popup_message pane",xmPanedWindowWidgetClass, pw[i].popup_message_dialog,
-                                    XmNbackground, colors[0xff],
-                                    NULL);
-
-      pw[i].scrollwindow = XtVaCreateManagedWidget("scrollwindow",
-                                                   xmScrolledWindowWidgetClass,
-                                                   pw[i].pane,
-                                                   XmNscrollingPolicy, XmAUTOMATIC,
-                                                   NULL);
-
-      pw[i].form =  XtVaCreateWidget("popup_message form",
-                                     xmFormWidgetClass,
-                                     pw[i].scrollwindow,
-                                     XmNfractionBase, 5,
-                                     XmNbackground, colors[0xff],
-                                     XmNautoUnmanage, FALSE,
-                                     XmNshadowThickness, 1,
-                                     NULL);
-
-      pw[i].popup_message_data = XtVaCreateManagedWidget("popup_message message",xmLabelWidgetClass, pw[i].form,
-                                 XmNtopAttachment, XmATTACH_FORM,
-                                 XmNtopOffset, 10,
-                                 XmNbottomAttachment, XmATTACH_NONE,
-                                 XmNleftAttachment, XmATTACH_FORM,
-                                 XmNleftOffset, 10,
-                                 XmNrightAttachment, XmATTACH_FORM,
-                                 XmNrightOffset, 10,
-                                 XmNbackground, colors[0xff],
+                                 XmNminWidth, 220,
+                                 XmNminHeight, 80,
                                  XmNfontList, fontlist1,
                                  NULL);
 
-      pw[i].button_close = XtVaCreateManagedWidget(langcode("UNIOP00003"),xmPushButtonGadgetClass, pw[i].form,
-                           XmNtopAttachment, XmATTACH_WIDGET,
-                           XmNtopWidget, pw[i].popup_message_data,
-                           XmNtopOffset, 10,
-                           XmNbottomAttachment, XmATTACH_FORM,
-                           XmNbottomOffset, 5,
-                           XmNleftAttachment, XmATTACH_POSITION,
-                           XmNleftPosition, 2,
-                           XmNrightAttachment, XmATTACH_POSITION,
-                           XmNrightPosition, 3,
-                           XmNbackground, colors[0xff],
-                           XmNfontList, fontlist1,
-                           NULL);
+    pw[i].pane = XtVaCreateWidget("popup_message pane",xmPanedWindowWidgetClass, pw[i].popup_message_dialog,
+                                  XmNbackground, colors[0xff],
+                                  NULL);
 
-      xastir_snprintf(pw[i].name,10,"%9d",i%1000);
+    pw[i].scrollwindow = XtVaCreateManagedWidget("scrollwindow",
+                                                 xmScrolledWindowWidgetClass,
+                                                 pw[i].pane,
+                                                 XmNscrollingPolicy, XmAUTOMATIC,
+                                                 NULL);
 
-      msg_str=XmStringCreateLtoR(message,XmFONTLIST_DEFAULT_TAG);
-      XtVaSetValues(pw[i].popup_message_data,XmNlabelString,msg_str,NULL);
-      XmStringFree(msg_str);
+    pw[i].form =  XtVaCreateWidget("popup_message form",
+                                   xmFormWidgetClass,
+                                   pw[i].scrollwindow,
+                                   XmNfractionBase, 5,
+                                   XmNbackground, colors[0xff],
+                                   XmNautoUnmanage, FALSE,
+                                   XmNshadowThickness, 1,
+                                   NULL);
 
-      XtAddCallback(pw[i].button_close, XmNactivateCallback, popup_message_destroy_shell,(XtPointer)pw[i].name);
+    pw[i].popup_message_data = XtVaCreateManagedWidget("popup_message message",xmLabelWidgetClass, pw[i].form,
+                               XmNtopAttachment, XmATTACH_FORM,
+                               XmNtopOffset, 10,
+                               XmNbottomAttachment, XmATTACH_NONE,
+                               XmNleftAttachment, XmATTACH_FORM,
+                               XmNleftOffset, 10,
+                               XmNrightAttachment, XmATTACH_FORM,
+                               XmNrightOffset, 10,
+                               XmNbackground, colors[0xff],
+                               XmNfontList, fontlist1,
+                               NULL);
 
-      delw = XmInternAtom(XtDisplay(pw[i].popup_message_dialog),"WM_DELETE_WINDOW", FALSE);
+    pw[i].button_close = XtVaCreateManagedWidget(langcode("UNIOP00003"),xmPushButtonGadgetClass, pw[i].form,
+                         XmNtopAttachment, XmATTACH_WIDGET,
+                         XmNtopWidget, pw[i].popup_message_data,
+                         XmNtopOffset, 10,
+                         XmNbottomAttachment, XmATTACH_FORM,
+                         XmNbottomOffset, 5,
+                         XmNleftAttachment, XmATTACH_POSITION,
+                         XmNleftPosition, 2,
+                         XmNrightAttachment, XmATTACH_POSITION,
+                         XmNrightPosition, 3,
+                         XmNbackground, colors[0xff],
+                         XmNfontList, fontlist1,
+                         NULL);
 
-      XmAddWMProtocolCallback(pw[i].popup_message_dialog, delw, popup_message_destroy_shell, (XtPointer)pw[i].name);
+    popup_controller_format_slot_name(i, pw[i].name, sizeof(pw[i].name));
 
-      pos_dialog(pw[i].popup_message_dialog);
+    msg_str=XmStringCreateLtoR(message,XmFONTLIST_DEFAULT_TAG);
+    XtVaSetValues(pw[i].popup_message_data,XmNlabelString,msg_str,NULL);
+    XmStringFree(msg_str);
 
-      XtManageChild(pw[i].form);
-      XtManageChild(pw[i].pane);
+    XtAddCallback(pw[i].button_close, XmNactivateCallback, popup_message_destroy_shell,(XtPointer)pw[i].name);
 
-      resize_dialog(pw[i].form, pw[i].popup_message_dialog);
+    delw = XmInternAtom(XtDisplay(pw[i].popup_message_dialog),"WM_DELETE_WINDOW", FALSE);
 
-      end_critical_section(&popup_message_dialog_lock, "popup_gui.c:popup_message" );
+    XmAddWMProtocolCallback(pw[i].popup_message_dialog, delw, popup_message_destroy_shell, (XtPointer)pw[i].name);
 
-      XtPopup(pw[i].popup_message_dialog,XtGrabNone);
+    pos_dialog(pw[i].popup_message_dialog);
 
-      pw[i].sec_opened=sec_now();
-    }
+    XtManageChild(pw[i].form);
+    XtManageChild(pw[i].pane);
+
+    resize_dialog(pw[i].form, pw[i].popup_message_dialog);
+
+    end_critical_section(&popup_message_dialog_lock, "popup_gui.c:popup_message" );
+
+    XtPopup(pw[i].popup_message_dialog,XtGrabNone);
+
+    pw[i].sec_opened = sec_now();
+    popup_controller_open_slot(&popup_ctrl, i, pw[i].sec_opened);
   }
 }
 
@@ -288,7 +294,7 @@ void popup_message(char *banner, char *message)
     return;
   }
 
-  if (banner == NULL || message == NULL)
+  if (!popup_controller_message_valid(banner, message))
   {
     return;
   }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,7 +4,7 @@
 TESTSUITE = $(srcdir)/testsuite
 AUTOTEST = $(AUTOM4TE) --language=autotest
 
-TESTSUITE_AT = testsuite.at interface_helpers.at db_tests.at object_utils_tests.at output_my_aprs_data_tests.at util_tests.at objects_tests.at
+TESTSUITE_AT = testsuite.at interface_helpers.at db_tests.at object_utils_tests.at output_my_aprs_data_tests.at util_tests.at objects_tests.at popup_controller_tests.at
 
 if HAVE_NOMINATIM
 TESTSUITE_AT += nominatim_tests.at
@@ -13,7 +13,7 @@ endif
 EXTRA_DIST = $(TESTSUITE_AT) $(TESTSUITE) package.m4 atlocal.in nominatim_tests.at
 
 # Test programs
-check_PROGRAMS = test_interface_helpers test_db test_object_utils test_output_my_aprs_data test_util test_objects
+check_PROGRAMS = test_interface_helpers test_db test_object_utils test_output_my_aprs_data test_util test_objects test_popup_controller
 
 # Conditionally add nominatim test program
 if HAVE_NOMINATIM
@@ -42,6 +42,12 @@ test_util_CPPFLAGS = $(CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir)/src -I$(top_bui
 
 test_objects_SOURCES = test_objects.c test_objects_stubs.c $(top_srcdir)/src/objects.c $(top_srcdir)/src/util.c $(top_srcdir)/src/object_utils.c $(top_srcdir)/src/db.c
 test_objects_CPPFLAGS = $(CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir)/src -I$(top_builddir)
+
+# Presentation/logic-separation migration: popup_controller is the kernel
+# extracted from popup_gui.c. It has no Xastir-side dependencies, so no
+# stubs file is needed.
+test_popup_controller_SOURCES = test_popup_controller.c $(top_srcdir)/src/popup_controller.c
+test_popup_controller_CPPFLAGS = $(CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir)/src -I$(top_builddir)
 
 # Nominatim tests (conditional on HAVE_NOMINATIM)
 if HAVE_NOMINATIM

--- a/tests/popup_controller_tests.at
+++ b/tests/popup_controller_tests.at
@@ -1,0 +1,70 @@
+# Autotest tests for popup_controller.c
+# Covers the presentation-free kernel extracted from popup_gui.c.
+
+AT_BANNER([Popup Controller])
+
+AT_SETUP([popup_controller_init: zeroes state])
+AT_KEYWORDS([popup popup_controller init])
+AT_CHECK(["$abs_top_builddir/tests/test_popup_controller" init_zeroes_state], [0], [PASS: popup_controller_init: zeroes state
+])
+AT_CLEANUP
+
+AT_SETUP([popup_controller_find_free_slot: empty/partial/full])
+AT_KEYWORDS([popup popup_controller find_free_slot])
+AT_CHECK(["$abs_top_builddir/tests/test_popup_controller" find_free_slot_empty_partial_full], [0], [PASS: popup_controller_find_free_slot: empty/partial/full
+])
+AT_CLEANUP
+
+AT_SETUP([popup_controller_open_slot: marks slot active])
+AT_KEYWORDS([popup popup_controller open_slot])
+AT_CHECK(["$abs_top_builddir/tests/test_popup_controller" open_slot_marks_active], [0], [PASS: popup_controller_open_slot: marks slot active
+])
+AT_CLEANUP
+
+AT_SETUP([popup_controller_close_slot: clears state])
+AT_KEYWORDS([popup popup_controller close_slot])
+AT_CHECK(["$abs_top_builddir/tests/test_popup_controller" close_slot_clears_state], [0], [PASS: popup_controller_close_slot: clears state
+])
+AT_CLEANUP
+
+AT_SETUP([popup_controller_clear: resets all slots])
+AT_KEYWORDS([popup popup_controller clear])
+AT_CHECK(["$abs_top_builddir/tests/test_popup_controller" clear_resets_all_slots], [0], [PASS: popup_controller_clear: resets all slots
+])
+AT_CLEANUP
+
+AT_SETUP([popup_controller_should_run_timeout_check: within interval])
+AT_KEYWORDS([popup popup_controller timeout])
+AT_CHECK(["$abs_top_builddir/tests/test_popup_controller" timeout_check_within_interval], [0], [PASS: popup_controller_should_run_timeout_check: within interval -> 0
+])
+AT_CLEANUP
+
+AT_SETUP([popup_controller_should_run_timeout_check: after interval])
+AT_KEYWORDS([popup popup_controller timeout])
+AT_CHECK(["$abs_top_builddir/tests/test_popup_controller" timeout_check_after_interval], [0], [PASS: popup_controller_should_run_timeout_check: after interval -> 1
+])
+AT_CLEANUP
+
+AT_SETUP([popup_controller_slot_expired: decisions correct])
+AT_KEYWORDS([popup popup_controller slot_expired])
+AT_CHECK(["$abs_top_builddir/tests/test_popup_controller" slot_expired_decision], [0], [PASS: popup_controller_slot_expired: decisions correct
+])
+AT_CLEANUP
+
+AT_SETUP([popup_controller_message_valid: NULL handling])
+AT_KEYWORDS([popup popup_controller message_valid])
+AT_CHECK(["$abs_top_builddir/tests/test_popup_controller" message_valid_combinations], [0], [PASS: popup_controller_message_valid: NULL handling correct
+])
+AT_CLEANUP
+
+AT_SETUP([popup_controller_format_slot_name: format and wrap])
+AT_KEYWORDS([popup popup_controller format_slot_name])
+AT_CHECK(["$abs_top_builddir/tests/test_popup_controller" format_slot_name_basic_and_wrap], [0], [PASS: popup_controller_format_slot_name: format and wrap correct
+])
+AT_CLEANUP
+
+AT_SETUP([popup_controller: defensive checks don't crash])
+AT_KEYWORDS([popup popup_controller defensive])
+AT_CHECK(["$abs_top_builddir/tests/test_popup_controller" defensive_null_and_oob], [0], [PASS: popup_controller: defensive checks don't crash
+])
+AT_CLEANUP

--- a/tests/test_popup_controller.c
+++ b/tests/test_popup_controller.c
@@ -1,0 +1,325 @@
+/*
+ *
+ * XASTIR, Amateur Station Tracking and Information Reporting
+ * Copyright (C) 2025-2026 The Xastir Group
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * Look at the README for more information on the program.
+ */
+
+/*
+ * Unit tests for popup_controller.c — the presentation-free kernel
+ * extracted from popup_gui.c.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tests/test_framework.h"
+
+#include "popup_controller.h"
+
+
+int test_init_zeroes_state(void)
+{
+  popup_controller_t pc;
+  int i;
+
+  /* fill with garbage so init has something to clear */
+  memset(&pc, 0x5a, sizeof(pc));
+
+  popup_controller_init(&pc);
+
+  for (i = 0; i < POPUP_MAX_SLOTS; i++)
+  {
+    TEST_ASSERT(pc.slots[i].active == 0, "all slots inactive after init");
+    TEST_ASSERT(pc.slots[i].sec_opened == 0, "all slot timestamps cleared after init");
+  }
+  TEST_ASSERT(pc.last_timeout_check == 0, "last_timeout_check zeroed after init");
+
+  TEST_PASS("popup_controller_init: zeroes state");
+}
+
+int test_find_free_slot_empty_partial_full(void)
+{
+  popup_controller_t pc;
+  int i;
+
+  popup_controller_init(&pc);
+
+  TEST_ASSERT(popup_controller_find_free_slot(&pc) == 0,
+              "empty controller hands out slot 0 first");
+
+  /* occupy slots 0..2 — find_free should return 3 */
+  popup_controller_open_slot(&pc, 0, 1000);
+  popup_controller_open_slot(&pc, 1, 1000);
+  popup_controller_open_slot(&pc, 2, 1000);
+  TEST_ASSERT(popup_controller_find_free_slot(&pc) == 3,
+              "first free slot when 0..2 are taken is 3");
+
+  /* fill everything */
+  for (i = 0; i < POPUP_MAX_SLOTS; i++)
+  {
+    popup_controller_open_slot(&pc, i, 1000);
+  }
+  TEST_ASSERT(popup_controller_find_free_slot(&pc) == -1,
+              "full controller returns -1");
+
+  TEST_PASS("popup_controller_find_free_slot: empty/partial/full");
+}
+
+int test_open_slot_marks_active(void)
+{
+  popup_controller_t pc;
+
+  popup_controller_init(&pc);
+
+  TEST_ASSERT(popup_controller_slot_is_active(&pc, 4) == 0,
+              "slot 4 is inactive before open");
+
+  popup_controller_open_slot(&pc, 4, 12345);
+
+  TEST_ASSERT(popup_controller_slot_is_active(&pc, 4) == 1,
+              "slot 4 active after open");
+  TEST_ASSERT(pc.slots[4].sec_opened == 12345,
+              "slot 4 records sec_opened");
+  TEST_ASSERT(popup_controller_slot_is_active(&pc, 3) == 0,
+              "neighbouring slot 3 untouched");
+  TEST_ASSERT(popup_controller_slot_is_active(&pc, 5) == 0,
+              "neighbouring slot 5 untouched");
+
+  TEST_PASS("popup_controller_open_slot: marks slot active");
+}
+
+int test_close_slot_clears_state(void)
+{
+  popup_controller_t pc;
+
+  popup_controller_init(&pc);
+  popup_controller_open_slot(&pc, 7, 99999);
+  TEST_ASSERT(popup_controller_slot_is_active(&pc, 7) == 1, "precondition: slot 7 active");
+
+  popup_controller_close_slot(&pc, 7);
+
+  TEST_ASSERT(popup_controller_slot_is_active(&pc, 7) == 0,
+              "slot 7 inactive after close");
+  TEST_ASSERT(pc.slots[7].sec_opened == 0,
+              "sec_opened cleared on close");
+
+  TEST_PASS("popup_controller_close_slot: clears state");
+}
+
+int test_clear_resets_all_slots(void)
+{
+  popup_controller_t pc;
+  int i;
+
+  popup_controller_init(&pc);
+  for (i = 0; i < POPUP_MAX_SLOTS; i++)
+  {
+    popup_controller_open_slot(&pc, i, 5000 + i);
+  }
+  pc.last_timeout_check = 9999;
+
+  popup_controller_clear(&pc);
+
+  for (i = 0; i < POPUP_MAX_SLOTS; i++)
+  {
+    TEST_ASSERT(pc.slots[i].active == 0, "slot inactive after clear");
+    TEST_ASSERT(pc.slots[i].sec_opened == 0, "slot timestamp cleared after clear");
+  }
+  /* clear() intentionally does NOT touch last_timeout_check — that's a sweep
+     concern, not a slot concern. Lock that contract in. */
+  TEST_ASSERT(pc.last_timeout_check == 9999,
+              "clear() does not reset the timeout-check timestamp");
+
+  TEST_PASS("popup_controller_clear: resets all slots");
+}
+
+int test_timeout_check_within_interval(void)
+{
+  popup_controller_t pc;
+
+  popup_controller_init(&pc);
+  popup_controller_mark_timeout_check(&pc, 1000);
+
+  TEST_ASSERT(popup_controller_should_run_timeout_check(&pc, 1000) == 0,
+              "no sweep at exact same time");
+  TEST_ASSERT(popup_controller_should_run_timeout_check(&pc, 1000 + POPUP_TIMEOUT_CHECK_INTERVAL) == 0,
+              "no sweep exactly at the boundary");
+
+  TEST_PASS("popup_controller_should_run_timeout_check: within interval -> 0");
+}
+
+int test_timeout_check_after_interval(void)
+{
+  popup_controller_t pc;
+
+  popup_controller_init(&pc);
+  popup_controller_mark_timeout_check(&pc, 1000);
+
+  TEST_ASSERT(popup_controller_should_run_timeout_check(&pc, 1000 + POPUP_TIMEOUT_CHECK_INTERVAL + 1) == 1,
+              "sweep one second past the interval");
+
+  popup_controller_mark_timeout_check(&pc, 5000);
+  TEST_ASSERT(pc.last_timeout_check == 5000, "mark_timeout_check stores the new time");
+
+  TEST_PASS("popup_controller_should_run_timeout_check: after interval -> 1");
+}
+
+int test_slot_expired_decision(void)
+{
+  popup_controller_t pc;
+
+  popup_controller_init(&pc);
+
+  /* inactive slot: never expired */
+  TEST_ASSERT(popup_controller_slot_expired(&pc, 0, 1000000) == 0,
+              "inactive slot is never expired");
+
+  /* young slot */
+  popup_controller_open_slot(&pc, 1, 1000);
+  TEST_ASSERT(popup_controller_slot_expired(&pc, 1, 1000 + POPUP_MAX_AGE_SECONDS) == 0,
+              "slot at exactly max age is not yet expired");
+
+  /* old slot */
+  TEST_ASSERT(popup_controller_slot_expired(&pc, 1, 1000 + POPUP_MAX_AGE_SECONDS + 1) == 1,
+              "slot one second past max age is expired");
+
+  TEST_PASS("popup_controller_slot_expired: decisions correct");
+}
+
+int test_message_valid_combinations(void)
+{
+  TEST_ASSERT(popup_controller_message_valid("banner", "msg") == 1, "both present -> 1");
+  TEST_ASSERT(popup_controller_message_valid(NULL,     "msg") == 0, "null banner -> 0");
+  TEST_ASSERT(popup_controller_message_valid("banner", NULL)  == 0, "null message -> 0");
+  TEST_ASSERT(popup_controller_message_valid(NULL,     NULL)  == 0, "both null -> 0");
+
+  /* empty strings are still valid — original code only NULL-checked */
+  TEST_ASSERT(popup_controller_message_valid("", "") == 1, "empty strings still valid");
+
+  TEST_PASS("popup_controller_message_valid: NULL handling correct");
+}
+
+int test_format_slot_name_basic_and_wrap(void)
+{
+  char buf[POPUP_SLOT_NAME_SIZE];
+
+  popup_controller_format_slot_name(5, buf, sizeof(buf));
+  TEST_ASSERT_STR_EQ("        5", buf, "single-digit slot formatted as right-aligned 9-wide");
+
+  popup_controller_format_slot_name(123, buf, sizeof(buf));
+  TEST_ASSERT_STR_EQ("      123", buf, "three-digit slot formatted correctly");
+
+  /* original code does idx % 1000 to keep the result in 9 chars */
+  popup_controller_format_slot_name(1234, buf, sizeof(buf));
+  TEST_ASSERT_STR_EQ("      234", buf, "wrap by mod 1000");
+
+  TEST_PASS("popup_controller_format_slot_name: format and wrap correct");
+}
+
+int test_defensive_null_and_oob(void)
+{
+  popup_controller_t pc;
+  char buf[POPUP_SLOT_NAME_SIZE];
+
+  popup_controller_init(&pc);
+
+  /* NULL controller — must not crash, sane returns */
+  popup_controller_init(NULL);
+  popup_controller_clear(NULL);
+  TEST_ASSERT(popup_controller_find_free_slot(NULL) == -1, "NULL pc -> no slot");
+  TEST_ASSERT(popup_controller_slot_is_active(NULL, 0) == 0, "NULL pc -> not active");
+  popup_controller_open_slot(NULL, 0, 0);   /* must not crash */
+  popup_controller_close_slot(NULL, 0);     /* must not crash */
+  TEST_ASSERT(popup_controller_should_run_timeout_check(NULL, 0) == 0,
+              "NULL pc -> never sweep");
+  popup_controller_mark_timeout_check(NULL, 0);   /* must not crash */
+  TEST_ASSERT(popup_controller_slot_expired(NULL, 0, 0) == 0,
+              "NULL pc -> not expired");
+
+  /* Out-of-range index — must not crash, sane returns */
+  TEST_ASSERT(popup_controller_slot_is_active(&pc, -1) == 0, "negative idx -> not active");
+  TEST_ASSERT(popup_controller_slot_is_active(&pc, POPUP_MAX_SLOTS) == 0,
+              "idx == count -> not active");
+  popup_controller_open_slot(&pc, -1, 0);                /* must not crash */
+  popup_controller_open_slot(&pc, POPUP_MAX_SLOTS, 0);   /* must not crash */
+  popup_controller_close_slot(&pc, -1);                  /* must not crash */
+  popup_controller_close_slot(&pc, POPUP_MAX_SLOTS);     /* must not crash */
+  TEST_ASSERT(popup_controller_slot_expired(&pc, -1, 0) == 0, "neg idx -> not expired");
+  TEST_ASSERT(popup_controller_slot_expired(&pc, POPUP_MAX_SLOTS, 0) == 0,
+              "oob idx -> not expired");
+
+  /* format_slot_name: NULL out and zero size are no-ops */
+  popup_controller_format_slot_name(0, NULL, 10);  /* must not crash */
+  buf[0] = 'X';
+  popup_controller_format_slot_name(0, buf, 0);    /* zero size: no write */
+  TEST_ASSERT(buf[0] == 'X', "zero-size buffer untouched");
+
+  TEST_PASS("popup_controller: defensive checks don't crash");
+}
+
+
+/* Test runner */
+typedef struct
+{
+  const char *name;
+  int (*func)(void);
+} test_case_t;
+
+int main(int argc, char *argv[])
+{
+  test_case_t tests[] =
+  {
+    {"init_zeroes_state",                   test_init_zeroes_state},
+    {"find_free_slot_empty_partial_full",   test_find_free_slot_empty_partial_full},
+    {"open_slot_marks_active",              test_open_slot_marks_active},
+    {"close_slot_clears_state",             test_close_slot_clears_state},
+    {"clear_resets_all_slots",              test_clear_resets_all_slots},
+    {"timeout_check_within_interval",       test_timeout_check_within_interval},
+    {"timeout_check_after_interval",        test_timeout_check_after_interval},
+    {"slot_expired_decision",               test_slot_expired_decision},
+    {"message_valid_combinations",          test_message_valid_combinations},
+    {"format_slot_name_basic_and_wrap",     test_format_slot_name_basic_and_wrap},
+    {"defensive_null_and_oob",              test_defensive_null_and_oob},
+    {NULL, NULL}
+  };
+
+  if (argc < 2)
+  {
+    fprintf(stderr, "Usage: %s <test name>\n", argv[0]);
+    fprintf(stderr, "Available tests:\n");
+    for (int i = 0; tests[i].name != NULL; i++)
+    {
+      fprintf(stderr, "  %s\n", tests[i].name);
+    }
+    return 1;
+  }
+
+  const char *test_name = argv[1];
+  for (int i = 0; tests[i].name != NULL; i++)
+  {
+    if (strcmp(test_name, tests[i].name) == 0)
+    {
+      return tests[i].func();
+    }
+  }
+
+  fprintf(stderr, "Unknown test: %s\n", test_name);
+  return 1;
+}

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -24,6 +24,9 @@ m4_include([util_tests.at])
 # Include basic objects function tests
 m4_include([objects_tests.at])
 
+# Include popup controller tests (presentation/logic-separation migration)
+m4_include([popup_controller_tests.at])
+
 # Include nominatim geocoding tests (conditionally compiled if HAVE_NOMINATIM)
 m4_ifdef([HAVE_NOMINATIM], [
 m4_include([nominatim_tests.at])


### PR DESCRIPTION
First pass of the *_gui.c controller-extraction effort. Lifts the business logic of the popup-message dialogs out of Motif callbacks into a self-contained controller that can be unit-tested without linking against Xt/Xm.

Adds src/popup_controller.{h,c} (80 + 147 LOC). Retires the file-scope global popup_time_out_check_last by folding it into popup_controller_t.last_timeout_check. The Widget bag (pw[]) and the popup_message_dialog_lock mutex stay in popup_gui.c -- they are Motif/threading concerns out of scope for this pass. Dead code (pwb, written by clear_popup_message_windows but never read) is also left untouched.

Behavior preserved: when all popup slots are full, the new popup is still silently dropped (legacy i=0 fallback kept in popup_message_always). popup_ID_message (rotated ATV ID rendering) is pure X11 graphics and is not extracted.

Tests: tests/test_popup_controller.c (11 cases). The controller has zero Xastir-side dependencies, so the test binary needs no stubs file -- first validation of the "self-contained controller header" rule. Full suite: 241/241 ok.

Note for reviewers: slot occupancy is now tracked in two places (Widget != NULL on the GUI side; controller.slots[i].active in the controller). Kept lockstep at the four mutation sites. Candidate for unification once more dialogs are migrated.

Part of the *_gui.c controller-extraction effort — see umbrella
issue #TBD (replace with the GitHub issue link before opening).
This is the first PR in a 9-PR stack; review independently or
follow the stack as `de-spaghetti-1` … `de-spaghetti-9`.

### Why

The popup-message dialogs in `src/popup_gui.c` mix Motif callback
plumbing with the small amount of state and decision logic that
governs when a popup should appear, which slot it occupies, and
when it should time out. That logic can't currently be unit-tested
because it's locked inside Xt/Xm callbacks. This PR is the first
shakedown of the pattern: lift the logic kernel out into a
self-contained controller so it can be tested directly.

### What changes

- New `src/popup_controller.{h,c}` (80 + 147 LOC). Pure standard C,
  no `<Xm/*.h>` includes, no Xastir-side dependencies.
- `popup_gui.c` callbacks are thinned to widget-marshalling only;
  decisions go through the controller.
- File-scope global `popup_time_out_check_last` retired (folded
  into `popup_controller_t.last_timeout_check`).
- New `tests/test_popup_controller.c` (11 cases) wired into the
  Autotest harness via `tests/popup_controller_tests.at`.
- Full test suite: 241/241 passing.

### What is intentionally not changed

- The Widget bag `pw[MAX_POPUPS]` and `popup_message_dialog_lock`
  mutex stay in `popup_gui.c` (Motif/threading concerns, out of
  scope for the logic split).
- `pwb` (Popup_Window) is dead code — written by
  `clear_popup_message_windows`, never read. Left untouched here.
- `popup_ID_message` (rotated ATV ID rendering) is pure X11
  graphics with no logic kernel worth extracting.

### Behavior preservation

- "All slots full" still silently drops the new popup (the legacy
  `i=0` fallback in `popup_message_always` is preserved).
- All visible popup behavior is unchanged.

### Reviewer hints

- The interesting file is `src/popup_controller.h` — the struct
  defines exactly what state the popup logic owns.
- One known asymmetry: slot occupancy is now tracked in two places
  (`Widget != NULL` on the GUI side, `slots[i].active` in the
  controller). They are kept lockstep at the four mutation sites.
  Candidate for unification once a few more dialogs are migrated.

### Tests

```
./bootstrap.sh && ./configure && make && make check
```

Should report 241/241 ok.