### PR TITLE
Improve spanish translations

### DIFF
--- a/config/language-Spanish.sys
+++ b/config/language-Spanish.sys
@@ -1332,17 +1332,17 @@ CADPUD014|Doble guion||
 #
 # Format strings for map metadata in top border
 #"XASTIR Map of <utm_coord> (upper left) to <utm_coord> (lower right).  UTM <grid_size> m grid, <wgs84> datum. ",
-MDATA001|XASTIR Map of %s (upper left) to %s (lower right).  UTM %d m grid, %s datum. ||
+MDATA001|Mapa XASTIR de %s (sup. izq.) a %s (inf. der.).  Cuadrícula UTM de %d m, datum %s. ||
 #
 #
 # Format strings for map metadata in top border
 #"XASTIR Map of <utm_coord> (upper left) to <utm_coord> (lower right).  UTM <grid_size> m grid, <wgs84> datum. ",
-MDATA002|XASTIR Map of %s (upper left) to %s %s (lower right).  Lat/Long grid, %s datum.||
+MDATA002|Mapa XASTIR de %s (sup. izq.) a %s %s (inf. der.).  Cuadrícula Lat/Long, datum %s.||
 #
 #
 # Format strings for map metadata in top border
 #"XASTIR Map of <utm_coord> (upper left) to <utm_coord> (lower right).  UTM <grid_size> m grid, <wgs84> datum. ",
-MDATA003|XASTIR Map of %s (upper left) to %s (lower right).  UTM zones, %s datum.||
+MDATA003|Mapa XASTIR de %s (sup. izq.) a %s (inf. der.).  Zonas UTM, datum %s.||
 #
 # Text interpretation of integer values of database type and schema type
 # used for sql database configuration in interface_gui.c

--- a/config/language-Spanish.sys
+++ b/config/language-Spanish.sys
@@ -67,7 +67,7 @@ PULDNMP001|Seleccionar Mapas|M|
 PULDNMP012|Ir a una ubicación|S|
 PULDNMP014|Localice rasgo del Mapa|L|
 PULDNMP016|Desactivar zoom/paneo/inicio rápido||
-PULDNMP013|Desactive todos los Mapas||
+PULDNMP013|Desactivar todos los Mapas||
 PULDNMP002|Activar Auto Mapas||
 PULDNMP003|Rejillas sobre Mapa||
 PULDNMP004|Niveles de Mapas||
@@ -198,7 +198,7 @@ PULDNDP020|- Mostrar Pot/Ganancia Móviles||
 PULDNDP023|Mostrar atributos DF||
 PULDNDP123|Mostrar ancho de haz DF||
 PULDNDP223|Mostrar rumbo DF||
-PULDNDP035|Activar Conteo-Muerto||
+PULDNDP035|Activar navegación estimada||
 PULDNDP036|- Mostrar Arco||
 PULDNDP037|- Mostrar Curso||
 PULDNDP038|- Mostrar Símbolo||
@@ -216,16 +216,16 @@ PULDNDP055|Exportar todo|E|
 PULDNDP056|Exportar a archivo KML||
 #
 # Inglesa/Métrica
-PULDNUT001|Activar Unidades Inglesa||
+PULDNUT001|Activar Unidades Imperiales||
 PULDNUT002|Métrica||
 #
 # Menú de Mensajes
 PULDNMG001|Enviar Mensaje A|E|
 PULDNMG002|Abrir Mensajes Grupos|G|
 PULDNMG003|Anular todos los mensajes salientes|B|
-PULDQUS001|Pregunta General a Estaciones|P|
-PULDQUS002|Pregunta a Estaciones I-Gate|I|
-PULDQUS003|Pregunta a Estaciones WX|W|
+PULDQUS001|Consulta general de estaciones|C|
+PULDQUS002|Consulta de estaciones I-Gate|I|
+PULDQUS003|Consulta de estaciones WX|W|
 PULDNMG004|Fijar Mensaje en Contestación Automática|F|
 PULDNMG005|Activar Auto contestación de Mensaje|A|
 PULDNMG006|Satélite Modo de Reconocimiento|M|
@@ -233,11 +233,11 @@ PULDNMG007|Mostrar mensajes pendientes|P|
 #
 # Menú de Interfaces
 PULDNTNT04|Control de interfaces||
-PULDNTNT03|Desactivar Transmitir: TODOS||
+PULDNTNT03|Desactivar Transmitir: TODO||
 PULDNTNT05|Desactivar Transmitir: Mi Posición||
 PULDNTNT06|Desactivar Transmitir: Objetos/Artículos||
 PULDNTNT11|Activar puertos de servidor||
-PULDNTNT01|Transmitir Ahora..!|T|
+PULDNTNT01|¡Transmitir Ahora..!|T|
 PULDNTNT07|Obtener track del GPS|F|
 PULDNTNT08|Obtener rutas del GPS|R|
 PULDNTNT09|Obtener waypoints del GPS|W|
@@ -256,7 +256,7 @@ POPUPMA00c|Centro||
 POPUPMA015|Info de estación||
 POPUPMA002|Acercar|A|
 POPUPMA003|Alejar|l|
-POPUPMA004|Nivel de Enfoque|N|
+POPUPMA004|Nivel de Zoom|N|
 POPUPMA005|Nivel 1|1|
 POPUPMA006|Nivel 16|6|
 POPUPMA007|Nivel 64|4|
@@ -275,7 +275,7 @@ POPUPMA014|Paneo derecha|r|
 POPUPMA020|Medida||
 POPUPMA021|Movimiento||
 POPUPMA022|RastréeMe||
-POPUPMA023|Modificadores Encontrado!||
+POPUPMA023|¡Modificadores Encontrado!||
 POPUPMA024|Apague Caps Lock/Num Lock/Scroll Lock y otros modificadores||
 POPUPMA026|Centrar y zoom||
 POPUPMA027|  Latitud||
@@ -312,8 +312,8 @@ POPUPMA055|mi||
 BBARZM0001|Foco %s||
 BBARZM0002|Foco %s Tr||
 BBARSTH001|%d/%d Estaciones||
-BBARSTA000|%-9s Nuevo objeto!||
-BBARSTA001|%-9s Nueva estación!||
+BBARSTA000|%-9s ¡Nuevo objeto!||
+BBARSTA001|%-9s ¡Nueva estación!||
 BBARSTA002|%s||
 BBARSTA003|Cargando mapas...||
 BBARSTA004|Mapas cargados...||
@@ -323,23 +323,23 @@ BBARSTA007|El uso de Auto Mapas, es ON||
 BBARSTA008|El uso de Auto Mapas, es OFF||
 BBARSTA009|Los Niveles del Mapa están ON||
 BBARSTA010|Los Niveles del Mapa están OFF||
-BBARSTA011|Auto contestación de Mensaje es OFF!||
+BBARSTA011|¡Auto contestación de Mensaje es OFF!||
 BBARSTA012|Archivo terminado..||
 BBARSTA013|Abriendo Puerto GPS||
 BBARSTA014|Cerrando Puerto GPS||
 BBARSTA015|Obtenido GPS RMC Cordón||
 BBARSTA016|Obtenido GPS GGA Cordón||
 BBARSTA017|Red desconectada del Servidor||
-BBARSTA018|Conexión a Red tiempo vencido!||
+BBARSTA018|¡Conexión a Red tiempo vencido!||
 BBARSTA019|Buscando Servidor %s||
 BBARSTA020|Conectado al %s||
-BBARSTA021|Fracaso en conexión de la Red!||
-BBARSTA022|Podría no atar el sócalo!||
-BBARSTA023|No IP para el Servidor!||
-BBARSTA024|No Servidor Especificado||
+BBARSTA021|¡Fallo en conexion a la red!||
+BBARSTA022|¡No se pudo abrir puerto!||
+BBARSTA023|¡IP del servidor no especificada!||
+BBARSTA024|Servidor no especificado||
 BBARSTA025|Servidor encontrado, Conectando %d||
 BBARSTA026|Esperando por datos del GPS vía HSP..||
-BBARSTA027|Limpiando el HSP datos obtenido del TNC..||
+BBARSTA027|Limpiando datos HSP del TNC..||
 BBARSTA028|Cargando %s||
 BBARSTA029|Abriendo Puerto WX||
 BBARSTA030|Cerrando Puerto WX||
@@ -380,8 +380,8 @@ WPUPLSP001|Localizar estación||
 WPUPLSP002|Localizar Indicativo||
 WPUPLSP003|Distinguir mayús./minús.|S|
 WPUPLSP004|Coincidencia exacta|E|
-WPUPLSP005|Localizar ahora!|A|
-WPUPLSP006|Localizar Emergencia!||
+WPUPLSP005|¡Localizar ahora!|A|
+WPUPLSP006|¡Localizar Emergencia!||
 WPUPLSP007|Consulta FCC/RAC||
 #
 # Configurar predefinidos
@@ -406,10 +406,10 @@ WPUPCFD018|Estación Móvil c/Fecha-hora Zúlu|Z|
 WPUPCFD019|Estación Móvil c/Horas-segundos Zúlu|u|
 WPUPCFD021|Posición de la estación c/Tiempo|T|
 WPUPCFD022|Posición de la estación, fecha-hora Zulu, y Tiempo|f|
-WPUPCFD023|Transmitir datos WX en Raw?||
-WPUPCFD024|Comprimir datos objeto/artículo cuando transmita?||
-WPUPCFD025|Activar Red Alternada?|A|
-WPUPCFD026|Enviar reportes de posición en qué intérvalos?||
+WPUPCFD023|¿Transmitir datos WX en Raw?||
+WPUPCFD024|¿Comprimir datos objeto/artículo cuando transmita?||
+WPUPCFD025|¿Activar Red Alternada?|A|
+WPUPCFD026|¿Enviar reportes de posición en qué intervalos?||
 WPUPCFD027|Mostrar boletines nuevos||
 WPUPCFD028|Avisar si hay teclas Modificadora||
 WPUPCFD029|Ver boletines de distancia cero||
@@ -420,19 +420,19 @@ WPUPCFD033|ALTNET:||
 #
 # Menu "Configurar - Cronómetro"
 WPUPCFTM01|Configurar Cronómetro||
-WPUPCFTM02|TX Posición Intérvalo (minutos)||
-WPUPCFTM03|Desvanecimiento de la Estación (minutos)||
-WPUPCFTM04|Objeto/Artículo TX Max Intérvalo (minutos)||
-WPUPCFTM05|Limpiar Tiempo de la Estación (horas)||
-WPUPCFTM06|Chequeo Intérvalo del GPS (segundos)||
-WPUPCFTM07|Borrar Tiempo de la Estación (días)||
-WPUPCFTM08|Descanso Conteo-Muerto (minutos)||
+WPUPCFTM02|Intervalo TX de posición (min)||
+WPUPCFTM03|Desvanecer estación luego de (minutos)||
+WPUPCFTM04|Intervalo TX máx de Objeto/Artículo (min)||
+WPUPCFTM05|Limpiar estación luego de (horas)||
+WPUPCFTM06|Intervalo de comprobación del GPS (seg)||
+WPUPCFTM07|Borrar estación luego de (días)||
+WPUPCFTM08|Tiempo de espera de navegación estimada (minutos)||
 WPUPCFTM09|Retardo serial entre caracteres (ms)||
-WPUPCFTM10|Nuevo Tiempo Rastro (min)||
-WPUPCFTM11|Nuevo Interval Rastro (grados)||
+WPUPCFTM10|Tiempo para nuevo rastro (min)||
+WPUPCFTM11|Intervalo para nuevo rastro (grados)||
 WPUPCFTM12|Intervalo RINO -> Objetos (min), 0 = desactivado||
 WPUPCFTM13|Intervalo de instantáneas (min)||
-WPUPCFTM14|Tiempo de fantasma/borrado de aeronaves (min), 0 = desactivado||
+WPUPCFTM14|Tiempo de desvanecimiento/borrado de aeronaves (min), 0 = desactivado||
 #
 # Configurar Sistema de Coordenada"
 WPUPCFC001|Configurar sistema de coordenadas||
@@ -447,31 +447,31 @@ WPUPCFC008|UTM con zonas especiales||
 # Configurar GPS
 WPUPCFG001|Configurar GPS||
 WPUPCFG003|Puerto exclusivo de GPS||
-WPUPCFG002|Usar Posición GPS?||
+WPUPCFG002|¿Usar Posición GPS?||
 WPUPCFG004|opciones del GPS||
 WPUPCFG005|GPS Exclusivo||
 WPUPCFG006|TNC conectado a GPS (Cable HSP)||
 WPUPCFG007|TNC conectado a GPS usando CTL-E||
 WPUPCFG008|GPS tiempo (Muestreo cada)||
-WPUPCFG009|5 sec||
-WPUPCFG010|15 sec||
-WPUPCFG011|30 sec||
+WPUPCFG009|5 seg.||
+WPUPCFG010|15 seg.||
+WPUPCFG011|30 seg.||
 WPUPCFG012|1 minuto||
 WPUPCFG013|2 minutos||
 WPUPCFG014|5 minutos||
 WPUPCFG015|10 minutos||
-WPUPCFG016|Red conectada al GPS||
+WPUPCFG016|GPS conectado por red||
 WPUPCFG017|Servidor GPSD||
 WPUPCFG018|Puerto GPSD||
 WPUPCFG019|Red GPS vía GPSD||
-WPUPCFG020|Reconectar en fallo?||
+WPUPCFG020|¿Reconectar en fallo?||
 WPUPCFG021|Red Conectada a WX||
 WPUPCFG022|Servidor WX||
 WPUPCFG023|Puerto WX||
 #
 # Configurar TNC (baudio también son para WX)
 WPUPCFT001|Configurar TNC||
-WPUPCFT002|Usar TNC?||
+WPUPCFT002|¿Usar TNC?||
 WPUPCFT003|Puerto TNC||
 WPUPCFT004|Velocidad del Puerto||
 WPUPCFT005|300 bps||
@@ -511,9 +511,9 @@ WPUPCFT038|TxTail (10 ms unidades)||
 WPUPCFT039|Dúplex completo||
 WPUPCFT040|Configurar un Multi-Port KISS TNC||
 WPUPCFT041|Puerto de radio||
-WPUPCFT042|Dubious UNPROTO Path!||
+WPUPCFT042|¡Ruta UNPROTO dudosa!||
 WPUPCFT043|Considere una ruta más corta, como WIDE2-2 o WIDE1-1,WIDE2-2||
-WPUPCFT044|Dubious IGATE Path!||
+WPUPCFT044|¡Ruta IGATE dudosa!||
 WPUPCFT045|Transmitiendo con ruta UNPROTO dudosa||
 WPUPCFT046|Transmitiendo con ruta IGATE dudosa||
 WPUPCFT047|Inicializar modo KISS al arrancar||
@@ -619,7 +619,7 @@ WPUPCFI005|Servidor1||
 WPUPCFI006|Puerto1||
 WPUPCFI007|Servidor2||
 WPUPCFI008|Puerto2||
-WPUPCFI009|Palabra de Paso||
+WPUPCFI009|Código de acceso||
 WPUPCFI010|Dejar en blanco si nada||
 WPUPCFI011|¿Reconectar en fallo de la RED?||
 WPUPCFI012|¿Correr como un I-Gate?||
@@ -638,9 +638,9 @@ WPUPCFID07|Servidor2||
 WPUPCFID08|Puerto2||
 WPUPCFID09|Palabra de Paso||
 WPUPCFID10|Dejar en blanco si nada||
-WPUPCFID11|Reconectar en fallo de la RED?||
-WPUPCFID12|Correr como un I-Gate?||
-WPUPCFID13|Difundir mensajes vía TNC cuando un I-Gate?||
+WPUPCFID11|¿Reconectar en fallo de la RED?||
+WPUPCFID12|¿Correr como un I-Gate?||
+WPUPCFID13|¿Difundir mensajes vía TNC cuando un I-Gate?||
 WPUPCFID14|¿Registrar transacciones del I-Gate?||
 WPUPCFID15|Parámetros de filtrado||
 #
@@ -655,9 +655,9 @@ WPUPCFIA07|Servidor2||
 WPUPCFIA08|Puerto2||
 WPUPCFIA09|Código de paso||
 WPUPCFIA10|(dejar en blanco si Nada)||
-WPUPCFIA11|Reconectar en fallo de RED?||
-WPUPCFIA12|Correr como un I-Gate?||
-WPUPCFIA13|Difundir mensajes via TNC cuando un I-Gate?||
+WPUPCFIA11|¿Reconectar en fallo de RED?||
+WPUPCFIA12|¿Correr como un I-Gate?||
+WPUPCFIA13|¿Difundir mensajes vía TNC cuando un I-Gate?||
 WPUPCFIA14|¿Registrar transacciones del I-Gate?||
 WPUPCFIA15|Transmitir RadioPuerto||
 #
@@ -690,7 +690,7 @@ WPUPTSP001|Rastreo estación||
 WPUPTSP002|Rastreo de indicativo|| 
 WPUPTSP003|Distinguir mayús./minús.|| 
 WPUPTSP004|Coincidencia exacta|| 
-WPUPTSP005|Rastrear Ahora!|| 
+WPUPTSP005|¡Rastrear Ahora!||
 WPUPTSP006|Limpiar Rastro|| 
 WPUPTSP007|Abajar Rastro||
 WPUPTSP008|Indicativo||
@@ -706,7 +706,7 @@ WPUPMSB005|Nuevo/Actualizar indicativo||
 WPUPMSB006|Nuevo grupo||
 WPUPMSB007|Limpiar historial de mensajes||
 WPUPMSB008|Mensaje:||
-WPUPMSB009|Enviar ahora!||
+WPUPMSB009|¡Enviar ahora!||
 WPUPMSB010|Ruta:||
 WPUPMSB011|Cancelar mensajes pendientes||
 WPUPMSB012|Reiniciar temporizador||
@@ -868,8 +868,8 @@ UNIOP00006|Dispositivo||
 UNIOP00007|Agregar||
 UNIOP00008|Anular||
 UNIOP00009|Propiedades||
-UNIOP00010|Permitir Transmisión?||
-UNIOP00011|Activar en Inicio?||
+UNIOP00010|¿Permitir Transmisión?||
+UNIOP00011|¿Activar en Inicio?||
 UNIOP00012|km/h||
 UNIOP00013|mph||
 UNIOP00014|C||
@@ -1027,9 +1027,9 @@ PULDNMAT01|Mostrar mapas de alerta sobre otros mapas||
 PULDNMAT02|Mostrar mapas de alerta bajo otros mapas||
 #
 # Error/popup mensajes
-POPEM00001|Localiza Error!||
-POPEM00002|La estación %s no fue encontrada!||
-POPEM00003|Rastreo Error!||
+POPEM00001|¡Localiza Error!||
+POPEM00002|¡La estación %s no fue encontrada!||
+POPEM00003|¡Rastreo Error!||
 POPEM00004|¡Error de interfaz!||
 POPEM00005|Inválido nombre de puerto AX.25 %s||
 POPEM00006|Inválido nombre de puerto AX.25 %s||
@@ -1047,7 +1047,7 @@ POPEM00017|¡No hay más interfaces disponibles!||
 POPEM00018|Consulta de datos - Línea de mensaje única||
 POPEM00019|La transmisión está desactivada para el puerto %d||
 POPEM00020|Error de base de datos||
-POPEM00021|El soporte de AX.25 no está compilado en Xastir!||
+POPEM00021|¡El soporte de AX.25 no está compilado en Xastir!||
 POPEM00022|Error de entrada||
 POPEM00023|No se especificó nombre de ubicación||
 POPEM00024|El nombre de ubicación especificado ya está en uso||
@@ -1055,10 +1055,10 @@ POPEM00025|¡No encontrado!||
 POPEM00026|El Rastreo empezará cuando el aparezca||
 POPEM00027|Información incorrecta. ¿Hay campos vacíos?||
 POPEM00028|No se puede abrir el archivo||
-POPEM00029|Encontrado!||
+POPEM00029|¡Encontrado!||
 POPEM00030|Símbolo de Estación Meteorológica||
 POPEM00031|Cambiado a símbolo WX '/_', otras opciones:  '\_'  '/W'  y  '\W'||
-POPEM00032|Aviso: Usando Símbolo del National Weather Service!||
+POPEM00032|¡Aviso: Usando Símbolo del National Weather Service!||
 POPEM00033|¡Sin datos GPS!||
 POPEM00034|Desactivando TX de mi posición hasta tener datos GPS válidos||
 POPEM00035|Advertencia||
@@ -1084,7 +1084,7 @@ POPEM00054|¡Estamos intentando hablarnos a nosotros mismos!||
 #
 # Salto de Locación
 JMLPO00001|Marcadores del mapa||
-JMLPO00002|IR!||
+JMLPO00002|¡IR!||
 JMLPO00003|Nombre de Nueva Localización:||
 #
 # Boletines 

--- a/config/language-Spanish.sys
+++ b/config/language-Spanish.sys
@@ -127,7 +127,7 @@ PULDNMBC01|Gris||
 PULDNMBC02|Rosado Místico||
 PULDNMBC03|Azul Marino||
 PULDNMBC04|Azul acerado||
-PULDNMBC05|Med. Verde mar||
+PULDNMBC05|Verde Agua||
 PULDNMBC06|Verde Pálido||
 PULDNMBC07|Dorado Pálido||
 PULDNMBC08|Dorado Amarillo||

--- a/config/language-Spanish.sys
+++ b/config/language-Spanish.sys
@@ -25,17 +25,17 @@ MENUTB0009|Ayuda|y|
 #
 # Menú archivo
 PULDNFI001|Configurar|C|
-PULDNFI002|Abrir Bitácora|B|
+PULDNFI002|Abrir registro|B|
 PULDNFI003|Prueba|P|
 PULDNFI004|Salir|S|
 PULDNFI007|Cambia nivel Depuración|D|
-PULDNFI010|Bitácora del TNC|T|
-PULDNFI011|Bitácora de Internet|I|
-PULDNFI012|Bitácora del I-Gate|G|
-PULDNFI013|Bitácora del WX|W|
+PULDNFI010|Registro del TNC|T|
+PULDNFI011|Registro de Internet|I|
+PULDNFI012|Registro del I-Gate|G|
+PULDNFI013|Registro de WX|W|
 PULDNFI014|Activa PNG Instantánea||
 PULDNFI015|Imprimir Mapa|P|
-PULDNFI016|KML Snapshots||
+PULDNFI016|Instantáneas KML||
 #
 # Menú visor
 PULDNVI001|Boletines|B|
@@ -47,68 +47,68 @@ PULDNVI012|Últimas Estaciones|U|
 PULDNVI005|Estaciones Meteorológicas|E|
 PULDNVI008|Su Estación Meteorológica|S|
 PULDNVI007|Alerta del tiempo|A|
-PULDNVI011|Tráficos de Mensajes|f|
-PULDNVI013|Tiempo de Inicio|I|
-PULDNVI014|Tiempo Transcurrido||
-PULDNVI015|GPS Status||
-PULDNVI016|ALOHA Statistics||
+PULDNVI011|Tráfico de mensajes|f|
+PULDNVI013|Tiempo en ejecución|I|
+PULDNVI014|Tiempo en ejecución del programa||
+PULDNVI015|Estado del GPS||
+PULDNVI016|Estadísticas ALOHA||
 #
 # Menú de Configuración
 PULDNCF004|Estación|E|
 PULDNCF001|Predefinidos|P|
 PULDNCF003|Cronómetro|t|
-PULDNCF002|Sistema de Coordenada|C|
+PULDNCF002|Sistema de coordenadas|C|
 PULDNCF006|Alarmas de Audio|A|
 PULDNCF007|Sintetizador de Voz|S|
-PULDNCF008|Guardar Configuración!|G|
+PULDNCF008|Guardar configuración|G|
 #
 # Menú de Mapas
 PULDNMP001|Seleccionar Mapas|M|
-PULDNMP012|Saltar a una Locación|S|
+PULDNMP012|Ir a una ubicación|S|
 PULDNMP014|Localice rasgo del Mapa|L|
-PULDNMP016|Disable Fast Zoom/Pan/Home||
+PULDNMP016|Desactivar zoom/paneo/inicio rápido||
 PULDNMP013|Desactive todos los Mapas||
 PULDNMP002|Activar Auto Mapas||
 PULDNMP003|Rejillas sobre Mapa||
 PULDNMP004|Niveles de Mapas||
 PULDNMP010|Etiquetas de Mapas||
-PULDNMP009|Activar Areas Coloridas||
+PULDNMP009|Activar áreas coloreadas||
 PULDNMP007|Alerta Mapa WX||
 PULDNMP005|Color de fondo|C|
-PULDNMP006|Etiquetas de estiones|E|
-PULDNMP026|Icon Outline Style|O|
+PULDNMP006|Estilo de texto de estación|E|
+PULDNMP026|Estilo del contorno del icono|O|
 PULDNMP011|Menú Indicador del Ratón|R|
 PULDNMP008|Intensidad del Mapa|I|
 PULDNMP021|Auto Mapa - Desactivar Mapas de Trama||
-PULDNMP022|Indezar Mapas en Inicio||
-PULDNMP023|Indice: Agregar Nuevos Mapas|A|
-PULDNMP024|Indice: Reindezar TODOS los Mapas|T|
-PULDNMP025|Fonts||
+PULDNMP022|Indexar mapas al inicio||
+PULDNMP023|Índice: agregar mapas nuevos|A|
+PULDNMP024|Índice: reindexar TODOS los mapas|T|
+PULDNMP025|Fuentes||
 PULDNMP015|Xfontsel||
-PULDNMP027|Re-download Maps (Not from cache)||
-PULDNMP028|Flush Entire Map Cache!||
+PULDNMP027|Volver a descargar mapas (sin caché)||
+PULDNMP028|Vaciar toda la caché de mapas||
 PULDNMP029|Buscar ubicación||
-PULDNMP030|Configure USGS DRG||
-PULDNMP031|Enable Map Border||
+PULDNMP030|Configurar USGS DRG||
+PULDNMP031|Activar borde del mapa||
 PULDNMP032|Configuración de geocodificación||
-MPUPTGR017|Internet Map Timeout (segundo)||
+MPUPTGR017|Tiempo de espera de mapa por Internet (seg)||
 #
 # PopUp "Configure USGS DRG"
-MPUPDRG001|Select items to be displayed:||
-MPUPDRG002|Tint Underlying Map (XOR)||
-MPUPDRG003|Black||
-MPUPDRG004|White||
-MPUPDRG005|Blue||
-MPUPDRG006|Red||
-MPUPDRG007|Brown||
-MPUPDRG008|Green||
-MPUPDRG009|Purple||
-MPUPDRG010|Yellow||
-MPUPDRG011|Light Blue||
-MPUPDRG012|Light Red||
-MPUPDRG013|Light Purple||
-MPUPDRG014|Light Gray||
-MPUPDRG015|Light Brown||
+MPUPDRG001|Seleccione los elementos que se mostrarán:||
+MPUPDRG002|Teñir mapa subyacente (XOR)||
+MPUPDRG003|Negro||
+MPUPDRG004|Blanco||
+MPUPDRG005|Azul||
+MPUPDRG006|Rojo||
+MPUPDRG007|Marrón||
+MPUPDRG008|Verde||
+MPUPDRG009|Púrpura||
+MPUPDRG010|Amarillo||
+MPUPDRG011|Azul claro||
+MPUPDRG012|Rojo claro||
+MPUPDRG013|Púrpura claro||
+MPUPDRG014|Gris claro||
+MPUPDRG015|Marrón claro||
 #
 # Seleccion de Mapas
 WPUPMCP001|Selección de Mapa||
@@ -117,10 +117,10 @@ PULDNMMC02|Vectores|V|
 PULDNMMC03|250k Topo|2|
 PULDNMMC04|100k Topo|1|
 PULDNMMC05|24k Topo|4|
-PULDNMMC06|Expandir Dirs|||
+PULDNMMC06|Expandir dirs||
 PULDNMMC07|Dirs/Mapas Seleccionado:||
-PULDNMMC08|Clear Dirs|C|
-PULDNMMC09|Select All|S|
+PULDNMMC08|Limpiar dirs|C|
+PULDNMMC09|Seleccionar todo|S|
 #
 # Colores de fondo del mapa
 PULDNMBC01|Gris||
@@ -140,18 +140,18 @@ PULDNMBC12|Negro||
 PULDNMSL01|Fondo Negro||
 PULDNMSL02|Fondo Gris||
 PULDNMSL03|Texto en Negro|T|
-PULDNMSL04|DropShadow||
+PULDNMSL04|Sombra proyectada||
 PULDNMSL05|Negro sobre blanco||
 #
 # PullDown "Icon Outline Style"
-PULDNMIO01|No Outline|N|
-PULDNMIO02|Black Outline|B|
-PULDNMIO03|Grey Outline|G|
-PULDNMIO04|White Outline|W|
+PULDNMIO01|Sin contorno|N|
+PULDNMIO02|Contorno negro|B|
+PULDNMIO03|Contorno gris|G|
+PULDNMIO04|Contorno blanco|W|
 #
 # Switches ON/OFF/Corto
-PULDNOT001|On||
-PULDNOT002|Off||
+PULDNOT001|Encendido||
+PULDNOT002|Apagado||
 PULDNOT003|Corto||
 #
 # Menú de Despliegue de Estaciones
@@ -170,7 +170,7 @@ PULDNDP044|- Seleccionar Estaciones||
 PULDNDP028|- Seleccionar Estaciones Fijas||
 PULDNDP029|- Seleccionar Estaciones Móviles||
 PULDNDP030|- Seleccionar Estaciones de WX||
-PULDNDP053|  - Select CWOP WX Stations||
+PULDNDP053|  - Seleccionar estaciones WX CWOP||
 PULDNDP045|- Seleccionar Objetos/Artículos||
 PULDNDP026|- Seleccionar Objetos/Artículos de WX||
 PULDNDP039|- Seleccionar Objetos/Artículos Medidores de Agua||
@@ -190,14 +190,14 @@ PULDNDP009|Mostrar Informe del Tiempo|T|
 PULDNDP046|- Mostrar Texto||
 PULDNDP018|- Sólo la Temperatura||
 PULDNDP047|- Mostrar Indicación de Viento||
-PULDNDP054|Display Aloha Circle||
+PULDNDP054|Mostrar círculo ALOHA||
 PULDNDP013|Mostrar Ambigüedad de Posición||
 PULDNDP008|Mostrar Potencia/Ganancia|P|
 PULDNDP021|- Usar Pot/Ganancia por Defecto||
 PULDNDP020|- Mostrar Pot/Ganancia Móviles||
 PULDNDP023|Mostrar atributos DF||
-PULDNDP123|Display DF Beamwidth||
-PULDNDP223|Display DF Bearing||
+PULDNDP123|Mostrar ancho de haz DF||
+PULDNDP223|Mostrar rumbo DF||
 PULDNDP035|Activar Conteo-Muerto||
 PULDNDP036|- Mostrar Arco||
 PULDNDP037|- Mostrar Curso||
@@ -208,12 +208,12 @@ PULDNDP015|Anular Todas las Estaciones|A|
 PULDNDP016|Limpiar Rastros|n|
 PULDNDP025|Limpiar Historia de Objeto/Artículo||
 PULDNDP048|Recargar Historia de Objeto/Artículo||
-PULDNDP049|Clear All Tactical Calls||
-PULDNDP050|Clear Tactical Call History||
-PULDNDP051|Select Tactical Calls Only||
-PULDNDP052|- Label Trailpoints||
-PULDNDP055|Export All|E|
-PULDNDP056|Export to KML File||
+PULDNDP049|Borrar todas las llamadas tácticas||
+PULDNDP050|Borrar historial de llamadas tácticas||
+PULDNDP051|Seleccionar solo llamadas tácticas||
+PULDNDP052|- Etiquetar puntos de rastro||
+PULDNDP055|Exportar todo|E|
+PULDNDP056|Exportar a archivo KML||
 #
 # Inglesa/Métrica
 PULDNUT001|Activar Unidades Inglesa||
@@ -222,33 +222,33 @@ PULDNUT002|Métrica||
 # Menú de Mensajes
 PULDNMG001|Enviar Mensaje A|E|
 PULDNMG002|Abrir Mensajes Grupos|G|
-PULDNMG003|Anular todos mensajes saliente|B|
+PULDNMG003|Anular todos los mensajes salientes|B|
 PULDQUS001|Pregunta General a Estaciones|P|
 PULDQUS002|Pregunta a Estaciones I-Gate|I|
 PULDQUS003|Pregunta a Estaciones WX|W|
 PULDNMG004|Fijar Mensaje en Contestación Automática|F|
 PULDNMG005|Activar Auto contestación de Mensaje|A|
 PULDNMG006|Satélite Modo de Reconocimiento|M|
-PULDNMG007|Show Pending Messages|P|
+PULDNMG007|Mostrar mensajes pendientes|P|
 #
 # Menú de Interfaces
-PULDNTNT04|Interface Control||
+PULDNTNT04|Control de interfaces||
 PULDNTNT03|Desactivar Transmitir: TODOS||
 PULDNTNT05|Desactivar Transmitir: Mi Posición||
 PULDNTNT06|Desactivar Transmitir: Objetos/Artículos||
-PULDNTNT11|Enable Server Port||
+PULDNTNT11|Activar puertos de servidor||
 PULDNTNT01|Transmitir Ahora..!|T|
-PULDNTNT07|Coger Huella de GPS|F|
-PULDNTNT08|Coger Rutas de GPS|R|
-PULDNTNT09|Coger VíaPuntos de GPS|W|
-PULDNTNT10|Fetch Garmin RINO Waypoints|G|
+PULDNTNT07|Obtener track del GPS|F|
+PULDNTNT08|Obtener rutas del GPS|R|
+PULDNTNT09|Obtener waypoints del GPS|W|
+PULDNTNT10|Obtener waypoints Garmin RINO|G|
 #
 # Menú de Ayuda
 PULDNHEL01|Acerca de|A|
-PULDNHEL02|Indice de Ayuda|I|
-PULDNHEL03|EMERGENCY BEACON MODE ENABLE|E|
-PULDNHEL04|!!! EMERGENCY BEACON MODE !!!||
-PULDNHEL05|About Xastir||
+PULDNHEL02|Índice de ayuda|I|
+PULDNHEL03|ACTIVAR MODO BALIZA DE EMERGENCIA|E|
+PULDNHEL04|!!! MODO BALIZA DE EMERGENCIA !!!||
+PULDNHEL05|Acerca de Xastir||
 #
 # Menú de Ratón
 POPUPMA001|Opciones||
@@ -264,10 +264,10 @@ POPUPMA008|Nivel 256|2|
 POPUPMA009|Nivel 1024|0|
 POPUPMA010|Nivel 8192|8|
 POPUPMA017|El Mundo Entero|E|
-POPUPMA016|Ultima Pos/Enfoque del Mapa|P|
+POPUPMA016|Última pos./zoom del mapa|P|
 POPUPMA018|Crear Objeto/Artículo|C|
 POPUPMA019|Modificar Objeto/Artículo|M|
-POPUPMA025||Mover Mi  Estación Aquí|A|
+POPUPMA025|Mover Mi Estación Aquí|A|
 POPUPMA011|Paneo arriba|u|
 POPUPMA012|Paneo abajo|d|
 POPUPMA013|Paneo izquierda|l|
@@ -276,37 +276,37 @@ POPUPMA020|Medida||
 POPUPMA021|Movimiento||
 POPUPMA022|RastréeMe||
 POPUPMA023|Modificadores Encontrado!||
-POPUPMA024|Por favor apague OFF CapsLock/NumLock/ScrollLock/otro modificadores||
-POPUPMA026|Centre & Enfoque||
+POPUPMA024|Apague Caps Lock/Num Lock/Scroll Lock y otros modificadores||
+POPUPMA026|Centrar y zoom||
 POPUPMA027|  Latitud||
 POPUPMA028| Longitud||
 POPUPMA029|Dibuje Objetos CAD||
-POPUPMA030|Draw||
+POPUPMA030|Dibujar||
 POPUPMA031|Cierre el Polígono||
-POPUPMA032|Erase CAD Polygons||
+POPUPMA032|Borrar polígonos CAD||
 POPUPMA033|**NOT USED**||
-POPUPMA034|Custom Zoom Level||
-POPUPMA035|10% out||
-POPUPMA036|10% in||
-POPUPMA037|Area||
-POPUPMA038|square||
-POPUPMA039|square feet||
-POPUPMA040|square meters||
-POPUPMA041|Bearing||
-POPUPMA042|degrees||
-POPUPMA043|Modify ambiguous position||
-POPUPMA044|Position abiguity is on, your new position may appear to jump.||
-POPUPMA045|Predefined Objects||
-POPUPMA046|CAD Polygons||
-POPUPMA047|Enable CAD objects||
-POPUPMA048|Enable CAD labels||
-POPUPMA049|Enable CAD comments||
-POPUPMA050|Enable CAD probability||
-POPUPMA051|Enable CAD area size||
-POPUPMA052|sq||
-POPUPMA053|ft||
-POPUPMA054|meters||
-POPUPMA055|mi|
+POPUPMA034|Nivel de zoom personalizado||
+POPUPMA035|10% menos||
+POPUPMA036|10% más||
+POPUPMA037|Área||
+POPUPMA038|cuadrada||
+POPUPMA039|pies cuadrados||
+POPUPMA040|metros cuadrados||
+POPUPMA041|Rumbo||
+POPUPMA042|grados||
+POPUPMA043|Modificar posición ambigua||
+POPUPMA044|La ambigüedad de posición está activada; su nueva posición puede parecer que salta.||
+POPUPMA045|Objetos predefinidos||
+POPUPMA046|Polígonos CAD||
+POPUPMA047|Activar objetos CAD||
+POPUPMA048|Activar etiquetas CAD||
+POPUPMA049|Activar comentarios CAD||
+POPUPMA050|Activar probabilidad CAD||
+POPUPMA051|Activar tamaño de área CAD||
+POPUPMA052|cuad.||
+POPUPMA053|pies||
+POPUPMA054|metros||
+POPUPMA055|mi||
 #
 # Menú de Estados de la líneas de Etiquetas
 BBARZM0001|Foco %s||
@@ -324,7 +324,7 @@ BBARSTA008|El uso de Auto Mapas, es OFF||
 BBARSTA009|Los Niveles del Mapa están ON||
 BBARSTA010|Los Niveles del Mapa están OFF||
 BBARSTA011|Auto contestación de Mensaje es OFF!||
-BBARSTA012|Achivo creado..||
+BBARSTA012|Archivo terminado..||
 BBARSTA013|Abriendo Puerto GPS||
 BBARSTA014|Cerrando Puerto GPS||
 BBARSTA015|Obtenido GPS RMC Cordón||
@@ -349,21 +349,21 @@ BBARSTA033|Eco desde digipeater||
 BBARSTA034|Cargando Mapas de alerta WX||
 BBARSTA035|Esperando por datos del GPS vía AUX..||
 BBARSTA036|Limpiando el AUX datos obtenido del TNC..||
-BBARSTA037|Datos de GPS Decondificado||
+BBARSTA037|Datos GPS decodificados||
 BBARSTA038|Coloque el cambio en mi estación||
-BBARSTA039|Indezando %s||
-BBARSTA040|Estación de Aficionado APRS(tm) %s||
-BBARSTA041|Esperando por GPS data..||
+BBARSTA039|Indexando %s||
+BBARSTA040|Estación APRS(tm) de radioaficionado %s||
+BBARSTA041|Esperando datos GPS..||
 BBARSTA042|Transmitiendo objetos/articulos||
 BBARSTA043|Anotando||
-BBARSTA044|ALOHA distance is %d%s||
-BBARSTA045|Loading symbols...||
-BBARSTA046|Reloading symbols...||
-BBARSTA047|Initialize my station...||
-BBARSTA048|Start interfaces...||
-BBARSTA049|Reading tiles...||
-BBARSTA050|Downloading tiles...||
-BBARSTA051|Downloading tile %li of %li||
+BBARSTA044|La distancia ALOHA es %d%s||
+BBARSTA045|Cargando símbolos...||
+BBARSTA046|Recargando símbolos...||
+BBARSTA047|Inicializando mi estación...||
+BBARSTA048|Iniciando interfaces...||
+BBARSTA049|Leyendo mosaicos...||
+BBARSTA050|Descargando mosaicos...||
+BBARSTA051|Descargando mosaico %li de %li||
 #
 # Despliegue Paquete de Datos
 WPUPDPD001|Despligue de Datos||
@@ -372,28 +372,28 @@ WPUPDPD003|sólo datos de la Red||
 WPUPDPD004|Datos del TNC y la Red||
 WPUPDPD005|TNC||
 WPUPDPD006|RED||
-WPUPDPD007|Station Capabilities||
-WPUPDPD008|Mine Only||
+WPUPDPD007|Capacidades de la estación||
+WPUPDPD008|Solo mías||
 #
 # Localizar Estación
 WPUPLSP001|Localizar estación||
 WPUPLSP002|Localizar Indicativo||
-WPUPLSP003|Macheo Sensible|S|
-WPUPLSP004|Macheo Exacto|E|
+WPUPLSP003|Distinguir mayús./minús.|S|
+WPUPLSP004|Coincidencia exacta|E|
 WPUPLSP005|Localizar ahora!|A|
 WPUPLSP006|Localizar Emergencia!||
-WPUPLSP007|FCC/RAC Lookup||
+WPUPLSP007|Consulta FCC/RAC||
 #
 # Configurar predefinidos
-WPUPCFD001|Configurar valores predefinidos||
-WPUPCFD002|desde qué intérvalo de tiempo será considerada una estación vieja?||
+WPUPCFD001|Configurar valores predeterminados||
+WPUPCFD002|¿Tras qué intervalo se considerará vieja una estación?||
 WPUPCFD003|15 minutos|1|
 WPUPCFD004|30 minutos|3|
 WPUPCFD005|45 minutos|4|
 WPUPCFD006|1 hora|H|
 WPUPCFD007|90 minutos|9|
 WPUPCFD008|2 horas|2|
-WPUPCFD009|desde qué intérvalo de tiempo la estación no será desplegada?||
+WPUPCFD009|¿Tras qué intervalo dejará de mostrarse la estación?||
 WPUPCFD010|6 horas|6|
 WPUPCFD011|12 horas|o|
 WPUPCFD012|1 Día|D|
@@ -410,12 +410,12 @@ WPUPCFD023|Transmitir datos WX en Raw?||
 WPUPCFD024|Comprimir datos objeto/artículo cuando transmita?||
 WPUPCFD025|Activar Red Alternada?|A|
 WPUPCFD026|Enviar reportes de posición en qué intérvalos?||
-WPUPCFD027|Mostrar bulletines Nuevo||
+WPUPCFD027|Mostrar boletines nuevos||
 WPUPCFD028|Avisar si hay teclas Modificadora||
-WPUPCFD029|Ver boletines de zero-distancia||
-WPUPCFD030|Disable Posit Dupe-Checks||
-WPUPCFD031|Load predefined objects from file||
-WPUPCFD032|My trails in one color||
+WPUPCFD029|Ver boletines de distancia cero||
+WPUPCFD030|Desactivar comprobación de duplicados de posición||
+WPUPCFD031|Cargar objetos predefinidos desde archivo||
+WPUPCFD032|Mis rastros en un color||
 WPUPCFD033|ALTNET:||
 #
 # Menu "Configurar - Cronómetro"
@@ -427,16 +427,16 @@ WPUPCFTM05|Limpiar Tiempo de la Estación (horas)||
 WPUPCFTM06|Chequeo Intérvalo del GPS (segundos)||
 WPUPCFTM07|Borrar Tiempo de la Estación (días)||
 WPUPCFTM08|Descanso Conteo-Muerto (minutos)||
-WPUPCFTM09|Serial Inter-Char Delay (ms)||
+WPUPCFTM09|Retardo serial entre caracteres (ms)||
 WPUPCFTM10|Nuevo Tiempo Rastro (min)||
 WPUPCFTM11|Nuevo Interval Rastro (grados)||
-WPUPCFTM12|RINO -> Objects Interval (min), 0 = Disabled||
-WPUPCFTM13|Snapshot Interval (min)||
-WPUPCFTM14|Aircraft Ghost/Clear Time (min), 0 = Disabled||
+WPUPCFTM12|Intervalo RINO -> Objetos (min), 0 = desactivado||
+WPUPCFTM13|Intervalo de instantáneas (min)||
+WPUPCFTM14|Tiempo de fantasma/borrado de aeronaves (min), 0 = desactivado||
 #
 # Configurar Sistema de Coordenada"
-WPUPCFC001|Configurar Sistema de Coordenada||
-WPUPCFC002|Seleccione Sistema de Coordenada||
+WPUPCFC001|Configurar sistema de coordenadas||
+WPUPCFC002|Seleccione sistema de coordenadas||
 WPUPCFC003|dd.ddddd|d|
 WPUPCFC004|dd mm.mmm|m|
 WPUPCFC005|dd mm ss.s|s|
@@ -505,18 +505,18 @@ WPUPCFT032|Arreglar Archivo del TNC||
 WPUPCFT033|Archivo de apagar TNC||
 WPUPCFT034|Parámetros TNC KISS modo||
 WPUPCFT035|TXDelay (10 ms unidades)||
-WPUPCFT036|Persistence (0 to 255)||
+WPUPCFT036|Persistencia (0 a 255)||
 WPUPCFT037|SlotTime (10 ms unidades)||
 WPUPCFT038|TxTail (10 ms unidades)||
-WPUPCFT039|Full Duplex||
+WPUPCFT039|Dúplex completo||
 WPUPCFT040|Configurar un Multi-Port KISS TNC||
-WPUPCFT041|Radio Port||
+WPUPCFT041|Puerto de radio||
 WPUPCFT042|Dubious UNPROTO Path!||
-WPUPCFT043|Please consider a shorter path such as WIDE2-2 or WIDE1-1,WIDE2-2||
+WPUPCFT043|Considere una ruta más corta, como WIDE2-2 o WIDE1-1,WIDE2-2||
 WPUPCFT044|Dubious IGATE Path!||
-WPUPCFT045|Transmitting w/Dubious UNPROTO Path!||
-WPUPCFT046|Transmitting w/Dubious IGATE Path!||
-WPUPCFT047|Init KISS-mode on startup||
+WPUPCFT045|Transmitiendo con ruta UNPROTO dudosa||
+WPUPCFT046|Transmitiendo con ruta IGATE dudosa||
+WPUPCFT047|Inicializar modo KISS al arrancar||
 #
 # Configurar el Puerto de la Estación Meteorológica
 WPUPCFWX01|Configurar el Puerto de la Estación Meteorológica||
@@ -546,7 +546,7 @@ WPUPCFS014|Altura de la Antena||
 WPUPCFS015|Ganancia de la Antena||
 WPUPCFS016|Omni||
 WPUPCFS017|Comentarios:||
-WPUPCFS018|Posición ambigüa||
+WPUPCFS018|Posición ambigua||
 WPUPCFS019|Ninguna||
 WPUPCFS020|.11 milla||
 WPUPCFS021|1.15 millas||
@@ -559,7 +559,7 @@ WPUPCFS027|111.19 kilómetros||
 WPUPCFS029|Envío de posición comprimida|C|
 #
 # Diálogo de Objeto/Artículo
-POPUPOB001|Objeto/Arículo||
+POPUPOB001|Objeto/Artículo||
 POPUPOB002|Nombre:||
 POPUPOB003|Crear Nuevo Objeto||
 POPUPOB004|Borrar Objeto||
@@ -584,11 +584,11 @@ POPUPOB022|Amarillo||
 POPUPOB023|Gris||
 POPUPOB024|Compense Arriba:||
 POPUPOB025|Compense Izq.(Excepto '/'):||
-POPUPOB026|Corridor:||
+POPUPOB026|Corredor:||
 POPUPOB027|Opciones Genéricas||
 POPUPOB028|Situación||
 POPUPOB029|Activar Letrero||
-POPUPOB030|Data:||
+POPUPOB030|Texto del letrero||
 POPUPOB031|Letrero Objeto||
 POPUPOB032|Activar Compresión||
 POPUPOB033|Borrar Artículo||
@@ -602,13 +602,13 @@ POPUPOB040|Dirigiendo - Ancho de la orientación||
 POPUPOB041|Antena Omni-direccional||
 POPUPOB042|Antena Direccional||
 POPUPOB043|Inútil||
-POPUPOB044|Adopt Object||
-POPUPOB045|Adopt Item||
-POPUPOB046|DF Bearing:||
-POPUPOB047|Probability Circles||
-POPUPOB048|Map View Object||
-POPUPOB049|Min (mi):||
-POPUPOB050|Max (mi):||
+POPUPOB044|Adoptar objeto||
+POPUPOB045|Adoptar artículo||
+POPUPOB046|Rumbo DF:||
+POPUPOB047|Círculos de probabilidad||
+POPUPOB048|Objeto de vista de mapa||
+POPUPOB049|Mín (mi):||
+POPUPOB050|Máx (mi):||
 #
 # Configurar Internet
 WPUPCFI001|Configurar Internet||
@@ -621,11 +621,11 @@ WPUPCFI007|Servidor2||
 WPUPCFI008|Puerto2||
 WPUPCFI009|Palabra de Paso||
 WPUPCFI010|Dejar en blanco si nada||
-WPUPCFI011|Reconectar en fallo de la RED?||
-WPUPCFI012|Correr como un I-Gate?||
-WPUPCFI013|Difundir mensajes vía TNC cuando un I-Gate?||
-WPUPCFI014|Bitácora de Transacciones del I-Gate?|||
-WPUPCFI015|Parametros de Filtrado||
+WPUPCFI011|¿Reconectar en fallo de la RED?||
+WPUPCFI012|¿Correr como un I-Gate?||
+WPUPCFI013|¿Difundir mensajes vía TNC cuando un I-Gate?||
+WPUPCFI014|¿Registrar transacciones del I-Gate?||
+WPUPCFI015|Parámetros de filtrado||
 #
 # Configurar Base de datos
 WPUPCFID01|Configurar Base de datos(TBD)||
@@ -641,8 +641,8 @@ WPUPCFID10|Dejar en blanco si nada||
 WPUPCFID11|Reconectar en fallo de la RED?||
 WPUPCFID12|Correr como un I-Gate?||
 WPUPCFID13|Difundir mensajes vía TNC cuando un I-Gate?||
-WPUPCFID14|Bitácora de Transacciones del I-Gate?|||
-WPUPCFID15|Parametros de Filtrado||
+WPUPCFID14|¿Registrar transacciones del I-Gate?||
+WPUPCFID15|Parámetros de filtrado||
 #
 # Menu "Configurar AGWPE"
 WPUPCFIA01|Configurar AGWPE||
@@ -653,12 +653,12 @@ WPUPCFIA05|Servidor1||
 WPUPCFIA06|Puerto1||
 WPUPCFIA07|Servidor2||
 WPUPCFIA08|Puerto2||
-WPUPCFIA09|Codigo de Paso||
+WPUPCFIA09|Código de paso||
 WPUPCFIA10|(dejar en blanco si Nada)||
 WPUPCFIA11|Reconectar en fallo de RED?||
 WPUPCFIA12|Correr como un I-Gate?||
 WPUPCFIA13|Difundir mensajes via TNC cuando un I-Gate?||
-WPUPCFIA14|Bitácora de Transacciones I-Gate?||
+WPUPCFIA14|¿Registrar transacciones del I-Gate?||
 WPUPCFIA15|Transmitir RadioPuerto||
 #
 # Configurar Alarmas de Audio
@@ -687,9 +687,9 @@ WPUPCFSP09|<- Estación Rastreada Alerta de Proximidad||
 #
 # Rastreo de Estación
 WPUPTSP001|Rastreo estación|| 
-WPUPTSP002|Rastreo Indicativo|| 
-WPUPTSP003|Macheo Sensible|| 
-WPUPTSP004|Macheo Exacto|| 
+WPUPTSP002|Rastreo de indicativo|| 
+WPUPTSP003|Distinguir mayús./minús.|| 
+WPUPTSP004|Coincidencia exacta|| 
 WPUPTSP005|Rastrear Ahora!|| 
 WPUPTSP006|Limpiar Rastro|| 
 WPUPTSP007|Abajar Rastro||
@@ -702,47 +702,47 @@ WPUPMSB001|Enviar mensaje %d||
 WPUPMSB002|Enviar Mensaje a grupo %d||
 WPUPMSB003|Indicativo de Estación:||
 WPUPMSB004|Indicativos de Grupos:||
-WPUPMSB005|Nuevo/Refresh Indicativo||
+WPUPMSB005|Nuevo/Actualizar indicativo||
 WPUPMSB006|Nuevo grupo||
-WPUPMSB007|Clear Msg History||
+WPUPMSB007|Limpiar historial de mensajes||
 WPUPMSB008|Mensaje:||
 WPUPMSB009|Enviar ahora!||
 WPUPMSB010|Ruta:||
-WPUPMSB011|Cancel Pending Msgs||
-WPUPMSB012|Kick Timer||
+WPUPMSB011|Cancelar mensajes pendientes||
+WPUPMSB012|Reiniciar temporizador||
 WPUPMSB013|seq||
-WPUPMSB014|type||
-WPUPMSB015|Broadcast||
-WPUPMSB016|*TIMEOUT*||
-WPUPMSB017|*CANCELLED*||
-WPUPMSB018|*REJECTED*||
-WPUPMSB019|Change Path||
-WPUPMSB020|Use Default Path(s)||
-WPUPMSB021|Direct (No path)||
-WPUPMSB022|Reverse Path (Hint):||
+WPUPMSB014|tipo||
+WPUPMSB015|Difusión||
+WPUPMSB016|*TIEMPO AGOTADO*||
+WPUPMSB017|*CANCELADO*||
+WPUPMSB018|*RECHAZADO*||
+WPUPMSB019|Cambiar ruta||
+WPUPMSB020|Usar ruta(s) predeterminada(s)||
+WPUPMSB021|Directo (sin ruta)||
+WPUPMSB022|Ruta inversa (sugerencia):||
 #
 # Auto Contestación
 WPUPARM001|Cambiar auto Contestación||
 WPUPARM002|Reenviar:||
 #
 # Ayuda / Indice
-WPUPHPI001|Indice de Ayuda|I|
+WPUPHPI001|Índice de ayuda|I|
 WPUPHPI002|Visualizar|V|
 #
 # Información de la Estación
 WPUPSTI000|Objeto creado desde: %s||
 WPUPSTI001|Info Estación||
 WPUPSTI002|Enviar mensaje||
-WPUPSTI003|Buscar datos FCC||
-WPUPSTI004|Buscar datos RAC||
+WPUPSTI003|Consultar base FCC||
+WPUPSTI004|Consultar base RAC||
 WPUPSTI005|%d: Paquetes recibidos, último recibido en fecha: ||
 WPUPSTI006|Oído vía TNC en dispositivo: %d, ||
 WPUPSTI007|Oído ||
-WPUPSTI008|Ultima vez vía Local||
-WPUPSTI009|Ultima vez vía TNC en dispositivo: %d||
-WPUPSTI010|Ultima vez vía Internet en dispositivo: %d||
-WPUPSTI011|Ultima vez vía Archivo||
-WPUPSTI012|Ultima vez vía Desconocida||
+WPUPSTI008|Última vez vía local||
+WPUPSTI009|Última vez vía TNC en dispositivo: %d||
+WPUPSTI010|Última vez vía Internet en dispositivo: %d||
+WPUPSTI011|Última vez vía archivo||
+WPUPSTI012|Última vez vía desconocida||
 WPUPSTI013|, y ha cambiado posición||
 WPUPSTI014|Actual Potencia/Ganancia:||
 WPUPSTI016|Altitud: %.1f%s ||
@@ -752,7 +752,7 @@ WPUPSTI019|Velocidad: %.1f mph||
 WPUPSTI020|%0.1f millas||
 WPUPSTI021|%0.1f km||
 WPUPSTI022|Distancia desde mi estación %s, Curso desde mi estación %s||
-WPUPSTI023|Ultima posición: ||
+WPUPSTI023|Última posición: ||
 WPUPSTI024|Datos de la estación Meteorológica %c:%s||
 WPUPSTI025|Curso del viento: %s°  Velocidad: %03d km/h||
 WPUPSTI026|Curso del viento: %s°  Velocidad: %s mph||
@@ -761,7 +761,7 @@ WPUPSTI028| Ráfaga: %s mph||
 WPUPSTI029|Temperatura: %02.1f°C   ||
 WPUPSTI030|Temperatura: %s°F   ||
 WPUPSTI031| Humedad: %s%%   ||
-WPUPSTI032|Indice de Humedad: %02.1f°C  ||
+WPUPSTI032|Índice de humedad: %02.1f°C  ||
 WPUPSTI033| Presión Barométrica: %s mb||
 WPUPSTI034|Nieve: %0.1f (cm/24h)||
 WPUPSTI035|Nieve: %0.0f (plg/24h)||
@@ -772,20 +772,20 @@ WPUPSTI039|%0.2f (mm/día)  ||
 WPUPSTI040|%0.2f (plg/día)  ||
 WPUPSTI041|%0.2f (mm/desde medianoche)||
 WPUPSTI042|%0.2f (mm/desde medianoche)||
-WPUPSTI043|Ruta de Datos: %s||
+WPUPSTI043|Ruta de datos: %s||
 WPUPSTI044|Comentarios %02d/%02d %02d:%02d : %s||
 WPUPSTI045|Limpiar Rastro||
 WPUPSTI046|Total lluvia: ||
 WPUPSTI047|%0.2f (mm)||
 WPUPSTI048|%0.2f (plg)||
 WPUPSTI049|Preguntar rastro||
-WPUPSTI050|Pregunta no-conocido Mensaje||
-WPUPSTI051|Pregunta directa a estación||
-WPUPSTI052|Pregunta versión a estación||
+WPUPSTI050|Consulta de mensajes sin acuse||
+WPUPSTI051|Consulta de estaciones directas||
+WPUPSTI052|Consulta de versión de estación||
 WPUPSTI053|Modificar Objeto/Artículo||
 WPUPSTI054|Almacenar Rastro||
 WPUPSTI055|Repetido desde:||
-WPUPSTI056|Activar Actualizaciones Automática||
+WPUPSTI056|Activar actualizaciones automáticas||
 WPUPSTI057|Omni-DF: %s||
 WPUPSTI058|Orientando DF: %s||
 WPUPSTI059|Estados %02d/%02d %02d:%02d : %s||
@@ -793,47 +793,47 @@ WPUPSTI060|Incendio Temp: %02.1f°C  ||
 WPUPSTI061|Incendio Temp: %s°F   ||
 WPUPSTI062|Humedad de Incendio: %s%%  ||
 WPUPSTI063|Baro: %0.2f en Hg||
-WPUPSTI064|Fetch NWS Alert||
-WPUPSTI065|Tactical Call: %s||
-WPUPSTI066|Assign Tactical Call||
-WPUPSTI067|Current Range: %d miles||
-WPUPSTI068|none||
-WPUPSTI069|default||
+WPUPSTI064|Obtener alerta NWS||
+WPUPSTI065|Llamada táctica: %s||
+WPUPSTI066|Asignar llamada táctica||
+WPUPSTI067|Alcance actual: %d millas||
+WPUPSTI068|ninguna||
+WPUPSTI069|predeterminado||
 WPUPSTI070|HAAT||
 WPUPSTI071|omni||
-WPUPSTI072|range||
-WPUPSTI073|BAD PHG||
-WPUPSTI074|BAD SHG||
-WPUPSTI075|DF Range||
-WPUPSTI076|No signal detected||
-WPUPSTI077|Detectible signal (Maybe)||
-WPUPSTI078|Detectible signal but not copyable)||
-WPUPSTI079|Weak signal, marginally readable||
-WPUPSTI080|Noisy but copyable signal||
-WPUPSTI081|Some noise, easy to copy signal||
-WPUPSTI082|Good signal w/detectible noise||
-WPUPSTI083|Near full-quieting signal||
-WPUPSTI084|Full-quieting signal||
-WPUPSTI085|Extremely strong & full-quieting signal||
-WPUPSTI086|BAD BEARING||
-WPUPSTI087|BAD NRQ||
-WPUPSTI088|DF Beamwidth||
-WPUPSTI089|DF Length||
-WPUPSTI090|Not Valid||
-WPUPSTI091|Change Trail Color||
-WPUPSTI092|Clear DF Bearing||
+WPUPSTI072|alcance||
+WPUPSTI073|PHG INCORRECTO||
+WPUPSTI074|SHG INCORRECTO||
+WPUPSTI075|Alcance DF||
+WPUPSTI076|No se detectó señal||
+WPUPSTI077|Señal detectable (quizá)||
+WPUPSTI078|Señal detectable pero no copiable||
+WPUPSTI079|Señal débil, apenas legible||
+WPUPSTI080|Señal con ruido pero copiable||
+WPUPSTI081|Algo de ruido, señal fácil de copiar||
+WPUPSTI082|Buena señal con ruido detectable||
+WPUPSTI083|Señal casi totalmente nítida||
+WPUPSTI084|Señal totalmente nítida||
+WPUPSTI085|Señal extremadamente fuerte y totalmente nítida||
+WPUPSTI086|RUMBO INCORRECTO||
+WPUPSTI087|NRQ INCORRECTO||
+WPUPSTI088|Ancho de haz DF||
+WPUPSTI089|Longitud DF||
+WPUPSTI090|No válido||
+WPUPSTI091|Cambiar color del rastro||
+WPUPSTI092|Borrar rumbo DF||
 #
 #
 # PopUp "ALOHA Statistics"
-WPUPALO001|ALOHA radius: %d %s||
-WPUPALO002|Stations inside ALOHA circle: %d||
+WPUPALO001|Radio ALOHA: %d %s||
+WPUPALO002|Estaciones dentro del círculo ALOHA: %d||
 WPUPALO003| Digis:               %d||
-WPUPALO004| Mobiles (in motion): %d||
-WPUPALO005| Mobiles (other):     %d||
-WPUPALO006| WX stations:         %d||
-WPUPALO007| Home stations:       %d||
-WPUPALO008|Last calculated %d %s %d %s ago.||
-WPUPALO666|ALOHA radius not calculated yet||
+WPUPALO004| Móviles (en movimiento): %d||
+WPUPALO005| Móviles (otros):     %d||
+WPUPALO006| Estaciones WX:       %d||
+WPUPALO007| Estaciones base:     %d||
+WPUPALO008|Calculado por última vez hace %d %s %d %s.||
+WPUPALO666|El radio ALOHA aún no se ha calculado||
 #
 # FCC-RAC buscar Indicativo
 STIFCC0001|Buscar en Base de datos FCC||
@@ -844,15 +844,15 @@ STIFCC0005|Ciudad:||
 STIFCC0006|Estado:||
 STIFCC0007|Zona Postal:||
 STIFCC0008|Básica ||
-STIFCC0009|Advanzada ||
+STIFCC0009|Avanzada ||
 STIFCC0010|5 wpm ||
 STIFCC0011|12 wpm ||
 #
 # FCC-RAC buscar Indicativo
-STIFCC0100|FCC index old, rebuilding||
-STIFCC0101|Callsign Search||
-STIFCC0102|Callsign Not Found!||
-STIFCC0103|RAC index old, rebuilding||
+STIFCC0100|Índice FCC antiguo, reconstruyendo||
+STIFCC0101|Búsqueda de indicativo||
+STIFCC0102|¡Indicativo no encontrado!||
+STIFCC0103|Índice RAC antiguo, reconstruyendo||
 #
 #
 # Mensaje de Banda abierta 
@@ -888,15 +888,15 @@ UNIOP00026|%||
 UNIOP00027|pg Hg||
 UNIOP00028|mm Hg||
 UNIOP00029|Fije el tiempo del sistema del GPS||
-UNIOP00030|Digipeat?||
+UNIOP00030|¿Digipeat?||
 UNIOP00031|m||
-UNIOP00032|Apply|||
-UNIOP00033|Reset||
+UNIOP00032|Aplicar||
+UNIOP00033|Restablecer||
 UNIOP00034|min||
-UNIOP00035|hr||
-UNIOP00036|day||
-UNIOP00037|Send Control-E to get GPS data?||
-UNIOP00038|Add Delay||
+UNIOP00035|h||
+UNIOP00036|día||
+UNIOP00037|¿Enviar Control-E para obtener datos GPS?||
+UNIOP00038|Añadir retardo||
 #
 # Seleccionar Estación
 STCHO00001|Seleccionar Estación||
@@ -906,8 +906,8 @@ WPUPWXA001|Alerta del Tiempo||
 WPUPWXA002|Lista de alerta del Tiempo||
 #
 # Configurar Interfaces
-WPUPCIF001|Interfaces Instalados||
-WPUPCIF002|Elegir Tipo de interfáz||
+WPUPCIF001|Interfaces instaladas||
+WPUPCIF002|Elegir tipo de interfaz||
 #
 # Configurar AX.25 TNC
 WPUPCAX001|Configurar AX.25 TNC||
@@ -916,19 +916,19 @@ WPUPCAX002|AX.25 nombre de puerto||
 # Nombres de dispositivos de la Interfáz
 IFDNL00000|Nada||
 IFDNL00001|TNC vía el Puerto Serial||
-IFDNL00002|Serial TNC c/GPS más (cable HSP)||
+IFDNL00002|TNC serial c/GPS (cable HSP)||
 IFDNL00003|GPS vía Puerto Serial||
 IFDNL00004|Est. Meteorológica vía Puerto Serial||
 IFDNL00005|Conexión a un Servidor en Internet||
 IFDNL00006|AX.25 TNC||
-IFDNL00007|GPS Enlazado vía el Servidor gpsd||
+IFDNL00007|GPS en red (vía gpsd)||
 IFDNL00008|Est. Meteorológica Enlazada a una RED||
-IFDNL00009|Serial TNC c/GPS más (cable AUX)||
-IFDNL00010|Serial KISS TNC||
-IFDNL00011|Red Base de Datos (Aun No Implementada)||
+IFDNL00009|TNC serial c/GPS (puerto AUX)||
+IFDNL00010|TNC KISS serial||
+IFDNL00011|Base de datos en red (aún no implementada)||
 IFDNL00012|Red AGWPE||
-IFDNL00013|Serial Multi-Port KISS TNC||
-IFDNL00014|SQL Database (Experimental)||
+IFDNL00013|TNC KISS serial multipuerto||
+IFDNL00014|Base de datos SQL (experimental)||
 #
 # Info dispositivo Interfáz
 IFDIN00000|%s %2d %s sobre serial %s   %s||
@@ -943,7 +943,7 @@ IFDIN00008|  ERROR    ||
 IFDIN00009|DESCONOCIDO||
 #
 # Control de la interfáz
-IFPUPCT000|Control de Interfáz||
+IFPUPCT000|Control de interfaz||
 IFPUPCT001|Iniciar||
 IFPUPCT002|Detener||
 IFPUPCT003|Iniciar todos||
@@ -959,29 +959,29 @@ IGPUPCF004|Igate -> RF Ruta   ||
 # Estación Meteorológica
 WXPUPSI000|Estación meteorológica||
 WXPUPSI001|Tipo de estación Meteorológica||
-WXPUPSI002|Datos Actuales||
+WXPUPSI002|Datos actuales||
 WXPUPSI003|Curso del viento||
 WXPUPSI004|Velocidad del viento||
 WXPUPSI005|Ráfaga del viento||
 WXPUPSI006|Temperatura||
 WXPUPSI007|Total lluvia||
-WXPUPSI008|Hoy Total lluvia||
-WXPUPSI009|Presión Barométrica||
-WXPUPSI010|Humedad Relativa||
+WXPUPSI008|Lluvia total de hoy||
+WXPUPSI009|Presión barométrica||
+WXPUPSI010|Humedad relativa||
 WXPUPSI011|Peet Bros ULTIMETER 2000 Tipo (Modo Datos Log)||
 WXPUPSI012|Peet Bros ULTIMETER II Tipo||
 WXPUPSI013|Peet Bros ULTIMETER 2000 Tipo (Modo Paquete)||
 WXPUPSI014|Actual Tot. hora lluvia||
-WXPUPSI015|Ultimas 24 Tot. lluvias||
-WXPUPSI016|Cualimétricos Q-Net||
+WXPUPSI015|Lluvia total de las últimas 24 h||
+WXPUPSI016|Qualimetrics Q-Net||
 WXPUPSI017|Tipo Peet Bros ULTIMETER 2000 (Modo Completo)||
 WXPUPSI018|Punto de Rocío||
-WXPUPSI019|Viento Alto||
-WXPUPSI020|Viento Frío||
-WXPUPSI021|Indice Caluroso||
-WXPUPSI022|3-Hr Baro||
-WXPUPSI023|Alta Temperat.||
-WXPUPSI024|Baja Temperat.||
+WXPUPSI019|Viento máx.||
+WXPUPSI020|Sensación térmica||
+WXPUPSI021|Índice de calor||
+WXPUPSI022|Baróm. 3 h||
+WXPUPSI023|Temp. máx.||
+WXPUPSI024|Temp. mín.||
 WXPUPSI025|Radio Shack WX-200/Oregon Scientific WM-918||
 WXPUPSI026|Davis Weather Monitor II/Wizard III/Vantage Pro||
 WXPUPSI027|LaCrosse WX-23xx||
@@ -992,7 +992,7 @@ LHPUPNI000|Todas las estaciones||
 LHPUPNI001|Estaciones móviles||
 LHPUPNI002|Estaciones Meteorológicas||
 LHPUPNI003|Estaciones locales (vía TNC)||
-LHPUPNI004|Ultimas Estaciones||
+LHPUPNI004|Últimas estaciones||
 LHPUPNI005|Objetos y Artículos||
 LHPUPNI006|Objetos y Artículos Propio||
 LHPUPNI010| #||
@@ -1023,14 +1023,14 @@ LHPUPNI208|RN24||
 LHPUPNI209|Lat/Lon o UTM||
 #
 # Traza Alertas WX sobre mapas
-PULDNMAT01|Muestra mapa de alarma sobre otros mapas||
-PULDNMAT02|Muestra mapa de alarma bajo otros mapas||
+PULDNMAT01|Mostrar mapas de alerta sobre otros mapas||
+PULDNMAT02|Mostrar mapas de alerta bajo otros mapas||
 #
 # Error/popup mensajes
 POPEM00001|Localiza Error!||
 POPEM00002|La estación %s no fue encontrada!||
 POPEM00003|Rastreo Error!||
-POPEM00004|Interfáz Error!||
+POPEM00004|¡Error de interfaz!||
 POPEM00005|Inválido nombre de puerto AX.25 %s||
 POPEM00006|Inválido nombre de puerto AX.25 %s||
 POPEM00007|Inválido Indicativo %s||
@@ -1041,49 +1041,49 @@ POPEM00011|No puedo conectar al Indicativo AX.25, %s||
 POPEM00012|AX.25 error en la salida de UI||
 POPEM00013|AX.25 problema con el archivo axports||
 POPEM00014|AX.25 inválido nombre de puerto %s||
-POPEM00015|Error abriendo la interfáz %d, duro fallo||
-POPEM00016|Error abriendo la interfáz %d Tiempo agotado||
-POPEM00017|No hay mas interfáz disponible!||
-POPEM00018|Dato requerido - Simple Línea de Mensaje|
-POPEM00019|El Puerto de transmisión está "off" para puerto %d|
-POPEM00020|Error banco de Datos!|
+POPEM00015|Error al abrir la interfaz %d: fallo grave||
+POPEM00016|Error al abrir la interfaz %d: tiempo agotado||
+POPEM00017|¡No hay más interfaces disponibles!||
+POPEM00018|Consulta de datos - Línea de mensaje única||
+POPEM00019|La transmisión está desactivada para el puerto %d||
+POPEM00020|Error de base de datos||
 POPEM00021|El soporte de AX.25 no está compilado en Xastir!||
-POPEM00022|Error de entrada!|
-POPEM00023|Nombre de locación no especificada!|
-POPEM00024|Nombre de Locación especificada en uso!|
-POPEM00025|No Encontrado!||
+POPEM00022|Error de entrada||
+POPEM00023|No se especificó nombre de ubicación||
+POPEM00024|El nombre de ubicación especificado ya está en uso||
+POPEM00025|¡No encontrado!||
 POPEM00026|El Rastreo empezará cuando el aparezca||
-POPEM00027|Info Impropia. Algunos campos vacío?||
+POPEM00027|Información incorrecta. ¿Hay campos vacíos?||
 POPEM00028|No se puede abrir el archivo||
 POPEM00029|Encontrado!||
 POPEM00030|Símbolo de Estación Meteorológica||
 POPEM00031|Cambiado a símbolo WX '/_', otras opciones:  '\_'  '/W'  y  '\W'||
 POPEM00032|Aviso: Usando Símbolo del National Weather Service!||
-POPEM00033|No GPS Data!||
-POPEM00034|Disactivando TX de Mi Posición Hasta ver Data de GPS Válido!||
-POPEM00035|Warning||
-POPEM00036|Notice||
-POPEM00037|HSP interface present: GPS timing has been increased||
-POPEM00038|Name Conflicts With Existing Object/Item/Station||
-POPEM00039|Illegal characters found, substituting periods in their place||
-POPEM00040|Custom outgoing path was lost||
-POPEM00041|Processing another file.  Wait a bit, then try again||
-POPEM00042|Object not owned by me! Try adopting the object first.||
-POPEM00043|Not an Object/Item!||
-POPEM00044|Fetch Findu Trail: Failed||
-POPEM00045|Fetch Findu Trail: Complete||
-POPEM00046|Berkeley DB header/shared library do NOT match! Disabling map cache.||
-POPEM00047|Global transmit is DISABLED. Emergency beacons are NOT going out!||
-POPEM00048|Emergency Beacon Mode!||
-POPEM00049|EMERGENCY BEACON MODE, transmitting every 60 seconds!||
-POPEM00050|Interfaces or posits/transmits DISABLED.  Emergency beacons are NOT going out!||
-POPEM00051|Altnet is enabled (Configure->Defaults dialog)||
-POPEM00052|Callsign is EMPTY!||
-POPEM00053|Message is EMPTY!||
-POPEM00054|We're trying to talk to ourselves!||
+POPEM00033|¡Sin datos GPS!||
+POPEM00034|Desactivando TX de mi posición hasta tener datos GPS válidos||
+POPEM00035|Advertencia||
+POPEM00036|Aviso||
+POPEM00037|Interfaz HSP presente: el temporizado GPS ha aumentado||
+POPEM00038|El nombre entra en conflicto con un objeto/artículo/estación existente||
+POPEM00039|Se encontraron caracteres no permitidos; se sustituyeron por puntos||
+POPEM00040|Se perdió la ruta de salida personalizada||
+POPEM00041|Se está procesando otro archivo. Espere un momento e inténtelo de nuevo||
+POPEM00042|¡El objeto no me pertenece! Intente adoptarlo primero.||
+POPEM00043|¡No es un objeto/artículo!||
+POPEM00044|Obtener rastro Findu: falló||
+POPEM00045|Obtener rastro Findu: completado||
+POPEM00046|¡La cabecera y la biblioteca compartida de Berkeley DB NO coinciden! Desactivando caché de mapas.||
+POPEM00047|La transmisión global está DESACTIVADA. ¡Las balizas de emergencia NO saldrán!||
+POPEM00048|¡Modo baliza de emergencia!||
+POPEM00049|¡MODO BALIZA DE EMERGENCIA, transmitiendo cada 60 segundos!||
+POPEM00050|Interfaces o posiciones/transmisiones DESACTIVADAS. ¡Las balizas de emergencia NO saldrán!||
+POPEM00051|Altnet está activado (diálogo Configurar->Predeterminados)||
+POPEM00052|¡El indicativo está VACÍO!||
+POPEM00053|¡El mensaje está VACÍO!||
+POPEM00054|¡Estamos intentando hablarnos a nosotros mismos!||
 #
 # Salto de Locación
-JMLPO00001|Localización de Mapa||
+JMLPO00001|Marcadores del mapa||
 JMLPO00002|IR!||
 JMLPO00003|Nombre de Nueva Localización:||
 #
@@ -1125,16 +1125,16 @@ SYMSEL0003|Tabla de Símbolo Secundario||
 #
 # Diálogo de la Propiedades de Impresora
 PRINT0001|Propiedades de Impresora||
-PRINT0002|Ancho del Paper||
-PRINT0003|Auto-Rotar Imagen
+PRINT0002|Tamaño del papel||
+PRINT0003|Auto-Rotar Imagen||
 PRINT0004|Rotar Imagen 90° CCW||
 PRINT0005|Auto-Balancear Imagen||
-PRINT0006|Balanza:||
-PRINT0007|Forza el predefinido color de fondo a blanco||
+PRINT0006|Escala:||
+PRINT0007|Forzar el color de fondo predeterminado a blanco||
 PRINT0008|Imprime en Blanco y Negro||
 PRINT0016|Colores Revertidos||
 PRINT0009|Resolución de Postscript:||
-PRINT0010|Prevista||
+PRINT0010|Vista previa||
 PRINT0011|Imprimir al archivo||
 PRINT0012|Guardar imagen a un archivo...||
 PRINT0013|Convirtiendo a Postscript...||
@@ -1142,21 +1142,21 @@ PRINT0014|Creando archivo de impresión Finalizado||
 PRINT0015|Estado de Impresora||
 #
 # Diálogo de la Propiedades de Impresora
-PRINT1001|Direct to:||
-PRINT1002|Via Previewer:||
+PRINT1001|Directo a:||
+PRINT1002|Mediante previsualizador:||
 #
 # Diálogo de localizar forma
 FEATURE001|Nombre:||
 FEATURE002|Estado/Provincia:||
-FEATURE003|Pais:||
-FEATURE004|Cuadratura del Mapa:||
+FEATURE003|Condado:||
+FEATURE004|Cuadrícula del mapa:||
 FEATURE005|Tipo:||
-FEATURE006|GNIS Archivo:||
-FEATURE007|Address:||
-FEATURE008|City:||
-FEATURE009|Mark Destination||
-FEATURE010|Zip Code:||
-FEATURE011|Geocoding File||
+FEATURE006|Archivo GNIS:||
+FEATURE007|Dirección:||
+FEATURE008|Ciudad:||
+FEATURE009|Marcar destino||
+FEATURE010|Código postal:||
+FEATURE011|Archivo de geocodificación||
 #
 # Geocoding Dialog (Nominatim)
 GEOCODE001|Buscar ubicación||
@@ -1198,8 +1198,8 @@ GEOCFG004|(Opcional pero recomendado)||
 GEOCFG005|País predeterminado:||
 #
 # Diálogo de Calcular Coordenada
-COORD001|Calcula Coordenada||
-COORD002|Calc||
+COORD001|Calculadora de coordenadas||
+COORD002|Calc.||
 COORD003|Calcular||
 COORD004|Limpiar||
 COORD005|UTM||
@@ -1208,14 +1208,14 @@ COORD007|Longitud o||
 COORD008|Zona||
 COORD009|UTM Hacia Este||
 COORD010|UTM Hacia Norte||
-COORD011|               Decimal Degrees:  ||
-COORD012|       Degrees/Decimal Minutes:  ||
-COORD013|  Degrees/Minutes/Dec. Seconds:  ||
-COORD014| Universal Transverse Mercator:  ||
-COORD015|Military Grid Reference System:  ||
-COORD016|       Maidenhead Grid Locator:  ||
-COORD017| **       Sorry, your input was not recognized!        **||
-COORD018| **   Please use one of the following input formats:   **||
+COORD011|               Grados decimales:  ||
+COORD012|       Grados/Minutos decimales:  ||
+COORD013|  Grados/Minutos/Seg. decimales:  ||
+COORD014| Mercator transversa universal:  ||
+COORD015|Sistema de referencia de cuadrícula militar:  ||
+COORD016|       Localizador de cuadrícula Maidenhead:  ||
+COORD017| **      Lo sentimos, no se reconoció su entrada       **||
+COORD018| ** Use uno de los siguientes formatos de entrada: **||
 #
 # Diálogo Baliza Inteligente
 SMARTB001|Baliza Inteligente||
@@ -1235,17 +1235,17 @@ GAMMA001|Ajuste Corrección de Gamma||
 GAMMA002|Corrección Gamma||
 #
 # Map labels font Dialog
-MAPFONT001|Change Fonts||
-MAPFONT002|Fonts||
+MAPFONT001|Cambiar fuentes||
+MAPFONT002|Fuentes||
 MAPFONT003|Map Font Minúsculo||
 MAPFONT004|Map Font Pequeño||
 MAPFONT005|Map Font Medio||
 MAPFONT006|Map Font Grande||
 MAPFONT007|Map Font Enorme||
-MAPFONT008|Map Font Border||
-MAPFONT009|Menu Font||
-MAPFONT010|Station Font||
-MAPFONT011|ATV ID Font||
+MAPFONT008|Borde de fuente de mapa||
+MAPFONT009|Fuente de menú||
+MAPFONT010|Fuente de estación||
+MAPFONT011|Fuente de ID ATV||
 #
 # Distancia/Orientación en línea de estado
 PULDNDB001|Estado de Distancia/Orientación||
@@ -1272,8 +1272,8 @@ MAPP005|Llenado->||
 MAPP006|Sí||
 MAPP007|No||
 MAPP008|Automapas->||
-MAPP009|Max Zoom->||
-MAPP010|Min Zoom->||
+MAPP009|Zoom máx.->||
+MAPP010|Zoom mín.->||
 MAPP011|Auto||
 MAPP012|USGS DRG->||
 #
@@ -1289,45 +1289,45 @@ TIME008|Segundos||
 #
 #
 # Map Caching
-CACHE001|Map now cached||
-CACHE002|Loading Cached Map||
-CACHE003|Map not found in cache...||
+CACHE001|Mapa almacenado en caché||
+CACHE002|Cargando mapa en caché||
+CACHE003|Mapa no encontrado en caché...||
 #
 #
 # Map Screen Misc
-RANGE001|RANGE SCALE||
+RANGE001|ESCALA DE DISTANCIA||
 #
 #
 # GPS Status
-GPSS001|WAAS or PPS||
+GPSS001|WAAS o PPS||
 GPSS002|DGPS||
-GPSS003|Valid SPS||
-GPSS004|Invalid||
-GPSS005|Sats/View||
-GPSS006|Fix||
-GPSS007|!GPS data is older than 30 seconds!||
-GPSS008|Simulation||
+GPSS003|SPS válido||
+GPSS004|Inválido||
+GPSS005|Sats/Vista||
+GPSS006|Fijación||
+GPSS007|¡Los datos GPS tienen más de 30 segundos!||
+GPSS008|Simulación||
 GPSS009|Manual||
-GPSS010|Estimated||
-GPSS011|Float RTK||
+GPSS010|Estimado||
+GPSS011|RTK flotante||
 GPSS012|RTK||
 #
 #
 # Popup cad_dialog to obtain CAD object data
-CADPUD001|Area Object||
-CADPUD002|Area Label:||
-CADPUD003|Comment:||
-CADPUD004|Probability (%):||
-CADPUD005|OK||
-CADPUD006|CAD Dialog||
-CADPUD007|Show/Edit Details||
-CADPUD008|Cancel||
-CADPUD009|Delete CAD objects?||
-CADPUD010|Delete All||
-CADPUD011|Delete Selected||
-CADPUD012|Solid||
-CADPUD013|Dashed||
-CADPUD014|Double Dash||
+CADPUD001|Objeto de área||
+CADPUD002|Etiqueta de área:||
+CADPUD003|Comentario:||
+CADPUD004|Probabilidad (%):||
+CADPUD005|Aceptar||
+CADPUD006|Diálogo CAD||
+CADPUD007|Mostrar/Editar detalles||
+CADPUD008|Cancelar||
+CADPUD009|¿Eliminar objetos CAD?||
+CADPUD010|Eliminar todos||
+CADPUD011|Eliminar seleccionados||
+CADPUD012|Sólido||
+CADPUD013|Discontinuo||
+CADPUD014|Doble guion||
 #
 #
 # Format strings for map metadata in top border

--- a/config/language-Spanish.sys
+++ b/config/language-Spanish.sys
@@ -77,12 +77,12 @@ PULDNMP007|Alerta Mapa WX||
 PULDNMP005|Color de fondo|C|
 PULDNMP006|Estilo de texto de estación|E|
 PULDNMP026|Estilo del contorno del icono|O|
-PULDNMP011|Menú Indicador del Ratón|R|
+PULDNMP011|Menú Contextual del Ratón|R|
 PULDNMP008|Intensidad del Mapa|I|
 PULDNMP021|Auto Mapa - Desactivar Mapas de Trama||
-PULDNMP022|Indexar mapas al inicio||
+PULDNMP022|Crear índice de mapas al inicio||
 PULDNMP023|Índice: agregar mapas nuevos|A|
-PULDNMP024|Índice: reindexar TODOS los mapas|T|
+PULDNMP024|Índice: reconstruir TODOS los mapas|T|
 PULDNMP025|Fuentes||
 PULDNMP015|Xfontsel||
 PULDNMP027|Volver a descargar mapas (sin caché)||
@@ -351,7 +351,7 @@ BBARSTA035|Esperando por datos del GPS vía AUX..||
 BBARSTA036|Limpiando el AUX datos obtenido del TNC..||
 BBARSTA037|Datos GPS decodificados||
 BBARSTA038|Coloque el cambio en mi estación||
-BBARSTA039|Indexando %s||
+BBARSTA039|Creando índice de %s||
 BBARSTA040|Estación APRS(tm) de radioaficionado %s||
 BBARSTA041|Esperando datos GPS..||
 BBARSTA042|Transmitiendo objetos/articulos||

--- a/help/help-Spanish.dat
+++ b/help/help-Spanish.dat
@@ -2,7 +2,7 @@ HELP-INDEX>LÉEME PRIMERO - Licencia
 
                           LÉEME PRIMERO - Licencia
 
-Para la información más actual, por favor lea el archivo README.md en el
+Para la información más actual, lea el archivo README.md en el
 directorio de Xastir. También vea los archivos LICENSE y COPYING para
 información adicional.
 
@@ -220,7 +220,7 @@ colocarán en algún lugar dentro del rango de la opción que seleccionó. Tenga
 cuenta que esto puede confundir a algunas estaciones que no cumplen con las
 especificaciones. Findu.com no entiende la ambigüedad de posición.
 
-Hacer clic en OK guardará los cambios, Hacer clic en Cancel mantendrá los
+Hacer clic en OK guardará los cambios, Hacer clic en Cancelar mantendrá los
 ajustes anteriores.
 
 HELP-INDEX>Configurar Funcionamiento Predeterminado
@@ -356,7 +356,7 @@ HELP-INDEX>Configurar Alarmas de Audio
 Haga clic en Archivo, luego Configurar, luego Alarmas de Audio.
 
 Para usar esta opción debe tener una tarjeta de sonido y un programa que
-reproduzca archivos wav. El Audio Play Command debe contener el programa que
+reproduzca archivos wav. El comando de reproducción de audio debe contener el programa que
 desea ejecutar para reproducir el archivo de audio (y cualquier opción de
 línea de comandos). Por supuesto, esto no funciona si la única tarjeta de
 sonido en el sistema se usa para un soundmodem...
@@ -375,7 +375,7 @@ Reproducir mensaje al recibir datos de una estación (vía TNC) dentro de la
 Reproducir mensaje al recibir y mostrar una alerta meteorológica nueva.
 
 Hay un conjunto estándar de sonidos disponibles en la mayoría de los lugares
-donde se puede obtener Xastir, por favor vea el archivo INSTALL.md para más
+donde se puede obtener Xastir; consulte el archivo INSTALL.md para más
 información.
 
 HELP-INDEX>Configurar síntesis de voz
@@ -391,20 +391,19 @@ puede experimentar problemas con conexiones rechazadas por el servidor.
 Una vez que tenga festival instalado, Xastir tendrá la capacidad de hablar
 usando las siguientes opciones:
 
-New Station       - Anunciar la indicación de una estación nueva.
-New Message Alert - Anunciar la llegada de un nuevo mensaje.
-New Message Body  - Leer el contenido de un mensaje.
-Proximity Alert   - Anunciar cuando se recibe datos de una estación dentro del
+Nueva estación    - Anunciar la indicación de una estación nueva.
+Alerta de mensaje nuevo - Anunciar la llegada de un nuevo mensaje.
+Cuerpo del mensaje nuevo - Leer el contenido de un mensaje.
+Alerta de proximidad - Anunciar cuando se recibe datos de una estación dentro del
     rango mín./máx. de su configuración de proximidad. Esta opción utiliza la
     configuración de proximidad encontrada en el menú Alarmas de Audio.
-Tracked station Proximity Alert - Anunciar cuando se recibe datos de una
+Alerta de proximidad de estación rastreada - Anunciar cuando se recibe datos de una
     estación dentro del rango mín./máx. de la estación monitoreada. Esta opción
     utiliza la configuración de proximidad encontrada en el menú Alarmas de Audio.
-Band Opening      - Anunciar cuando se recibe datos de una estación (vía TNC)
+Apertura de banda - Anunciar cuando se recibe datos de una estación (vía TNC)
     dentro del rango mín./máx. de su configuración de apertura de banda. Esta
-    opción utiliza la configuración de distancia encontrada en el menú Audio
-    Alarms.
-New Weather Alert - Aún no implementado.
+  opción utiliza la configuración de distancia encontrada en el menú Alarmas de Audio.
+Nueva alerta meteorológica - Aún no implementado.
 
 Información sobre Festival se puede obtener de:
 https://www.cstr.ed.ac.uk/projects/festival/
@@ -596,30 +595,30 @@ Una estación podría colocar varios objetos diferentes en el mapa, con su
 posición transmitida a otras estaciones. Los nombres de los objetos son menos
 restrictivos que los nombres de estaciones normales.
 
-Objects y Items son casi lo mismo, pero su uso podría diferir un poco. Los
-Objects se utilizan generalmente para cosas móviles o variables como
-tormentas, mientras que los Items se utilizan generalmente para cosas más
+Objetos y Artículos son casi lo mismo, pero su uso podría diferir un poco. Los
+Objetos se utilizan generalmente para cosas móviles o variables como
+tormentas, mientras que los Artículos se utilizan generalmente para cosas más
 inanimadas, como estaciones de agua. Debido a que algunos sabores de programas
-APRS(tm) no pueden decodificar Items, los Objects se usan a menudo para cosas
+APRS(tm) no pueden decodificar Artículos, los Objetos se usan a menudo para cosas
 inanimadas también.
 
 Además de los objetos normales con un símbolo en su posición hay algunos
-objetos especiales disponibles. Los Area Objects son útiles para una variedad
+objetos especiales disponibles. Los Objetos de área son útiles para una variedad
 de operaciones en las que desea dibujar o resaltar un área de interés en el
 mapa. También se pueden usar para dibujar senderos/carreteras/límites, cajas
 de vigilancia para clima severo, pistas, perímetro de un área de búsqueda o de
 un evento de servicio público, áreas de daño, áreas para evitar, edificios que
 no están en el mapa, tableros de damas/ajedrez para juegos en APRS(tm). :-)
-Tenga en cuenta que los Area Objects no se implementan en todas las versiones
+Tenga en cuenta que los Objetos de área no se implementan en todas las versiones
 de programas APRS(tm), y algunos de los detalles de cómo se muestran también
 pueden ser diferentes en otros programas.
 Para los otros tres, círculos de probabilidad, señalización y objetos DF,
 vea abajo.
 
-Objects/Items se retransmiten a una tasa decreciente hasta el intervalo máximo
+Los Objetos/Artículos se retransmiten a una tasa decreciente hasta el intervalo máximo
 especificado en Archivo|Configurar|Cronómetro. Los objetos/items "killed" también se
 retransmiten de esta manera hasta que expiren de la cola (actualmente 20
-transmisiones). Objects/Items persisten en sesiones de Xastir y se almacenan
+transmisiones). Los Objetos/Artículos persisten en sesiones de Xastir y se almacenan
 en ~/.xastir/config/object.log. Este archivo puede borrarse seleccionando
 "Limpiar Historia de Objeto/Artículo" desde el menú Estaciones.
 
@@ -633,7 +632,7 @@ información actual del objeto ya está rellenada, y el nombre del objeto y
 algunas de las otras opciones no se pueden cambiar. También podría eliminar el
 objeto con esta opción.
 
-Objects e Items se pueden mover con el ratón si la casilla de verificación
+Los Objetos y Artículos se pueden mover con el ratón si la casilla de verificación
 "Move" en la barra de herramientas está habilitada.
 
 La opción Objetos predefinidos en el menú de clic derecho le permite colocar
@@ -660,16 +659,16 @@ Consulte el archivo predefined_SAR.sys para obtener detalles.
 
 Descripción de las entradas en el diálogo de objetos:
 
-= Signpost =
+= Señalización =
 Esto hace que el objeto sea un objeto de señalización. Estos signos pueden
 contener uno a tres caracteres y actualmente aparecen en Xastir como un signo
 en blanco. Info Estación muestra el valor contenido en el signo.
 
-= Area Object =
+= Objeto de área =
 Esto hace que el objeto sea un Area Object e habilita los controles de Area
 Object descritos a continuación.
 
-= DF Object =
+= Objeto DF =
 Este es un informe de búsqueda de dirección. Habilitarlo le permite elegir
 Omni o Beam report, y le permite poner en los detalles específicos de cada
 uno. Vea:
@@ -677,7 +676,7 @@ uno. Vea:
 para la discusión de Bob Bruninga sobre cómo usar estas técnicas.
 (FIXME: Sección separada sobre técnicas DF'ing?)
 
-= Probability Circles =
+= Círculos de probabilidad =
 Esto le permite definir el radio (en millas) de dos círculos centrados en el
 objeto o item. Min es el radio (en millas) del círculo interior más pequeño, y
 Max es el radio (en millas) del círculo exterior más grande. Estos círculos se
@@ -690,57 +689,57 @@ software de cliente no muestren círculos de probabilidad.
 Este es el nombre del objeto o item. Puede tener hasta 9 caracteres de largo,
 con espacios permitidos dentro del nombre. Al modificar un objeto, esto no se
 puede cambiar. Para cambiar el nombre de un objeto debe eliminar el original y
-luego crear un nuevo objeto. Tenga en cuenta que si selecciona Signpost/Area
-Object/DF Object, este campo y posiblemente otros se borran. Ingrese el nombre
+luego crear un nuevo objeto. Tenga en cuenta que si selecciona Señalización/Objeto de área/
+Objeto DF, este campo y posiblemente otros se borran. Ingrese el nombre
 DESPUÉS de haber seleccionado el tipo de objeto en el que se convertirá.
 
-= Station Symbol =
-Puede seleccionar un símbolo para el objeto. Presione select para elegir
+= Símbolo de la estación =
+Puede seleccionar un símbolo para el objeto. Presione Seleccionar para elegir
 gráficamente, o consulte la sección de ayuda de la tabla de símbolos para
 descripciones de cada símbolo. Tenga en cuenta también que los objetos de
-Area, signpost y DF tienen símbolos fijos especiales y por lo tanto no se
+área, señalización y DF tienen símbolos fijos especiales y por lo tanto no se
 pueden seleccionar aquí. Esos símbolos particulares se asignan automáticamente
 cuando cambia a ese tipo de objeto.
 
-= Location =
-La ubicación del objeto se especifica aquí. Si seleccionó "Create Object/Item"
+= Ubicación =
+La ubicación del objeto se especifica aquí. Si seleccionó "Crear Objeto/Artículo"
 del menú de clic derecho, la ubicación en la que hizo clic se rellenará. Si
 movió un objeto con el ratón, la nueva ubicación estará en estos campos. También
 puede escribir una ubicación, por ejemplo, puede estar colocando un objeto desde
 un informe de voz sobre el aire.
 
-= Generic Options =
+= Opciones generales =
 Puede especificar la velocidad, dirección y altitud de los objetos aquí. Algunos
 tipos de objetos no pueden tener una velocidad o dirección, en cuyo caso los
 campos están atenuados.
 
-= Signpost Text =
+= Texto de señalización =
 Si el objeto es un objeto de señalización, puede especificar aquí el número de
 1 a 3 dígitos que aparece en el signo. Tenga en cuenta que Xastir aún no
 muestra correctamente los objetos de señalización.
 
-= Area Object =
-Los Area Objects se utilizan para resaltar partes específicas de mapas, o para
+= Objeto de área =
+Los Objetos de área se utilizan para resaltar partes específicas de mapas, o para
 dibujar detalles adicionales en mapas. Esto se hará con las siguientes
 entradas:
-  = Bright Color =
+  = Color brillante =
     Use la versión más brillante de los colores permitidos.
-  = Color-Fill =
+  = Relleno de color =
     El área debe ser rellenada, no solo perfilada. Esto puede ser útil para
     excluir un área de una búsqueda u otro evento.
-  = Object Type =
+  = Tipo de objeto =
     Elija entre las formas geométricas permitidas.
-  = Object Color =
+  = Color del objeto =
     Elija el color en el cual se mostrará el objeto. Esto también se ve
-    afectado por la opción "Bright Color" anterior.
-  = Object Offset Up =
+    afectado por la opción "Color brillante" anterior.
+  = Desplazamiento superior del objeto =
     En 1/1500 de un grado de latitud. Un detalle desafortunado de la
     especificación, y difícil de calcular fácilmente. Baste decir que puede
     cambiar el tamaño del objeto una vez que lo coloque.
-  = Object Offset Left except / =
+  = Desplazamiento izquierdo del objeto excepto / =
     En 1/1500 de un grado de longitud. Vea arriba.
-  = Object corridor =
-    Este es el ancho de una línea de Area Object. Útil para pistas, cajas de
+  = Corredor del objeto =
+    Este es el ancho de una línea de Objeto de área. Útil para pistas, cajas de
     vigilancia de clima, describiendo un área de interés o un área de
     exclusión, etc.
 
@@ -765,16 +764,16 @@ Watch boxes y "areas of maximum concern" (AOMC) generadas por el WXSVR
 HELP-INDEX>Objetos CAD
 
                      Objetos CAD
-El soporte de CAD Objects es preliminar en este momento. Las características y
+El soporte de Objetos CAD es preliminar en este momento. Las características y
 la interfaz de usuario están sujetas a cambios.
 
-Los CAD Objects son formas arbitrarias que puede dibujar en mapas en xastir,
+Los Objetos CAD son formas arbitrarias que puede dibujar en mapas en xastir,
 pero no puede transmitir por APRS.
 
-Los CAD Objects actualmente soportados son:
+Los Objetos CAD actualmente soportados son:
 Polygons: Áreas cerradas de al menos tres puntos.
 
-Para crear un CAD Object, primero presione el botón de radio Draw en la barra
+Para crear un Objeto CAD, primero presione el botón de radio Dibujar en la barra
 de herramientas. Esto cambiará el cursor a un lápiz. Comience a dibujar un
 polígono haciendo clic con el botón central del ratón (o ambos botones en un
 ratón de dos botones, para lo cual necesitará tener habilitada la emulación de
@@ -784,16 +783,16 @@ derecho funcionan normalmente) y haga clic en el botón central del ratón
 nuevamente. Esto dibuja una línea entre los dos puntos que ha seleccionado.
 Haga clic central nuevamente para dibujar otro segmento de línea y repita hasta
 que haya dibujado todos excepto el segmento de línea de cierre de su polígono.
-Para cerrar el polígono, seleccione Map/Draw CAD Objects/Close Polygon. Esto
+Para cerrar el polígono, seleccione Mapas/Dibuje Objetos CAD/Cerrar polígono. Esto
 cerrará su polígono y traerá un diálogo que le permitirá ingresar un nombre,
 comentario y probabilidad del polígono.
 
-Cuando haya terminado de dibujar CAD Objects, salga del modo de dibujo CAD
-deseleccionando el botón de radio Draw en la barra de herramientas.
+Cuando haya terminado de dibujar Objetos CAD, salga del modo de dibujo CAD
+deseleccionando el botón de radio Dibujar en la barra de herramientas.
 
-Los CAD Objects se pueden editar desde el menú View/CAD Polygons y desde el
-menú Map/Draw CAD Objects/CAD Polygons. Los CAD Objects se pueden eliminar
-desde el menú Map/Draw CAD Objects/Erase CAD Polygons.
+Los Objetos CAD se pueden editar desde el menú Visualizar/Polígonos CAD y desde el
+menú Mapas/Dibuje Objetos CAD/Polígonos CAD. Los Objetos CAD se pueden eliminar
+desde el menú Mapas/Dibuje Objetos CAD/Borrar polígonos CAD.
 
 HELP-INDEX>Menú Visualizar
 
@@ -806,7 +805,7 @@ Este es el tablero de anuncios APRS(tm), donde se publican anuncios importantes.
 Si está conectado con la interfaz de internet, es una buena idea establecer el
 campo de rango a algunas cientos de millas, para ignorar publicaciones de otras
 partes del mundo. "0" en el campo de rango significa el mundo entero. Haga clic
-en el botón "Change range" para que los cambios en este campo sean efectivos.
+en el botón "Cambiar rango" para que los cambios en este campo sean efectivos.
 Xastir actualmente no admite el envío de boletines. Los boletines entrantes
 abrirán este diálogo automáticamente si selecciona "Mostrar boletines nuevos" en el
 diálogo Configurar|Predefinidos. El botón "Ver boletines de distancia cero" habilita la
@@ -906,10 +905,10 @@ en el botón OK. Puede seleccionar cualquier número de mapas. Hacer clic en
 "Limpiar" no seleccionará mapas, hacer clic en "Vectores" seleccionará solo mapas
 vectoriales. Las tres opciones "topo" seleccionarán automáticamente todas las
 imágenes GeoTIFF del tamaño listado. Hacer clic en el botón OK mostrará los
-mapas seleccionados. Cancel abandonará cualquier cambio.
+mapas seleccionados. Cancelar abandonará cualquier cambio.
 
   Propiedades de la Selección de Mapa
-  Hacer clic en el botón Properties traerá un diálogo donde puede especificar
+  Hacer clic en el botón Propiedades traerá un diálogo donde puede especificar
   la capa en la cual aparecen los mapas, y en qué niveles de zoom aparecen.
   Los números de capas más altos se muestran encima de los números más bajos.
   El rango puede especificarse de -99999 a 99999; se sugiere que espacie ampliamente
@@ -917,7 +916,7 @@ mapas seleccionados. Cancel abandonará cualquier cambio.
   adicionales. Desde este diálogo puede especificar si un mapa vectorial se
   dibuja con rellenos de color. Esta es una configuración por mapa; la opción de
   deshabilitación global en el menú Mapas puede reemplazar esto. La configuración
-  Filled se ignora para mapas raster (imágenes). Una configuración de "auto"
+  La opción de relleno se ignora para mapas raster (imágenes). Una configuración de "automático"
   permite que un archivo dbfawk controle este parámetro directamente (usable solo
   si dbfawk está compilado y el mapa en cuestión es un Shapefile). También puede
   seleccionar si un mapa es considerado por la característica "Activar Auto Mapas" aquí.
@@ -946,8 +945,8 @@ o nombre de un negocio o ubicación. Generará una solicitud de internet a un
 servidor "Nominatim" que consulta datos de OpenStreetMap para encontrar la
 ubicación. Si se encuentran algunos, el diálogo se rellenará con una lista de
 ubicaciones coincidentes. Elija uno haciendo clic en él y luego haga clic en
-"Go To" o "Mark". Cualquiera de las opciones centrará el mapa en la ubicación
-elegida, el botón "Mark" también colocará una gran "X" azul sobre la ubicación.
+"Ir a" o "Marcar". Cualquiera de las opciones centrará el mapa en la ubicación
+elegida, el botón "Marcar" también colocará una gran "X" azul sobre la ubicación.
 
 Calculadora de coordenadas
 Esta opción abre una calculadora simple que puede convertir entre sistemas de
@@ -966,7 +965,7 @@ Menú Configurar:
   Esto controla el brillo de cualquier gráfico utilizado como mapas. Esta
   opción solo aparece si ha compilado con soporte GeoTIFF.
 
-  Adjust Gamma Correction
+  Ajustar corrección gamma
   Esto le permite aplicar corrección gamma a todos los gráficos de mapas
   cargados. Los mapas se pueden ajustar individualmente en sus archivos .geo,
   consulte la sección sobre .geos en "Archivos de mapas y condados WX". Esta opción
@@ -991,7 +990,7 @@ en cada redibujado. Tenga en cuenta que esta opción no se guarda entre sesiones
 
 Activar Auto Mapas
 
-NOTA: ¡"Activar Auto Mapas" es una característica deprecated que es mejor dejarla
+NOTA: ¡"Activar Auto Mapas" es una característica obsoleta que es mejor dejarla
 desactivada!
 
 Cuando está habilitado, cualquier mapa encontrado en el directorio de mapas
@@ -1017,11 +1016,11 @@ fina. El espaciado de la cuadrícula de latitud y longitud se puede ajustar
 manualmente con las teclas "+" y "-".
 
 Activar borde del mapa
-Cuando tanto Enable Map Grid como Enable Map Border están habilitados, se dibuja
+Cuando tanto la cuadrícula del mapa como el borde del mapa están habilitados, se dibuja
 un borde blanco estrecho alrededor del mapa y las líneas de cuadrícula se
-etiquetan usando el sistema de coordenadas seleccionado (File/Configure/
-Coordinate System), y la fuente de borde seleccionada (Map/Configure/Map Labels
-font/Border Font). Si se seleccionan los sistemas de coordenadas UTM o MGRS, las
+etiquetan usando el sistema de coordenadas seleccionado (Archivo/Configurar/
+Sistema de coordenadas), y la fuente de borde seleccionada en la configuración
+de etiquetas del mapa. Si se seleccionan los sistemas de coordenadas UTM o MGRS, las
 líneas de cuadrícula se etiquetarán solo con valores de este y norte en niveles
 de zoom más pequeños que aproximadamente 2048.
 
@@ -1814,7 +1813,7 @@ FCC y RAC deben colocarse en el directorio /usr/local/share/xastir/fcc, ¡y la
 mayúsculas/minúsculas es importante! Presionar este botón agrega el nombre y
 dirección de la estación al cuadro de Información de la Estación. Las
 instrucciones para instalar estas bases de datos se encuentran en la página
-"Helper Scripts" en el wiki,
+"Scripts auxiliares" en el wiki,
 https://github.com/Xastir/Xastir/wiki/Helper-Scripts
 
 Xastir creará archivos de índice para cada archivo de base de datos al
@@ -1948,34 +1947,34 @@ tenga visibles. Esto puede ahorrar bastante tinta.
 HELP-INDEX>Crear Instantáneas
 
                      Crear Instantáneas Automáticas
-Xastir tiene la capacidad de crear snapshots automáticos de la pantalla del mapa
+Xastir tiene la capacidad de crear instantáneas automáticas de la pantalla del mapa
 en forma recurrente. El período de tiempo predeterminado es una vez cada cinco
 minutos. Si tiene "convert" de las herramientas GraphicsMagick instaladas,
 Xastir creará un archivo en formato XPM en ~/.xastir/tmp/, luego lo convertirá
 al archivo PNG ~/.xastir/tmp/snapshot.png. Este archivo es útil para
 incrustar en páginas web para mostrar una imagen "en vivo" de lo que hay en su
-pantalla de Xastir. Activa esta característica mediante el botón de alternancia
+pantalla de Xastir. Active esta característica mediante el botón de alternancia
 "Archivo->Activa PNG Instantánea". La frecuencia es una vez cada cinco minutos (configurable
 desde el diálogo Configurar Cronómetro desde "Archivo->Configurar->Cronómetro"), o cada vez
 que el botón se alterna de apagado a encendido. Se crea un archivo .geo para que
-pueda usar el snapshot como mapa. También se escribe un archivo .kml para que
-pueda usar el snapshot como una superposición gráfica en terreno en
+pueda usar la instantánea como mapa. También se escribe un archivo .kml para que
+pueda usar la instantánea como una superposición gráfica en terreno en
 aplicaciones capaces de leer kml. Ver kml_snapshot_to_web.sh y
 kml_snapshot_feed.kml en el directorio scripts para más información sobre cómo
 usar los archivos snapshot.png y snapshot.kml para producir una fuente kml
-usando los snapshots.
+usando las instantáneas.
 
-                    Crear Snapshots KML Automáticos
+                    Crear Instantáneas KML Automáticas
 
 Xastir es capaz de escribir todas las estaciones actuales y pistas a un archivo
-kml en forma recurrente. Activa esta característica mediante el botón de
+kml en forma recurrente. Active esta característica mediante el botón de
 alternancia "Archivo->Instantáneas KML". La frecuencia a la que se generan estos
-snapshots es la misma que la de los snapshots PNG, configurada desde
-"Archivo->Configurar->Cronómetro" estableciendo el intervalo de tiempo de snapshot.
-Cada snapshot se escribe a un archivo .kml en ~/.xastir/tracklogs, con un nombre
-de archivo basado en la fecha y hora del snapshot, ej. 20080206-000720.kml. Este
-comportamiento puede cambiar para que los snapshots KML se escriban a un único
-archivo como los snapshots PNG.
+archivos es la misma que la de las instantáneas PNG, configurada desde
+"Archivo->Configurar->Cronómetro" estableciendo el intervalo de tiempo de instantánea.
+Cada instantánea se escribe a un archivo .kml en ~/.xastir/tracklogs, con un nombre
+de archivo basado en la fecha y hora de la instantánea, ej. 20080206-000720.kml. Este
+comportamiento puede cambiar para que las instantáneas KML se escriban en un único
+archivo como las instantáneas PNG.
 
 
 HELP-INDEX>Scripts Incluidos
@@ -1986,7 +1985,7 @@ Xastir incluye varios scripts Perl y un script de shell que pueden ser útiles:
 
 get-fcc-rac.pl
 Este script de shell automatiza la recuperación e instalación de las bases de
-datos de callsign FCC y RAC. ¡Ten en cuenta que estas bases de datos son muy
+datos de indicativos FCC y RAC. Tenga en cuenta que estas bases de datos son muy
 grandes!
 
 icontable.pl
@@ -2076,9 +2075,9 @@ Serial Multi-Port KISS TNC
 SQL Databases (Experimental)
 
 Para agregar un dispositivo, haga clic en el botón Agregar. Aparecerá un cuadro
-"Choose Interface Type". Haga clic en el tipo de dispositivo que desee agregar.
-Luego haga clic en el botón Agregar en el cuadro "Choose Interface Type". Las
-propiedades de ese dispositivo aparecerán. Completa la información solicitada y
+"Seleccionar tipo de interfaz". Haga clic en el tipo de dispositivo que desee agregar.
+Luego haga clic en el botón Agregar en el cuadro "Seleccionar tipo de interfaz". Las
+propiedades de ese dispositivo aparecerán. Complete la información solicitada y
 haga clic en Aceptar.
 
 Para eliminar el dispositivo, haga clic en el dispositivo que desee eliminar y
@@ -2165,7 +2164,7 @@ HELP-INDEX>Configurar Serial TNC con GPS en Cable HSP o Puerto AUX
                 Configurar Serial TNC con GPS en Cable HSP o Puerto AUX
 
 Estos tipos de interfaz híbridos implementan las opciones tanto de TNCs en
-Serie como de GPSs en Serie. Por favor consulta la ayuda de configuración tanto
+Serie como de GPSs en Serie. Por favor, consulte la ayuda de configuración tanto
 para Serial TNCs como para Serial Gpsd para más información sobre la
 configuración de estos dispositivos.
 
@@ -2215,7 +2214,7 @@ recomienda para estaciones base en regiones donde hay pocos otros digipeaters de
 relleno en el área. Consulte con un grupo local sobre la mejor configuración
 para su región. Puede editar manualmente el archivo de configuración de Xastir
 cuando Xastir no está en ejecución para cambiar esta cadena para que coincida
-con tus recomendaciones locales. En EE.UU., "WIDE1-1" es la configuración
+con sus recomendaciones locales. En EE.UU., "WIDE1-1" es la configuración
 recomendada.
 
 El Puerto TNC es el dispositivo serial Unix al que está conectado el TNC.
@@ -2281,7 +2280,7 @@ relleno en el área. Consulte con un grupo local sobre la mejor configuración
 para su región. Esto solo es necesario si no está usando ningún otro software
 que realice esta función, como aprsdigi o DIGI_NED. Puede editar manualmente el
 archivo de configuración de Xastir cuando Xastir no está en ejecución para
-cambiar esta cadena para que coincida con tus recomendaciones locales. En
+cambiar esta cadena para que coincida con sus recomendaciones locales. En
 EE.UU., "WIDE1-1" es la configuración recomendada.
 
 Ingrese el nombre del Dispositivo AX.25 que especificó en el archivo axports
@@ -2382,7 +2381,7 @@ de Internet que desea contactar.
 Ingrese un código de acceso válido para validar su conexión; esto le permitirá
 que sus datos se transmitan a través de un IGate. Si no tiene un código de
 acceso, use el programa "callpass" incluido para generar uno. Tenga en cuenta que
-los códigos de acceso dependen de los callsigns. Desde el directorio src,
+los códigos de acceso dependen de los indicativos. Desde el directorio src,
 "make callpass" debería crear el ejecutable si no está ya compilado.
 
 Ingrese cualquier parámetro de filtro. Esto causa que se envíe un mensaje
@@ -2458,7 +2457,7 @@ HELP-INDEX>Configurar una Conexión AGWPE
 Xastir puede usar una interfaz de red AGWPE que se ejecuta en una caja Windows
 como una interfaz TNC. También puede usar la seguridad de inicio de sesión/
 contraseña que tiene AGWPE integrada, pero debe configurar la cuenta en la
-aplicación AGWPE con su callsign como nombre de usuario, todo en letras
+aplicación AGWPE con su indicativo como nombre de usuario, todo en letras
 mayúsculas. Por ejemplo: "AB7CD".
 
 Las otras opciones se describen en las secciones para Serial TNC e interfaces
@@ -2475,11 +2474,11 @@ sección "OPTIONAL: Experimental. Add GIS database support." en el archivo
 INSTALL para más información. Los datos de estaciones y objetos se almacenan
 como datos espaciales, y pueden recuperarse desde otras aplicaciones GIS; por
 ejemplo, Xastir puede escribir ubicaciones de estaciones en una base de datos
-Postgis desde las cuales también pueden verse usando QGIS. Las conexiones SQL
-database también permiten la persistencia de datos entre sesiones de Xastir.
+Postgis desde las cuales también pueden verse usando QGIS. Las conexiones de
+bases de datos SQL también permiten la persistencia de datos entre sesiones de Xastir.
 Todos los aspectos del soporte de base de datos espacial, incluyendo estructuras
 de base de datos, son actualmente experimentales y pueden cambiar en cualquier
-momento. Puede configurar múltiples conexiones SQL database, pero solo debería
+momento. Puede configurar múltiples conexiones de bases de datos SQL, pero solo debería
 tener una activa a la vez.
 
 Antes de crear una conexión de base de datos en Xastir, necesitará crear una
@@ -2489,7 +2488,7 @@ usuario con una contraseña y derechos para acceder a la base de datos. Para
 bases de datos postgis también puede necesitar configurar apropiadamente el
 usuario en pg_hba.conf
 
-Las opciones de configuración en el diálogo SQL database incluyen:
+Las opciones de configuración en el diálogo de bases de datos SQL incluyen:
 Base de datos: MySQL (lat/long) para bases de datos MySQL muy antiguas,
           Postgis para postgresql + postgis, y
           MySQL (Spatial) para bases de datos MySQL actuales.
@@ -2505,30 +2504,30 @@ Password: Único para su base de datos.
 Schema name: El nombre de su base de datos. ej. xastir
 MySQL Socket: revisa my.cnf, o mysql --help | grep socket
           Deja en blanco para bases de datos postgis.
-Reconnect on Net Failure: [Aún no implementado]
+Reconectar ante fallos de red: [Aún no implementado]
 Los valores predeterminados de MySQL y los valores predeterminados de Postgis
 proporcionados por los botones pueden o pueden no ser correctos para su base de
 datos.
 
-Tres opciones controlan el comportamiento de la interfaz SQL Database:
-Activate on Startup: Intenta conectar a esta base de datos y comienza a
+Tres opciones controlan el comportamiento de la interfaz de base de datos SQL:
+Activar al iniciar: Intenta conectar a esta base de datos y comienza a
 almacenar datos de estaciones escuchadas tan pronto como Xastir se inicia (si
-store incoming data también está seleccionado).
+Almacenar datos entrantes también está seleccionado).
 
-Store incoming data: Almacena cada reporte de estación (incluyendo objetos e
+Almacenar datos entrantes: Almacena cada reporte de estación (incluyendo objetos e
 items) como un registro en la base de datos. Todas las estaciones escuchadas en
 todas las interfaces serán almacenadas en la base de datos - si está conectado
 a fuentes de internet y deja xastir ejecutándose esto fácilmente puede ser un
 millón de registros por día.
 
-Load data on startup: Recupera todos los datos de estaciones desde la base de
+Cargar datos al iniciar: Recupera todos los datos de estaciones desde la base de
 datos cuando reinicia Xastir. Actualmente la única forma de recuperar datos
 persistentes desde una base de datos. Intentará conectar a la base de datos y
-recuperar datos independiente de la configuración de activate on startup o
-store incoming data. Debido a errores de redondeo y conversión, las estaciones
+recuperar datos independientemente de la configuración de Activar al iniciar o
+Almacenar datos entrantes. Debido a errores de redondeo y conversión, las estaciones
 no móviles pueden moverse ligeramente.
 
-El cuadro "Most Recent Error" puede o puede no contener un mensaje de error para
+El cuadro "Error más reciente" puede o puede no contener un mensaje de error para
 ayudar a identificar problemas de conexión. Cuando Xastir falla en conectar a
 una base de datos, la interfaz mostrará ERROR en la lista de interfaces, y el
 error más reciente puede mostrarse aquí. Ejecutar xastir desde la consola y
@@ -2536,7 +2535,7 @@ observar los mensajes de error allí, o ejecutar xastir desde la consola con
 xastir -v1 puede ayudar a identificar la causa de los problemas de conexión, como
 puede la examinación de los registros de error de la base de datos.
 
-Solo serás capaz de configurar una interfaz SQL Database si has compilado Xastir
+Solo será capaz de configurar una interfaz de base de datos SQL si ha compilado Xastir
 con soporte para ese DBMS (--with-mysql o --with-postgis).
 
 HELP-INDEX>Tabla de Símbolos

--- a/help/help-Spanish.dat
+++ b/help/help-Spanish.dat
@@ -131,10 +131,10 @@ de interfaces se detalla en el tema de ayuda "Configurar Interfaces" y sus
 subtemas.
 
 Si está operando en una situación donde un sistema de coordenadas distinto
-del sistema predeterminado DD MM.MMMM sería útil, puede seleccionar su
+del sistema predeterminado dd mm.mmm sería útil, puede seleccionar su
 sistema preferido yendo a Archivo|Configurar|Sistema de coordenadas. Se puede usar
 cualquiera de los sistemas de coordenadas soportados como entrada utilizando
-la Calculadora de Coordenadas.
+la Calculadora de coordenadas.
 
 HELP-INDEX>Configurar la Información de la Estación
 
@@ -153,7 +153,7 @@ También puede seleccionar "Mover Mi Estación Aquí" en el menú del botón der
 mientras su ratón está sobre su ubicación. Si tiene un GPS puede omitir esto
 y configurar el GPS más tarde.
 
-"Send Compressed posits", si está seleccionado, transmitirá en el formato
+"Envío de posición comprimida", si está seleccionado, transmitirá en el formato
 comprimido más nuevo. Este formato reducirá la cantidad de datos en el aire,
 aumentando así la capacidad de la red APRS(tm). La precisión máxima de la
 posición transmitida también es mayor. Algunos programas más antiguos,
@@ -185,7 +185,7 @@ con la especificación APRS(tm) aún.
 
 A continuación, ingrese los datos de potencia/altura/ganancia de su estación.
 Esta es información útil pero no es obligatoria; simplemente seleccione
-"Disable PHG" para deshabilitarlo. Estas opciones presentan una representación
+"Desactive PHG" para deshabilitarlo. Estas opciones presentan una representación
 granular del rango de su estación. Seleccione la combinación de valores más
 cercana a la descripción de su estación. Por favor, use la altura sobre el
 terreno promedio (HAAT) para el valor de altura. NO use la altura promedio
@@ -220,7 +220,7 @@ colocarán en algún lugar dentro del rango de la opción que seleccionó. Tenga
 cuenta que esto puede confundir a algunas estaciones que no cumplen con las
 especificaciones. Findu.com no entiende la ambigüedad de posición.
 
-Hacer clic en OK guardará los cambios, Hacer clic en Cancelar mantendrá los
+Hacer clic en Aceptar guardará los cambios, Hacer clic en Cancelar mantendrá los
 ajustes anteriores.
 
 HELP-INDEX>Configurar Funcionamiento Predeterminado
@@ -232,67 +232,70 @@ Haga clic en Archivo, luego Configurar, luego Predefinidos.
 Esta página configura algunos valores predeterminados estándar para la
 operación del programa.
 
-Transmit Station Option establece el tipo de paquete que su estación
-transmitirá sus datos.
+"Opción modo de Transmisión de la estación" establece el tipo de paquete con
+el que su estación transmitirá sus datos.
 
-IGate Options configurará su estación como una puerta de enlace Internet-RF.
-Esta opción debe usarse con cuidado; Como radioaficionado es responsable de
-los datos que ingresan por Internet y se transmiten por RF. También deberá
-elegir una opción IGate en cada interfaz para que IGate funcione. Si desea que
-su IGate reenvíe alertas meteorológicas de NWS a RF, debe crear un archivo
-~/.xastir/data/nws-stations.txt que enumere cada llamada o estación NWS (como
-"PHISVR") que desee transmitir por RF. Esta función también funciona para
-enrutar llamadas específicas a RF.
+Las opciones de I-Gate configurarán su estación como una puerta de enlace
+Internet-RF. Esta opción debe usarse con cuidado; como radioaficionado es
+responsable de los datos que ingresan por Internet y se transmiten por RF.
+También deberá elegir una opción I-Gate en cada interfaz para que el I-Gate
+funcione. Si desea que su I-Gate reenvíe alertas meteorológicas de NWS a RF,
+debe crear un archivo ~/.xastir/data/nws-stations.txt que enumere cada
+indicativo o estación NWS (como "PHISVR") que desee transmitir por RF. Esta
+función también funciona para enrutar indicativos específicos a RF.
 
-"Transmit Compressed objects/items?", si está seleccionado, transmitirá
-objetos e elementos en el formato comprimido más nuevo. La precisión máxima
-de la posición transmitida es mayor, y la transmisión es más corta, pero
-algunos programas más antiguos no decodifican este formato. Actualmente esto
-solo comprime objetos/elementos "estándar" con velocidad/curso opcionales. No
-comprimirá objetos/elementos de área, poste indicador o DF, y actualmente no
-representará altitud en objetos/elementos "estándar".
+"Comprimir datos objeto/artículo cuando transmita?", si está seleccionado,
+transmitirá objetos y artículos en el formato comprimido más nuevo. La
+precisión máxima de la posición transmitida es mayor, y la transmisión es
+más corta, pero algunos programas más antiguos no decodifican este formato.
+Actualmente esto solo comprime objetos/artículos "estándar" con velocidad/
+curso opcionales. No comprimirá objetos/artículos de área, letrero o DF, y
+actualmente no representará altitud en objetos/artículos "estándar".
 
-"Pop up new Bulletins", si está seleccionado, hará que Xastir abra el diálogo
-de boletín cuando se reciban boletines dentro del rango configurado. "View
-zero-distance bulletins" hará que los boletines sin ubicación conocida no se
-muestren ni causen pop-ups.
+"Mostrar boletines nuevos", si está seleccionado, hará que Xastir abra el
+diálogo de boletín cuando se reciban boletines dentro del rango configurado.
+"Ver boletines de distancia cero" hará que los boletines sin ubicación
+conocida no se muestren ni causen pop-ups.
 
-"Warn if Modifier keys" hará que Xastir imprima una advertencia si intenta usar
-Xastir mientras Bloqueo de números, Bloqueo de desplazamiento o Bloqueo de
-mayúsculas está activado. Algunos usuarios reportan que la pantalla se oscurece
-y problemas similares cuando intentan usar Xastir con una de estas teclas de
-modificador activada.
+"Avisar si hay teclas Modificadora" hará que Xastir imprima una advertencia
+si intenta usar Xastir mientras Bloqueo de números, Bloqueo de desplazamiento
+o Bloqueo de mayúsculas está activado. Algunos usuarios reportan que la
+pantalla se oscurece y problemas similares cuando intentan usar Xastir con
+una de estas teclas de modificador activada.
 
-También puede seleccionar "Activate alternate net?" y elegir una llamada altnet
-de este diálogo. Altnet le permite tener una red APRS(tm) privada entre las
-estaciones que también tienen altnet configurado y tienen el mismo altnet
-ingresado.
+También puede seleccionar "Activar Red Alternada?" y elegir un indicativo
+altnet de este diálogo. Altnet le permite tener una red APRS(tm) privada
+entre las estaciones que también tienen altnet configurado y tienen el mismo
+altnet ingresado.
 
-"Disable Posit Dupe-Checks" desactiva la verificación de copias duplicadas de
-una posición. Esto solo debe usarse cuando una estación podría volver a la
-misma posición exacta (dentro de aproximadamente 60' para posiciones no
-comprimidas) y desea ver las posiciones duplicadas y/o pistas mostradas en el
-mapa. Esta opción casi nunca es necesaria en la práctica, pero puede ser útil
-para eventos especiales como operaciones de búsqueda y rescate.
+"Desactivar comprobación de duplicados de posición" desactiva la verificación
+de copias duplicadas de una posición. Esto solo debe usarse cuando una
+estación podría volver a la misma posición exacta (dentro de aproximadamente
+60' para posiciones no comprimidas) y desea ver las posiciones duplicadas
+y/o rastros mostrados en el mapa. Esta opción casi nunca es necesaria en la
+práctica, pero puede ser útil para eventos especiales como operaciones de
+búsqueda y rescate.
 
-"My Trails in one color" muestra todas las pistas con su indicativo pero con
-diferentes ssids en el mismo color. Con Mi Trails en un color seleccionado,
-micall-1 y micall-2 se muestran en el mismo color. Con Mi Trails en un color
-sin marcar, micall-1 y micall-2 se muestran en colores diferentes.
+"Mis rastros en un color" muestra todos los rastros con su indicativo pero
+con diferentes ssids en el mismo color. Con esta opción seleccionada,
+micall-1 y micall-2 se muestran en el mismo color. Sin marcar, micall-1 y
+micall-2 se muestran en colores diferentes.
 
-"Load predefined objects from file" y la lista de selección que le sigue le
-permite reemplazar la lista de Objetos predefinidos que son accesibles desde el
-menú de clic derecho con su propia lista de objetos. Se proporcionan un conjunto
-de objetos de Búsqueda y Rescate estándar y un conjunto de objetos de eventos
-públicos típicos en los archivos predefined_SAR.sys y predefined_EVENT.sys.
-También puede usar estos archivos como plantilla para crear un archivo
-predefined_USER.sys. Consulte las instrucciones en el archivo predefined_SAR.sys
-y predefined_EVENT.sys para obtener detalles sobre cómo definir objetos para un
-menú de objetos predefinidos personalizado. Si tanto "Load predefined objects
-from file" está seleccionado como un archivo que existe en el directorio
-xastir/config/ está seleccionado, entonces los objetos definidos en ese archivo
-se mostrarán en el menú Objetos predefinidos. El archivo predefined_SAR.sys
-inalterado define los mismos objetos que el menú predeterminado.
+"Cargar objetos predefinidos desde archivo" y la lista de selección que le
+sigue le permite reemplazar la lista de Objetos predefinidos que son
+accesibles desde el menú de clic derecho con su propia lista de objetos. Se
+proporcionan un conjunto de objetos de Búsqueda y Rescate estándar y un
+conjunto de objetos de eventos públicos típicos en los archivos
+predefined_SAR.sys y predefined_EVENT.sys. También puede usar estos archivos
+como plantilla para crear un archivo predefined_USER.sys. Consulte las
+instrucciones en el archivo predefined_SAR.sys y predefined_EVENT.sys para
+obtener detalles sobre cómo definir objetos para un menú de objetos
+predefinidos personalizado. Si tanto "Cargar objetos predefinidos desde
+archivo" está seleccionado como un archivo que existe en el directorio
+xastir/config/ está seleccionado, entonces los objetos definidos en ese
+archivo se mostrarán en el menú Objetos predefinidos. El archivo
+predefined_SAR.sys inalterado define los mismos objetos que el menú
+predeterminado.
 
 
 HELP-INDEX>Configurar Temporización
@@ -301,51 +304,57 @@ HELP-INDEX>Configurar Temporización
 
 Haga clic en Archivo, luego Configurar, luego Cronómetro.
 
-Posit TX Interval especifica con qué frecuencia se transmitirá la posición de
-su estación. Para estaciones fijas, una buena recomendación es cada 30 minutos,
-y definitivamente no menos de 10 minutos. Las estaciones móviles pueden desear
-usar una velocidad más rápida. Tenga en cuenta que si está usando
-SmartBeaconing, este control deslizante se ignora.
+"TX Posición Intérvalo (minutos)" especifica con qué frecuencia se transmitirá
+la posición de su estación. Para estaciones fijas, una buena recomendación es
+cada 30 minutos, y definitivamente no menos de 10 minutos. Las estaciones
+móviles pueden desear usar una velocidad más rápida. Tenga en cuenta que si
+está usando Baliza Inteligente, este control deslizante se ignora.
 
-Object/Item Max TX Interval es el intervalo máximo usado para enviar objetos e
-elementos. Intente mantener estos intervalos razonables, ya que transmitir a
-una ruta larga cada 5 minutos realmente consumirá mucho tiempo de aire. Se
-activa un algoritmo de intervalo decreciente cada vez que se crea, modifica o
-mata un objeto. El intervalo de transmisión aumentará hasta que alcance el
-intervalo máximo indicado por el control deslizante.
+"Objeto/Artículo TX Max Intérvalo (minutos)" es el intervalo máximo usado
+para enviar objetos y artículos. Intente mantener estos intervalos
+razonables, ya que transmitir a una ruta larga cada 5 minutos realmente
+consumirá mucho tiempo de aire. Se activa un algoritmo de intervalo
+decreciente cada vez que se crea, modifica o elimina un objeto. El intervalo
+de transmisión aumentará hasta que alcance el intervalo máximo indicado por
+el control deslizante.
 
-GPS Check Interval establecerá el intervalo de tiempo para verificar el GPS en
-busca de nuevos datos. Esto está disponible para estaciones que utilizan un HSP
-o cable compartido con su TNC.
+"Chequeo Intérvalo del GPS (segundos)" establecerá el intervalo de tiempo
+para verificar el GPS en busca de nuevos datos. Esto está disponible para
+estaciones que utilizan un HSP o cable compartido con su TNC.
 
-Dead-Reckoning Timeout ajusta cuánto tiempo se supone que una posición es válida
-para el propósito de estimar su posición actual.
+"Descanso Conteo-Muerto (minutos)" ajusta cuánto tiempo se supone que una
+posición es válida para el propósito de estimar su posición actual.
 
-New Track Time ajusta cuántos minutos deben transcurrir antes de que se inicie
-una nueva pista separada. Precaución: establecer el tiempo de nueva pista en 0
-desactivará la visualización de todas las pistas.
+"Nuevo Tiempo Rastro (min)" ajusta cuántos minutos deben transcurrir antes
+de que se inicie un nuevo rastro separado. Precaución: establecer este
+valor en 0 desactivará la visualización de todos los rastros.
 
-RINO -> Objects Interval ajusta la frecuencia con la que se descargan los
-puntos de referencia de una unidad de radio/GPS Garmin RINO conectada. Se
-crean Objetos APRS(tm) a partir de cualquier punto de referencia que comience
-con "APRS". El prefijo "APRS" se elimina al crear los nombres de los Objetos.
+"Intervalo RINO -> Objetos (min), 0 = desactivado" ajusta la frecuencia con
+la que se descargan los puntos de referencia de una unidad de radio/GPS
+Garmin RINO conectada. Se crean Objetos APRS(tm) a partir de cualquier punto
+de referencia que comience con "APRS". El prefijo "APRS" se elimina al crear
+los nombres de los Objetos.
 
-Station Ghosting Time especifica el intervalo de fantasma. Las estaciones que no
-se han escuchado en el período dado aparecerán como fantasma en la pantalla.
+"Desvanecimiento de la Estación (minutos)" especifica el intervalo de
+desvanecimiento. Las estaciones que no se han escuchado en el período dado
+aparecerán desvanecidas en la pantalla.
 
-Station Clear Time especifica cuándo se eliminará una estación de la pantalla.
+"Limpiar Tiempo de la Estación (horas)" especifica cuándo se eliminará una
+estación de la pantalla.
 
-Station Delete Time especifica el número de días completos antes de que los
-datos de una estación se eliminen completamente de la base de datos de Xastir.
+"Borrar Tiempo de la Estación (días)" especifica el número de días completos
+antes de que los datos de una estación se eliminen completamente de la base
+de datos de Xastir.
 
-Serial Inter-Char Delay especifica un tiempo de espera en milisegundos entre
-cada carácter enviado a un TNC conectado.
+"Retardo serial entre caracteres (ms)" especifica un tiempo de espera en
+milisegundos entre cada carácter enviado a un TNC conectado.
 
-New Track Interval (degrees) especifica la distancia en grados de lat/long en
-la cual se inicia un nuevo segmento de pista. Precaución: establecer el nuevo
-intervalo de pista a 0 grados desactivará la visualización de todas las pistas.
+"Nuevo Interval Rastro (grados)" especifica la distancia en grados de
+lat/long en la cual se inicia un nuevo segmento de rastro. Precaución:
+establecer este valor a 0 grados desactivará la visualización de todos los
+rastros.
 
-Snapshot Interval (minutes) especifica con qué frecuencia se escribirán
+"Intervalo de instantáneas (min)" especifica con qué frecuencia se escribirán
 archivos de instantánea si se selecciona Archivo->Activa PNG Instantánea o
 Archivo->Instantáneas KML.
 
@@ -356,23 +365,26 @@ HELP-INDEX>Configurar Alarmas de Audio
 Haga clic en Archivo, luego Configurar, luego Alarmas de Audio.
 
 Para usar esta opción debe tener una tarjeta de sonido y un programa que
-reproduzca archivos wav. El comando de reproducción de audio debe contener el programa que
-desea ejecutar para reproducir el archivo de audio (y cualquier opción de
-línea de comandos). Por supuesto, esto no funciona si la única tarjeta de
-sonido en el sistema se usa para un soundmodem...
+reproduzca archivos wav. La "Aplicación Audio" debe contener el programa
+que desea ejecutar para reproducir el archivo de audio (y cualquier
+opción de línea de comandos). Por supuesto, esto no funciona si la única
+tarjeta de sonido en el sistema se usa para un soundmodem...
 
-Cada tipo de alerta tiene una casilla de verificación para habilitarla. Los
-campos contendrán el nombre del archivo a reproducir. Los campos bajo la
-opción establecerán parámetros para la opción.
+Cada tipo de alerta tiene una casilla de verificación para habilitarla.
+Los campos contendrán el nombre del archivo a reproducir. Los campos bajo
+la opción establecerán parámetros para la opción.
 
 Las opciones actuales son:
-Reproducir mensaje al escuchar una estación nueva.
-Reproducir mensaje al recibir un mensaje nuevo.
-Reproducir mensaje al recibir datos de una estación dentro de la distancia
-     mín/máx de su configuración de proximidad.
-Reproducir mensaje al recibir datos de una estación (vía TNC) dentro de la
-     distancia mín/máx de su configuración de apertura de banda.
-Reproducir mensaje al recibir y mostrar una alerta meteorológica nueva.
+Nueva estación: reproducir mensaje al escuchar una estación nueva.
+Nuevo mensaje: reproducir mensaje al recibir un mensaje nuevo.
+Proximidad: reproducir mensaje al recibir datos de una estación dentro de
+     la distancia Mínima distancia/Máxima distancia de su configuración de
+     proximidad.
+Banda abierta: reproducir mensaje al recibir datos de una estación (vía
+     TNC) dentro de la distancia mín/máx de su configuración de apertura
+     de banda.
+Alerta del Tiempo: reproducir mensaje al recibir y mostrar una alerta
+     meteorológica nueva.
 
 Hay un conjunto estándar de sonidos disponibles en la mayoría de los lugares
 donde se puede obtener Xastir; consulte el archivo INSTALL.md para más
@@ -409,63 +421,64 @@ Información sobre Festival se puede obtener de:
 https://www.cstr.ed.ac.uk/projects/festival/
 
 
-HELP-INDEX>Configurar SmartBeaconing
+HELP-INDEX>Configurar Baliza Inteligente
 
 Haga clic en Archivo, luego Configurar, luego Baliza Inteligente.
 
-El "Activar SmartBeaconing(tm)" principal hará que Xastir transmita posiciones
-a diferentes velocidades y ubicaciones basadas en el movimiento de la estación.
-Crea senderos más realistas y hace que la predicción de movimiento sea mucho
-más precisa. Esta opción solo es útil en una estación móvil con un GPS
-conectado.
+El botón "Activar Baliza Inteligente(tm)" principal hará que Xastir transmita
+posiciones a diferentes velocidades y ubicaciones basadas en el movimiento de
+la estación. Crea rastros más realistas y hace que la predicción de
+movimiento sea mucho más precisa. Esta opción solo es útil en una estación
+móvil con un GPS conectado.
 
-Hay varias opciones disponibles para personalizar la operación de
-SmartBeaconing:
+Hay varias opciones disponibles para personalizar la operación de la Baliza
+Inteligente:
 
-High rate
-El intervalo (en segundos) en el cual se envían beacons cuando la velocidad
-está por encima de la configuración de High speed. Este parámetro también se
-utiliza para calcular una tasa de beacon basada en la velocidad cuando se
+Alta Proporción (secs)
+El intervalo (en segundos) en el cual se envían balizas cuando la velocidad
+está por encima de la configuración de velocidad alta. Este parámetro también
+se utiliza para calcular una tasa de balizas basada en la velocidad cuando se
 viaja entre velocidades altas y bajas.
 
-High speed
-El umbral de velocidad que causará beacons a la velocidad especificada
+Alta Velocidad
+El umbral de velocidad que causará balizas a la velocidad especificada
 anteriormente.
 
-Low rate
-El intervalo (en minutos) en el cual se envían beacons cuando la velocidad
-está por debajo de la configuración de Low speed. Básicamente considere esto
-como la tasa de beacon cuando está detenido.
-Este parámetro no se utiliza en absoluto cuando se viaja a una velocidad mayor
-que "Low speed".
+Baja Proporción (mins)
+El intervalo (en minutos) en el cual se envían balizas cuando la velocidad
+está por debajo de la configuración de velocidad baja. Básicamente considere
+esto como la tasa de baliza cuando está detenido.
+Este parámetro no se utiliza en absoluto cuando se viaja a una velocidad
+mayor que "Baja Velocidad".
 
-Low speed
-El umbral de velocidad que causará beacons a la velocidad especificada
+Baja Velocidad
+El umbral de velocidad que causará balizas a la velocidad especificada
 anteriormente.
 
-Minimum Turn
-Los grados mínimos que el corner pegging puede ocurrir en "High speed" o
+Mínima Vuelta (grados)
+Los grados mínimos para que el ajuste por giro ocurra en "Alta Velocidad" o
 superior. Las velocidades más bajas requerirán más grados de giro para
-activar una posición, basado en el valor de "Turn Slope" a continuación.
+activar una posición, en función del valor de "Vuelta de declive" a
+continuación.
 
-Turn Slope
-Factor de ajuste para hacer los giros menos sensibles a velocidades más bajas.
-El parámetro no tiene unidades. Termina siendo no lineal en el rango de
-velocidad de la manera en que funciona el algoritmo SmartBeaconing(tm)
+Vuelta de declive
+Factor de ajuste para hacer los giros menos sensibles a velocidades más
+bajas. El parámetro no tiene unidades. Termina siendo no lineal en el rango
+de velocidad de la manera en que funciona el algoritmo Baliza Inteligente(tm)
 original.
 
-Wait Time
-El tiempo en segundos entre beacons de corner-pegging, previene múltiples
-beacons en sucesión corta.
+Tiempo de Espera (secs)
+El tiempo en segundos entre balizas por ajuste en giro evita múltiples
+balizas en sucesión corta.
 
 HELP-INDEX>Configurar unidades de medida
 
                      Configurar unidades de medida
 
 La selección predeterminada es para el Sistema Métrico: mm, cm, km/h, etc.
-Para seleccionar unidades inglesas, pulgadas, pies, MPH, etc. Haga clic en
-File, luego Configure, luego active la casilla de verificación "Enable
-English Units".
+Para seleccionar unidades inglesas, pulgadas, pies, MPH, etc., vaya a
+Archivo, luego Configurar, y active la casilla de verificación de unidades
+inglesas.
 
 HELP-INDEX>¡Guardar configuración ahora!
 
@@ -485,9 +498,9 @@ En el primer cuadro a la izquierda se muestran mensajes de estado general
 por un corto tiempo.
 
 El segundo cuadro muestra la lat/long actual o posición de cuadrícula
-UTM y Maidenhead del ratón sobre el mapa. Si file|configure|Dist/Bearing
-Status está seleccionado, este cuadro también contendrá el curso y el
-acimut de esta posición en relación a su estación.
+UTM y Maidenhead del ratón sobre el mapa. Si está activada la opción
+"Estado de Distancia/Orientación" en Archivo|Configurar, este cuadro también
+contendrá el curso y el acimut de esta posición en relación a su estación.
 
 Un tercer cuadro se utiliza para mostrar cuántas estaciones hay en pantalla
 y cuántas hay en la base de datos.
@@ -564,7 +577,7 @@ Más sobre el menú de opciones:
 Marcadores del mapa
 Consulte el tema de ayuda "Crear y usar marcadores de pantalla de mapa"
 
-La selección "Info Estación" en el menú de opciones buscará la estación más
+La selección "Info de estación" en el menú de opciones buscará la estación más
 cercana a donde hizo clic con el botón derecho del ratón. Si más de una
 estación está cerca de esa posición, aparecerá una lista "Seleccionar Estación",
 luego puede elegir qué datos de estación desea ver. Si solo una estación está
@@ -615,16 +628,17 @@ pueden ser diferentes en otros programas.
 Para los otros tres, círculos de probabilidad, señalización y objetos DF,
 vea abajo.
 
-Los Objetos/Artículos se retransmiten a una tasa decreciente hasta el intervalo máximo
-especificado en Archivo|Configurar|Cronómetro. Los objetos/items "killed" también se
-retransmiten de esta manera hasta que expiren de la cola (actualmente 20
-transmisiones). Los Objetos/Artículos persisten en sesiones de Xastir y se almacenan
-en ~/.xastir/config/object.log. Este archivo puede borrarse seleccionando
-"Limpiar Historia de Objeto/Artículo" desde el menú Estaciones.
+Los Objetos/Artículos se retransmiten a una tasa decreciente hasta el
+intervalo máximo especificado en Archivo|Configurar|Cronómetro. Los
+objetos/artículos "eliminados" también se retransmiten de esta manera hasta
+que expiren de la cola (actualmente 20 transmisiones). Los Objetos/Artículos
+persisten en sesiones de Xastir y se almacenan en ~/.xastir/config/object.log.
+Este archivo puede borrarse seleccionando "Limpiar Historia de
+Objeto/Artículo" desde el menú Estaciones.
 
 La opción Crear Objeto/Artículo en el menú de clic derecho traerá un diálogo con
 la posición de su objeto rellenada según donde hizo clic con el ratón. Puede
-rellenar los detalles y agregar un objeto/item desde este menú.
+rellenar los detalles y agregar un objeto o artículo desde este menú.
 
 La opción Modificar Objeto/Artículo le trae el diálogo de modificación de
 objetos. Es similar al diálogo de creación de objetos, excepto que la
@@ -633,11 +647,11 @@ algunas de las otras opciones no se pueden cambiar. También podría eliminar el
 objeto con esta opción.
 
 Los Objetos y Artículos se pueden mover con el ratón si la casilla de verificación
-"Move" en la barra de herramientas está habilitada.
+"Mover" en la barra de herramientas está habilitada.
 
 La opción Objetos predefinidos en el menú de clic derecho le permite colocar
 rápidamente objetos de Búsqueda y Rescate estándar sin tener que pasar por el
-diálogo de creación de Object/Item. Estos objetos incluyen símbolos del Sistema
+diálogo de creación de Objeto/Artículo. Estos objetos incluyen símbolos del Sistema
 de Comando de Incidentes estándar para ICP, Staging, Base y Helibase, así como
 objetos SAR para PLS, IPP (con 4 círculos de área) y LKP. Si un objeto con el
 mismo nombre que un objeto que selecciona de la lista ya existe, se creará un
@@ -659,18 +673,18 @@ Consulte el archivo predefined_SAR.sys para obtener detalles.
 
 Descripción de las entradas en el diálogo de objetos:
 
-= Señalización =
-Esto hace que el objeto sea un objeto de señalización. Estos signos pueden
-contener uno a tres caracteres y actualmente aparecen en Xastir como un signo
-en blanco. Info Estación muestra el valor contenido en el signo.
+= Letrero Objeto =
+Esto hace que el objeto sea un objeto de letrero. Estos letreros pueden
+contener uno a tres caracteres y actualmente aparecen en Xastir como un
+letrero en blanco. "Info Estación" muestra el valor contenido en el letrero.
 
-= Objeto de área =
-Esto hace que el objeto sea un Area Object e habilita los controles de Area
-Object descritos a continuación.
+= Activar Area de Objeto =
+Esto hace que el objeto sea un objeto de área y habilita los controles del
+área de objeto descritos a continuación.
 
-= Objeto DF =
+= DF Objeto =
 Este es un informe de búsqueda de dirección. Habilitarlo le permite elegir
-Omni o Beam report, y le permite poner en los detalles específicos de cada
+Omni o informe direccional, y le permite introducir los detalles específicos de cada
 uno. Vea:
     https://www.aprs.org/dfing.html
 para la discusión de Bob Bruninga sobre cómo usar estas técnicas.
@@ -678,28 +692,30 @@ para la discusión de Bob Bruninga sobre cómo usar estas técnicas.
 
 = Círculos de probabilidad =
 Esto le permite definir el radio (en millas) de dos círculos centrados en el
-objeto o item. Min es el radio (en millas) del círculo interior más pequeño, y
-Max es el radio (en millas) del círculo exterior más grande. Estos círculos se
-dibujan en rojo. Se pueden usar para ayudar en la planificación de operaciones
+objeto o artículo. "Mín (mi):" es el radio (en millas) del círculo interior
+más pequeño, y "Máx (mi):" es el radio (en millas) del círculo exterior más
+grande. Estos círculos se dibujan en rojo. Se pueden usar para ayudar en la
+planificación de operaciones
 de Búsqueda y Rescate. Para crear más de dos círculos, agregue objetos de
 círculo de probabilidad adicionales en la misma ubicación. Es posible que otros
-software de cliente no muestren círculos de probabilidad.
+clientes de software no muestren círculos de probabilidad.
 
-= Name =
-Este es el nombre del objeto o item. Puede tener hasta 9 caracteres de largo,
-con espacios permitidos dentro del nombre. Al modificar un objeto, esto no se
-puede cambiar. Para cambiar el nombre de un objeto debe eliminar el original y
-luego crear un nuevo objeto. Tenga en cuenta que si selecciona Señalización/Objeto de área/
-Objeto DF, este campo y posiblemente otros se borran. Ingrese el nombre
-DESPUÉS de haber seleccionado el tipo de objeto en el que se convertirá.
+= Nombre =
+Este es el nombre del objeto o artículo. Puede tener hasta 9 caracteres de
+largo, con espacios permitidos dentro del nombre. Al modificar un objeto,
+esto no se puede cambiar. Para cambiar el nombre de un objeto debe eliminar
+el original y luego crear un nuevo objeto. Tenga en cuenta que si selecciona
+Letrero Objeto/Activar Area de Objeto/DF Objeto, este campo y posiblemente
+otros se borran. Ingrese el nombre DESPUÉS de haber seleccionado el tipo de
+objeto en el que se convertirá.
 
 = Símbolo de la estación =
-Puede seleccionar un símbolo para el objeto. Presione Seleccionar para elegir
+Puede seleccionar un símbolo para el objeto. Presione "Seleccione" para elegir
 gráficamente, o consulte la sección de ayuda de la tabla de símbolos para
 descripciones de cada símbolo. Tenga en cuenta también que los objetos de
-área, señalización y DF tienen símbolos fijos especiales y por lo tanto no se
-pueden seleccionar aquí. Esos símbolos particulares se asignan automáticamente
-cuando cambia a ese tipo de objeto.
+área, letrero y DF tienen símbolos fijos especiales y por lo tanto no se
+pueden seleccionar aquí. Esos símbolos particulares se asignan
+automáticamente cuando cambia a ese tipo de objeto.
 
 = Ubicación =
 La ubicación del objeto se especifica aquí. Si seleccionó "Crear Objeto/Artículo"
@@ -708,58 +724,58 @@ movió un objeto con el ratón, la nueva ubicación estará en estos campos. Tam
 puede escribir una ubicación, por ejemplo, puede estar colocando un objeto desde
 un informe de voz sobre el aire.
 
-= Opciones generales =
-Puede especificar la velocidad, dirección y altitud de los objetos aquí. Algunos
-tipos de objetos no pueden tener una velocidad o dirección, en cuyo caso los
-campos están atenuados.
+= Opciones Genéricas =
+Puede especificar la velocidad, dirección y altitud de los objetos aquí.
+Algunos tipos de objetos no pueden tener una velocidad o dirección, en cuyo
+caso los campos están atenuados.
 
-= Texto de señalización =
-Si el objeto es un objeto de señalización, puede especificar aquí el número de
-1 a 3 dígitos que aparece en el signo. Tenga en cuenta que Xastir aún no
-muestra correctamente los objetos de señalización.
+= Texto del letrero =
+Si el objeto es un objeto de letrero, puede especificar aquí el número de
+1 a 3 dígitos que aparece en el letrero. Tenga en cuenta que Xastir aún no
+muestra correctamente los objetos de letrero.
 
-= Objeto de área =
-Los Objetos de área se utilizan para resaltar partes específicas de mapas, o para
-dibujar detalles adicionales en mapas. Esto se hará con las siguientes
+= Area de Objeto =
+Los Objetos de área se utilizan para resaltar partes específicas de mapas, o
+para dibujar detalles adicionales en mapas. Esto se hará con las siguientes
 entradas:
-  = Color brillante =
+  = Color Luminoso =
     Use la versión más brillante de los colores permitidos.
-  = Relleno de color =
+  = Area Colorida =
     El área debe ser rellenada, no solo perfilada. Esto puede ser útil para
     excluir un área de una búsqueda u otro evento.
   = Tipo de objeto =
     Elija entre las formas geométricas permitidas.
   = Color del objeto =
     Elija el color en el cual se mostrará el objeto. Esto también se ve
-    afectado por la opción "Color brillante" anterior.
-  = Desplazamiento superior del objeto =
+    afectado por la opción "Color Luminoso" anterior.
+  = Compense Arriba =
     En 1/1500 de un grado de latitud. Un detalle desafortunado de la
     especificación, y difícil de calcular fácilmente. Baste decir que puede
     cambiar el tamaño del objeto una vez que lo coloque.
-  = Desplazamiento izquierdo del objeto excepto / =
+  = Compense Izq. (Excepto '/') =
     En 1/1500 de un grado de longitud. Vea arriba.
-  = Corredor del objeto =
-    Este es el ancho de una línea de Objeto de área. Útil para pistas, cajas de
-    vigilancia de clima, describiendo un área de interés o un área de
+  = Corredor =
+    Este es el ancho de una línea de Objeto de área. Útil para pistas, cajas
+    de vigilancia de clima, describiendo un área de interés o un área de
     exclusión, etc.
 
-¡Siempre elimine sus objetos e items cuando haya terminado con ellos! No los
+¡Siempre elimine sus objetos y artículos cuando haya terminado con ellos! No los
 deje simplemente expirar de su caché, ya que pueden permanecer en las pantallas
 de otras personas durante un período prolongado.
 
 
 Descripción de las cajas de vigilancia meteorológica:
 
-Watch boxes y "areas of maximum concern" (AOMC) generadas por el WXSVR
+Las cajas de vigilancia y las "areas of maximum concern" (AOMC) generadas por el WXSVR
 (https://www.aprs-is.net/WX/Default.aspx) están coloreadas como sigue:
 
-  Yellow dashed = Severe Thunderstorm Watch (parece cinta de escena de crimen)
-   Yellow solid = AOMC for Severe Thunderstorm Warning
-     Red dashed = Tornado Watch
-      Red solid = AOMC for Tornado Warning.
-   Green dashed = Mesoscale (larger) discussion area
-    Blue dashed = Test Watch
-     Blue solid = Test Warning
+  Amarillo discontinuo = Vigilancia de tormenta severa (parece cinta de escena del crimen)
+   Amarillo continuo = AOMC para advertencia de tormenta severa
+     Rojo discontinuo = Vigilancia de tornado
+      Rojo continuo = AOMC para advertencia de tornado.
+   Verde discontinuo = Área de discusión mesoescala (más amplia)
+    Azul discontinuo = Vigilancia de prueba
+     Azul continuo = Advertencia de prueba
 
 HELP-INDEX>Objetos CAD
 
@@ -771,7 +787,7 @@ Los Objetos CAD son formas arbitrarias que puede dibujar en mapas en xastir,
 pero no puede transmitir por APRS.
 
 Los Objetos CAD actualmente soportados son:
-Polygons: Áreas cerradas de al menos tres puntos.
+Polígonos: Áreas cerradas de al menos tres puntos.
 
 Para crear un Objeto CAD, primero presione el botón de radio Dibujar en la barra
 de herramientas. Esto cambiará el cursor a un lápiz. Comience a dibujar un
@@ -798,34 +814,36 @@ HELP-INDEX>Menú Visualizar
 
                    Opciones del menú Visualizar
 
-El menú Ver presenta varias formas de ver datos en Xastir.
+El menú Visualizar presenta varias formas de ver datos en Xastir.
 
 Boletines
-Este es el tablero de anuncios APRS(tm), donde se publican anuncios importantes.
-Si está conectado con la interfaz de internet, es una buena idea establecer el
-campo de rango a algunas cientos de millas, para ignorar publicaciones de otras
-partes del mundo. "0" en el campo de rango significa el mundo entero. Haga clic
-en el botón "Cambiar rango" para que los cambios en este campo sean efectivos.
-Xastir actualmente no admite el envío de boletines. Los boletines entrantes
-abrirán este diálogo automáticamente si selecciona "Mostrar boletines nuevos" en el
-diálogo Configurar|Predefinidos. El botón "Ver boletines de distancia cero" habilita la
-visualización de boletines para los cuales aún no tiene un rango (no han enviado
-una posición aún, pero recibió un boletín de ellos). Si esto no está marcado,
-debe obtener una posición de una estación, y la estación debe estar dentro del
-rango seleccionado (o el rango debe establecerse en cero), para poder ver el
+Este es el tablero de anuncios APRS(tm), donde se publican anuncios
+importantes. Si está conectado con la interfaz de internet, es una buena idea
+establecer el campo de rango a algunas cientos de millas, para ignorar
+publicaciones de otras partes del mundo. "0" en el campo de rango significa
+el mundo entero. Haga clic en el botón "Cambio de Rango" para que los
+cambios en este campo sean efectivos. Xastir actualmente no admite el envío
+de boletines. Los boletines entrantes abrirán este diálogo automáticamente si
+selecciona "Mostrar boletines nuevos" en el diálogo Configurar|Predefinidos.
+El botón "Ver boletines de distancia cero" habilita la visualización de
+boletines para los cuales aún no tiene un rango (no han enviado una posición
+aún, pero recibió un boletín de ellos). Si esto no está marcado, debe obtener
+una posición de una estación, y la estación debe estar dentro del rango
+seleccionado (o el rango debe establecerse en cero), para poder ver el
 boletín.
 
-Datos de paquetes entrantes
-Esto muestra los datos entrantes en su TNC o interfaz de internet. Los botones
-de radio a continuación seleccionan si desea ver solo datos de TNC, solo datos
-de internet, o ambos.
+Datos entrantes
+Esto muestra los datos entrantes en su TNC o interfaz de internet. Los
+botones de radio a continuación seleccionan si desea ver solo datos del TNC,
+solo datos de la Red, o ambos.
 
 Estaciones Móviles
-Esta es una lista de estaciones que se están moviendo. Las estaciones califican
-para esta lista si se han movido (más de una posición recibida para ellas), el
-símbolo de la estación no se considera. La información mostrada incluye curso,
-velocidad, altitud, posición, número de paquetes recibidos, número de satélites
-GPS visibles, curso desde su estación y distancia desde su estación.
+Esta es una lista de estaciones que se están moviendo. Las estaciones
+califican para esta lista si se han movido (más de una posición recibida
+para ellas); el símbolo de la estación no se considera. La información
+mostrada incluye curso, velocidad, altura, posición, número de paquetes
+recibidos, número de satélites GPS visibles, curso desde su estación y
+distancia desde su estación.
 
 Todas las Estaciones
 Esta opción muestra una tabla de todas las estaciones ordenadas alfabéticamente.
@@ -846,15 +864,15 @@ paquetes escuchados, la hora en que se escuchó por última vez la estación, la
 ruta que tomó el paquete más reciente, el PHG y el comentario de la estación.
 
 Objetos y Artículos
-Esta opción muestra solo objetos e artículos. Incluye el número de paquetes
-escuchados, la hora en que se escuchó por última vez el objeto/item, la ruta
-que tomó el paquete más reciente, el PHG y el comentario del objeto/item.
+Esta opción muestra solo objetos y artículos. Incluye el número de paquetes
+escuchados, la hora en que se escuchó por última vez el objeto o artículo, la ruta
+que tomó el paquete más reciente, el PHG y el comentario del objeto o artículo.
 
 Objetos y Artículos Propio
-Esta opción muestra solo objetos e artículos que controla (es decir, ha enviado la
-actualización más reciente para). Incluye el número de paquetes escuchados, la
-hora en que se escuchó por última vez el objeto/item, la ruta que tomó el
-paquete más reciente, el PHG y el comentario del objeto/item. Un icono
+Esta opción muestra solo objetos y artículos que controla (es decir, para los que ha enviado la
+actualización más reciente). Incluye el número de paquetes escuchados, la
+hora en que se escuchó por última vez el objeto o artículo, la ruta que tomó el
+paquete más reciente, el PHG y el comentario del objeto o artículo. Un icono
 atenuado indica que el objeto ha sido eliminado.
 
 Estaciones Meteorológicas
@@ -878,13 +896,13 @@ versiones futuras pueden acceder a estos datos por radio también.
 
 Tráfico de mensajes
 Muestra todo el tráfico de mensajes mientras la ventana esté abierta. Incluye
-la fuente, destino, interfaz y mensaje. La opción de rango puede limitar esta
-pantalla a estaciones cercanas, similar al control de rango en los boletines.
-Un rango de 0 causa que se muestren todos los mensajes.
+la fuente, destino, interfaz y mensaje. La opción de rango puede limitar
+esta pantalla a estaciones cercanas, similar al control de rango en los
+boletines. Un rango de 0 causa que se muestren todos los mensajes.
 
 Estado del GPS
-Muestra el estado de su unidad GPS, incluido el tipo de corrección y el número
-de satélites adquiridos.
+Muestra el estado de su unidad GPS, incluido el tipo de Fijación y el número
+de Sats/Vista adquiridos.
 
 Tiempo en ejecución del programa
 Muestra la cantidad de tiempo transcurrido desde que se inició Xastir.
@@ -897,15 +915,16 @@ Menú Mapas:
 
 Selección de Mapa
 Esto le presentará una lista de directorios de mapas y/o archivos en su
-directorio de mapas. Marcar la opción "Expandir dirs" alterna la expansión de
-directorios en archivos de mapas individuales. El diálogo de propiedades
-permite controles más avanzados, y se describe a continuación. Haga clic en
-nombres de mapas para resaltarlos, esto hará que se muestren cuando haga clic
-en el botón OK. Puede seleccionar cualquier número de mapas. Hacer clic en
-"Limpiar" no seleccionará mapas, hacer clic en "Vectores" seleccionará solo mapas
-vectoriales. Las tres opciones "topo" seleccionarán automáticamente todas las
-imágenes GeoTIFF del tamaño listado. Hacer clic en el botón OK mostrará los
-mapas seleccionados. Cancelar abandonará cualquier cambio.
+directorio de mapas. Marcar la opción "Expandir dirs" alterna la
+expansión de directorios en archivos de mapas individuales. El diálogo de
+"Propiedades" permite controles más avanzados, y se describe a
+continuación. Haga clic en nombres de mapas para resaltarlos, esto hará
+que se muestren cuando haga clic en el botón "Aceptar". Puede seleccionar
+cualquier número de mapas. Hacer clic en "Limpiar" no seleccionará mapas,
+hacer clic en "Vectores" seleccionará solo mapas vectoriales. Las tres
+opciones "Topo" seleccionarán automáticamente todas las imágenes GeoTIFF
+del tamaño listado. Hacer clic en el botón "Aceptar" mostrará los mapas
+seleccionados. "Cancelar" abandonará cualquier cambio.
 
   Propiedades de la Selección de Mapa
   Hacer clic en el botón Propiedades traerá un diálogo donde puede especificar
@@ -915,7 +934,7 @@ mapas seleccionados. Cancelar abandonará cualquier cambio.
   los números de capas para permitir la inserción posterior de capas de mapas
   adicionales. Desde este diálogo puede especificar si un mapa vectorial se
   dibuja con rellenos de color. Esta es una configuración por mapa; la opción de
-  deshabilitación global en el menú Mapas puede reemplazar esto. La configuración
+  deshabilitación global en el menú Mapas puede reemplazar esto.
   La opción de relleno se ignora para mapas raster (imágenes). Una configuración de "automático"
   permite que un archivo dbfawk controle este parámetro directamente (usable solo
   si dbfawk está compilado y el mapa en cuestión es un Shapefile). También puede
@@ -927,7 +946,7 @@ mapas seleccionados. Cancelar abandonará cualquier cambio.
   de 10. Del mismo modo, un zoom máximo de 256 significa que un mapa se mostrará
   en todos los zooms por debajo e incluyendo 256.
 
-Marcadores del mapa
+Ir a una ubicación
 Consulte el tema de ayuda "Crear y usar marcadores de pantalla de mapa"
 
 Localice rasgo del Mapa
@@ -1060,15 +1079,16 @@ archivo de mapa es más nueva que el archivo de índice de mapas, el mapa se
 indexará.
 
 Índice: agregar mapas nuevos
-Esta opción agrega cualquier nuevo mapa al índice máximo. Las mismas reglas que
-la característica Index New Maps anterior, pero un método manual de invocación.
+Esta opción agrega cualquier nuevo mapa al índice máximo. Las mismas
+reglas que la característica "Crear índice de mapas al inicio" anterior,
+pero un método manual de invocación.
 
 Índice: reconstruir TODOS los mapas
-Esta opción comienza desde cero, indexando todos los mapas que reconoce en el
-directorio de mapas. Esto es útil si la función Add New Maps está omitiendo
-algunos mapas, tal vez debido a marcas de tiempo antiguas en los archivos de
-mapas. Esta función puede tomar bastante tiempo para completarse si tiene muchos
-mapas.
+Esta opción comienza desde cero, indexando todos los mapas que reconoce
+en el directorio de mapas. Esto es útil si la función "Índice: agregar
+mapas nuevos" está omitiendo algunos mapas, tal vez debido a marcas de
+tiempo antiguas en los archivos de mapas. Esta función puede tomar
+bastante tiempo para completarse si tiene muchos mapas.
 
 Menú Contextual del Ratón
 Esta opción trae el menú de opciones normalmente disponible por clic derecho.
@@ -1300,23 +1320,23 @@ HELP-INDEX>Menú de Estaciones
 
                              Menú de Estaciones
 
-Estas opciones le permitirán controlar los datos que se muestran alrededor de
-las estaciones en el mapa. También le permitirá rastrear y encontrar estaciones,
-y limpiar estaciones y pistas en la base de datos y del mapa.
+Estas opciones le permitirán controlar los datos que se muestran alrededor
+de las estaciones en el mapa. También le permitirá rastrear y localizar
+estaciones, y limpiar estaciones y rastros en la base de datos y del mapa.
 
-Encontrar Estación
+Localizar Estación
 Vea el tema de ayuda "Localización de una Estación".
 
-Rastrear Estación
+Rastreo de Estación
 Vea el tema de ayuda "Rastreo de una Estación"
 
-Obtener Pista de Findu
-Descarga datos históricos de pista de findu.com. Las barras deslizantes
+Sacar Rastro de Findu
+Descarga datos históricos de rastro de findu.com. Las barras deslizantes
 controlan el punto de inicio y la duración de los datos descargados. Por
-ejemplo, si deseaba ver la pista que ocurrió hace dos días, todo el día, podría
-establecer el primer deslizador a 48 horas (hora de inicio hace dos días) y el
-segundo deslizador a 24 horas para obtener exactamente un día de datos, desde
-el inicio hasta 24 horas después.
+ejemplo, si deseaba ver el rastro que ocurrió hace dos días, todo el día,
+podría establecer el primer deslizador a 48 horas (hora de inicio hace dos
+días) y el segundo deslizador a 24 horas para obtener exactamente un día de
+datos, desde el inicio hasta 24 horas después.
 
 
 Exportar todo
@@ -1324,11 +1344,11 @@ Este submenú permite guardar datos para todas las estaciones en archivos [o
 bases de datos]
 
     Exportar a archivo KML
-      Guarda todas las estaciones y sus pistas en un archivo de Lenguaje de
-      Marcado de Agujeros de Llave en ~/.xastir/tracklogs. El nombre de archivo
-      será la fecha y hora actual con extensión .kml, p. ej.
-      20080125-033045.kml. Los archivos KML también se pueden escribir de forma
-      regular utilizando Instantáneas KML en el menú de archivo.
+      Guarda todas las estaciones y sus rastros en un archivo KML (Keyhole
+      Markup Language) en ~/.xastir/tracklogs. El nombre de archivo será la
+      fecha y hora actual con extensión .kml, p. ej. 20080125-033045.kml.
+      Los archivos KML también se pueden escribir de forma regular utilizando
+      "Instantáneas KML" en el menú Archivo.
 
     Guardar en bases de datos abiertas [No implementado aún]
       [La interfaz de almacenamiento a base de datos actualmente solo se
@@ -1340,22 +1360,22 @@ bases de datos]
 Filtrar Datos
 Este submenú permite el filtrado de los símbolos mostrados:
 
-  Seleccionar Ninguno
+  Seleccionar Nada
     Determina si los símbolos deben dibujarse en el mapa. Las otras opciones
     dependen de que esto esté habilitado.
 
   Seleccionar Mío
     Determina si su propia estación se muestra en el mapa.
 
-  Seleccionar vía TNC
-   Activación/desactivación global para mostrar datos recibidos a través de un
-   TNC, pero se puede reducir:
+  Seleccionar TNC
+   Activación/desactivación global para mostrar datos recibidos a través de
+   un TNC, pero se puede reducir:
 
    Seleccionar Directo
      Esta opción solo muestra estaciones escuchadas directamente (no
      digipeated).
 
-   Seleccionar vía Digi
+   Seleccionar Vía Digi
      Esta opción muestra estaciones escuchadas indirectamente a través de un
      digipeater.
 
@@ -1363,9 +1383,9 @@ Este submenú permite el filtrado de los símbolos mostrados:
     Esta opción muestra estaciones con datos recibidos a través de Internet.
 
   Incluir Datos Expirados
-    Hace que Xastir continúe mostrando los datos de la estación que normalmente
-    desaparecen cuando el símbolo se desvanece. El tiempo de expiración se puede
-    ajustar en el menú Archivo|Configurar|Predefinidos.
+    Hace que Xastir continúe mostrando los datos de la estación que
+    normalmente desaparecen cuando el símbolo se desvanece. El tiempo de
+    expiración se puede ajustar en el menú Archivo|Configurar|Predefinidos.
 
 
   Seleccionar Estaciones
@@ -1375,31 +1395,31 @@ Este submenú permite el filtrado de los símbolos mostrados:
     Seleccionar Estaciones Fijas
       Esta opción muestra estaciones estacionarias.
 
-    Seleccionar Estaciones en Movimiento
+    Seleccionar Estaciones Móviles
       Esta opción muestra estaciones con múltiples posiciones o velocidad
-      distinta de cero
+      distinta de cero.
 
-    Seleccionar Estaciones WX
+    Seleccionar Estaciones de WX
       Esta opción muestra Estaciones Meteorológicas.
 
-     Seleccionar Estaciones CWOP WX
+     Seleccionar estaciones WX CWOP
       Esta opción incluye la visualización de datos meteorológicos de
       ciudadano (no radioaficionado). Actualmente, Xastir reconoce cualquier
-      estación que comience con las letras C hasta G, cuya segunda letra es "W",
-      y que tenga cuatro dígitos después como estaciones CWOP.
+      estación que comience con las letras C hasta G, cuya segunda letra es
+      "W", y que tenga cuatro dígitos después como estaciones CWOP.
 
-  Seleccionar Objetos/Elementos
-    Activación/desactivación global para mostrar objetos/elementos, pero se
+  Seleccionar Objetos/Artículos
+    Activación/desactivación global para mostrar objetos/artículos, pero se
     puede reducir:
 
-    Seleccionar Objetos/Elementos WX
-     Esta opción muestra Objetos y Elementos meteorológicos. Esto incluye
+    Seleccionar Objetos/Artículos de WX
+     Esta opción muestra Objetos y Artículos meteorológicos. Esto incluye
      tormentas tropicales y estaciones meteorológicas remotas.
 
-    Seleccionar Objetos/Elementos de Indicador de Agua
-     Esta opción alterna la visualización de objetos de indicador de agua (/w).
+    Seleccionar Objetos/Artículos Medidores de Agua
+     Esta opción alterna la visualización de objetos medidores de agua (/w).
 
-    Seleccionar Otros Objetos/Elementos
+    Seleccionar Otros Objetos/Artículos
      Esta opción habilita o deshabilita la visualización de objetos que no se
      enumeran arriba.
 
@@ -1410,191 +1430,195 @@ Este submenú permite el filtrado de los datos mostrados:
   Mostrar Indicativo
   Determina si el indicativo se muestra.
 
-    Etiquetar Puntos de Pista
-    Esta opción incluye indicativos a lo largo de las pistas para ayudar a
+    Etiquetar puntos de rastro
+    Esta opción incluye indicativos a lo largo de los rastros para ayudar a
     identificar qué puntos pertenecen a qué estaciones.
 
   Mostrar Símbolo
   Determina si el símbolo se muestra a la izquierda del indicativo.
 
-    Girar Símbolo
+    Símbolo Rotado
     Algunos símbolos cambiarán su orientación para mostrar la dirección en la
     que se están moviendo.
 
-  Mostrar Pista
+  Mostrar Rastros
   Cuando está habilitado, cualquier estación móvil dejará un rastro de línea
-  coloreada. Ahora mostramos tantas ubicaciones como tenemos en nuestra base de
-  datos (el antiguo límite era 100). Los segmentos de pista largos (más de 2
-  grados de latitud o 2 grados de largo), o segmentos con más de 45 minutos de
-  retardo entre los puntos no se mostrarán. Los puntos duplicados también se
-  eliminan de la pista (equipo de SAR que regresa a la base: el último segmento
-  puede no mostrarse debido a que el punto de partida aparece dos veces en la
-  lista de pistas).
+  coloreada. Ahora mostramos tantas ubicaciones como tenemos en nuestra base
+  de datos (el antiguo límite era 100). Los segmentos de rastro largos (más
+  de 2 grados de latitud o 2 grados de largo), o segmentos con más de 45
+  minutos de retardo entre los puntos no se mostrarán. Los puntos duplicados
+  también se eliminan del rastro (equipo de SAR que regresa a la base: el
+  último segmento puede no mostrarse debido a que el punto de partida
+  aparece dos veces en la lista de rastros).
 
   Mostrar Curso
-  Cuando está habilitado, el texto verde aparecerá debajo del indicativo. Esto
-  mostrará el último curso conocido (en grados) en el que se estaba moviendo la
-  estación.
+  Cuando está habilitado, el texto verde aparecerá debajo del indicativo.
+  Esto mostrará el último curso conocido (en grados) en el que se estaba
+  moviendo la estación.
 
   Mostrar Velocidad
-  Cuando está activado, el texto rojo aparecerá debajo del indicativo (o curso).
-  Esto mostrará la última velocidad conocida de la estación.
+  Cuando está activado, el texto rojo aparecerá debajo del indicativo (o
+  curso). Esto mostrará la última velocidad conocida de la estación.
 
     Mostrar Velocidad Corta
-    Esta opción elimina la visualización de las unidades de medida de velocidad.
+    Esta opción elimina la visualización de las unidades de medida de
+    velocidad.
 
-  Mostrar Altitud
-  Cuando está habilitado, el texto azul aparecerá arriba del indicativo. Esto
-  mostrará la última altitud conocida de la estación.
+  Mostrar Altura
+  Cuando está habilitado, el texto azul aparecerá arriba del indicativo.
+  Esto mostrará la última altura conocida de la estación.
 
 
-  Mostrar Información Meteorológica
-  Activación/desactivación global para mostrar información meteorológica, pero
-  se puede reducir:
+  Mostrar Informe del Tiempo
+  Activación/desactivación global para mostrar información meteorológica,
+  pero se puede reducir:
 
-    Mostrar Texto Meteorológico Cuando está habilitado, los datos meteorológicos
-    más recientes (temperatura, velocidad del viento/curso/ráfagas, humedad) se
+    Mostrar Texto: cuando está habilitado, los datos meteorológicos más
+    recientes (temperatura, velocidad del viento/curso/ráfagas, humedad) se
     muestran. Esto se puede ajustar con la siguiente opción:
 
-      Mostrar Solo Temperatura Muestra solo los datos de temperatura para la
+      Sólo la Temperatura: muestra solo los datos de temperatura para la
       estación.
 
-    Mostrar Barba de Viento Cuando está habilitado, se dibuja una barba de
-    viento que muestra la dirección y la velocidad del viento para todas las
-    estaciones mostradas que reportan esta información.
+    Mostrar Indicación de Viento: cuando está habilitado, se dibuja una
+    barba de viento que muestra la dirección y la velocidad del viento para
+    todas las estaciones mostradas que reportan esta información.
 
 
-  Mostrar Ambigüedad de Posición Cuando está habilitado, se sombrea el área en
-  la que la estación que utiliza ambigüedad de posición puede estar ubicada,
-  con la estación relevante en el centro.
+  Mostrar Ambigüedad de Posición: cuando está habilitado, se sombrea el área
+  en la que la estación que utiliza ambigüedad de posición puede estar
+  ubicada, con la estación relevante en el centro.
 
-  Mostrar Potencia/Ganancia Cuando está activado, se mostrarán Círculos de
+  Mostrar Potencia/Ganancia: cuando está activado, se mostrarán Círculos de
   Potencia/Ganancia. Los círculos superpuestos indican que las estaciones
   teóricamente están dentro del rango simplex entre sí. Esto solo es
   aproximadamente preciso, especialmente en áreas de terreno variable.
 
-    Usar Potencia/Ganancia Predeterminada Habilita una configuración de
+    Usar Pot/Ganancia por Defecto: habilita una configuración de
     potencia/ganancia predeterminada como se especifica en la especificación
     APRS(tm).
 
-    Mostrar Potencia/Ganancia Móvil Habilita círculos de potencia/ganancia para
-    estaciones móviles.
+    Mostrar Pot/Ganancia Móviles: habilita círculos de potencia/ganancia
+    para estaciones móviles.
 
 
-  Mostrar Atributos DF Cuando está habilitado, se mostrarán todos los
+  Mostrar atributos DF: cuando está habilitado, se mostrarán todos los
   círculos/líneas de DF en la pantalla.
 
-  Habilitar Predicción Muerta Cuando está habilitado, las posiciones de las
+  Activar Conteo-Muerto: cuando está habilitado, las posiciones de las
   estaciones se estiman en función del curso y la velocidad pasados. La
   velocidad de recálculo debería ser razonable, pero se puede ajustar en el
   archivo de configuración.
 
-    Mostrar Arco Muestra un arco que se expande de la distancia de viaje máximo
-    esperada, la ubicación y el curso dados del curso y la velocidad pasados.
-    El arco se convierte lentamente en un círculo a medida que el informe de
-    posición envejece.
+    Mostrar Arco: muestra un arco que se expande de la distancia de viaje
+    máximo esperada, la ubicación y el curso dados del curso y la velocidad
+    pasados. El arco se convierte lentamente en un círculo a medida que el
+    informe de posición envejece.
 
-    Mostrar Curso Muestra un curso esperado y una distancia recorrida por la
-    estación, asumiendo que el curso no ha cambiado.
+    Mostrar Curso: muestra un curso esperado y una distancia recorrida por
+    la estación, asumiendo que el curso no ha cambiado.
 
-    Mostrar Símbolos Muestra una versión fantasmal del símbolo de las estaciones
-    en la posición esperada, asumiendo que la estación ha continuado a su curso
-    y velocidad actuales.
+    Mostrar Símbolo: muestra una versión fantasmal del símbolo de las
+    estaciones en la posición esperada, asumiendo que la estación ha
+    continuado a su curso y velocidad actuales.
 
 
-  Mostrar Dist/Rumbo Cuando está habilitado, dos líneas de texto se mostrarán
-  en el lado izquierdo del icono de las estaciones. La línea superior contendrá
-  la distancia desde su estación a esta estación. La línea inferior contendrá el
-  curso desde su estación a esta estación.
+  Mostrar Orientación/Distancia: cuando está habilitado, dos líneas de texto
+  se mostrarán en el lado izquierdo del icono de las estaciones. La línea
+  superior contendrá la distancia desde su estación a esta estación. La
+  línea inferior contendrá el curso desde su estación a esta estación.
 
-  Mostrar Edad del Último Informe Muestra el tiempo desde que se escuchó por
-  última vez la estación.
+  Mostrar Tiempo del Ultimo Informe: muestra el tiempo desde que se escuchó
+  por última vez la estación.
 
-Recargar Historial de Objetos/Elementos Esto recargará el archivo
+Recargar Historia de Objeto/Artículo: esto recargará el archivo
 ~/.xastir/config/objects.log utilizado para la persistencia de Objetos y
-Elementos. Esto es necesario si edita el archivo mientras Xastir se está
+Artículos. Esto es necesario si edita el archivo mientras Xastir se está
 ejecutando.
 
-Borrar Historial de Objetos/Elementos Esto borrará el archivo
+Limpiar Historia de Objeto/Artículo: esto borrará el archivo
 ~/.xastir/config/objects.log utilizado para la persistencia de Objetos y
-Elementos. Se recomienda que seleccione y elimine manualmente todos los
-Objetos y Elementos que posee antes de hacer esto, de lo contrario pueden
+Artículos. Se recomienda que seleccione y elimine manualmente todos los
+Objetos y Artículos que posee antes de hacer esto, de lo contrario pueden
 permanecer en las pantallas de otros usuarios de APRS(tm).
 
-Borrar Todos los Indicativos Tácticos Borra todos los indicativos tácticos
-asignados. Esto tendrá efecto en el próximo redibujado. Tenga en cuenta que
-esto NO borrará los indicativos tácticos en las pantallas de otras personas si
-los ha publicado a través de un mensaje a "TACTICAL" (vea el texto de ayuda
-para "Enviar Mensaje").
+Borrar todas las llamadas tácticas: borra todas las llamadas tácticas
+asignadas. Esto tendrá efecto en el próximo redibujado. Tenga en cuenta que
+esto NO borrará las llamadas tácticas en las pantallas de otras personas si
+las ha publicado a través de un mensaje a "TACTICAL" (vea el texto de ayuda
+para "Enviar Mensaje A").
 
-Borrar Historial de Indicativo Táctico Esto elimina el archivo de historial
-de indicativo táctico, lo que significa que los indicativos tácticos asignados
+Borrar historial de llamadas tácticas: esto elimina el archivo de historial
+de llamadas tácticas, lo que significa que las llamadas tácticas asignadas
 no permanecerán permanentes entre reinicios de Xastir. Tenga en cuenta que
-esto NO borrará los indicativos tácticos en las pantallas de otras personas si
-los ha publicado a través de un mensaje a "TACTICAL" (vea el texto de ayuda
-para "Enviar Mensaje".
+esto NO borrará las llamadas tácticas en las pantallas de otras personas si
+las ha publicado a través de un mensaje a "TACTICAL" (vea el texto de ayuda
+para "Enviar Mensaje A").
 
-Borrar Todas las Pistas Esto borrará todos los datos de seguimiento de línea
-de la base de datos de estaciones y actualizará la pantalla. Esta opción es
+Limpiar Rastros: esto borrará todos los datos de seguimiento de línea de la
+base de datos de estaciones y actualizará la pantalla. Esta opción es
 quizás útil si tiene poca memoria o simplemente desea una pantalla sin
-desorden. También puede borrar las pistas de estaciones individuales desde el
-diálogo Información de la Estación.
+desorden. También puede borrar los rastros de estaciones individuales desde
+el diálogo Info Estación.
 
-Borrar Todas las Estaciones Esto borrará todos los datos de la base de datos
-de estaciones excepto el suyo. Esta opción es quizás útil si tiene poca
-memoria o simplemente desea desorden su pantalla.
+Anular Todas las Estaciones: esto borrará todos los datos de la base de
+datos de estaciones excepto el suyo. Esta opción es quizás útil si tiene
+poca memoria o simplemente desea una pantalla sin desorden.
 
 HELP-INDEX>Mensajes y el menú de Mensajes
 
                   Mensajes y el menú de Mensajes
 
-Enviar Mensaje a y Abrir mensajes de grupo
+Enviar Mensaje A y Abrir Mensajes Grupos
 
-Estos son muy similares. "Enviar mensaje a" enviará sus mensajes a una
-estación y solo recibirá datos de esa estación. Los mensajes de grupo son más
-generales: puede recibir cualquier mensaje para el grupo y enviará sus mensajes
-a ese nombre de grupo. El código de mensajes de grupo no está completamente
-implementado aún y varios problemas aún deben resolverse. El archivo "groups"
-se busca en ~/.xastir/config. Aquí es donde se almacenan los grupos de los que
-es miembro. Como se dijo anteriormente, la funcionalidad de "grupos" puede que
-aún no esté completa.
+Estos son muy similares. "Enviar Mensaje A" enviará sus mensajes a una
+estación y solo recibirá datos de esa estación. Los mensajes de grupo son
+más generales: puede recibir cualquier mensaje para el grupo y enviará sus
+mensajes a ese nombre de grupo. El código de mensajes de grupo no está
+completamente implementado aún y varios problemas aún deben resolverse. El
+archivo "groups" se busca en ~/.xastir/config. Aquí es donde se almacenan
+los grupos de los que es miembro. Como se dijo anteriormente, la
+funcionalidad de "grupos" puede que aún no esté completa.
 
-En algún momento en el futuro, el envío de boletines debería agregarse a este
-menú también. Aún no está codificado.
+En algún momento en el futuro, el envío de boletines debería agregarse a
+este menú también. Aún no está codificado.
 
-Cada una de estas dos pantallas contiene un cuadro de mensaje, una línea de
-llamada, una línea de mensaje y varios botones. Primero debe ingresar la
-llamada del grupo o estación que desea contactar. Una vez hecho esto, cualquier
-nuevo mensaje que haya llegado de esa estación a usted se mostrará. Si la
-estación le está enviando información y no hay una ventana de mensaje abierta,
-se abrirá automáticamente una nueva ventana (hasta 10) con el indicativo de esa
-estación rellenado para usted. Ahora puede ingresar un mensaje en la línea de
-mensaje. El mensaje puede ser más largo que la línea de mensaje, y alcanzará
-un máximo de aproximadamente 250+ caracteres. Una vez que ingrese su mensaje,
-hacer clic en el botón "¡Enviar Ahora!" enviará su mensaje. El botón "¡Enviar
-Ahora!" se desactivará hasta que su mensaje sea completamente reconocido. Cualquier
-mensaje que reciba se ordenará por el número de línea y se colocará en la ventana
-de mensaje. Si está en modo de grupo, cada línea mostrará el indicativo desde
-donde se envió el mensaje seguido del mensaje en sí. Actualmente, los mensajes de
-grupo se ordenan por indicativo y luego por número de línea. Cuando haya
-terminado de enviar mensajes, hacer clic en el botón de salida cerrará la
-ventana. También hay otros botones disponibles: El botón "Nueva Llamada" le
-permitirá ver datos antiguos que una estación ha enviado. Escriba la llamada y
-haga clic en este botón; se mostrará información antigua. También puede usar
-este botón para cambiar la llamada de la estación con la que está hablando.
-Ingrese la nueva llamada y haga clic en el botón. El botón "Borrar Historial
-de Mensajes" borrará cualquier mensaje que se muestre en la ventana de mensaje.
-"Cancelar Mensajes Pendientes" cancelará todos los mensajes en la cola de
-transmisión que aún no han sido reconocidos por la estación remota. Después de
-cancelar los mensajes pendientes o recibir un paquete de reconocimiento de la
-estación remota, puede enviar nuevos mensajes a la estación remota. Xastir le
-permitirá escribir con anticipación, por lo que puede seguir escribiendo si no
-desea esperar los reconocimientos.
+Cada una de estas dos pantallas contiene un cuadro de mensaje, una línea
+de indicativo, una línea de mensaje y varios botones. Primero debe ingresar
+el indicativo del grupo o estación que desea contactar. Una vez hecho esto,
+cualquier nuevo mensaje que haya llegado de esa estación a usted se
+mostrará. Si la estación le está enviando información y no hay una ventana
+de mensaje abierta, se abrirá automáticamente una nueva ventana (hasta 10)
+con el indicativo de esa estación rellenado para usted. Ahora puede
+ingresar un mensaje en la línea de mensaje. El mensaje puede ser más largo
+que la línea de mensaje, y alcanzará un máximo de aproximadamente 250+
+caracteres. Una vez que ingrese su mensaje, hacer clic en el botón
+"¡Enviar ahora!" enviará su mensaje. El botón "¡Enviar ahora!" se
+desactivará hasta que su mensaje sea completamente reconocido. Cualquier
+mensaje que reciba se ordenará por el número de línea y se colocará en la
+ventana de mensaje. Si está en modo de grupo, cada línea mostrará el
+indicativo desde donde se envió el mensaje seguido del mensaje en sí.
+Actualmente, los mensajes de grupo se ordenan por indicativo y luego por
+número de línea. Cuando haya terminado de enviar mensajes, hacer clic en
+el botón de salida cerrará la ventana. También hay otros botones
+disponibles: el botón "Nuevo/Actualizar indicativo" le permitirá ver datos
+antiguos que una estación ha enviado. Escriba el indicativo y haga clic en
+este botón; se mostrará información antigua. También puede usar este botón
+para cambiar el indicativo de la estación con la que está hablando.
+Ingrese el nuevo indicativo y haga clic en el botón. El botón "Limpiar
+historial de mensajes" borrará cualquier mensaje que se muestre en la
+ventana de mensaje. "Cancelar mensajes pendientes" cancelará todos los
+mensajes en la cola de transmisión que aún no han sido reconocidos por la
+estación remota. Después de cancelar los mensajes pendientes o recibir un
+paquete de reconocimiento de la estación remota, puede enviar nuevos
+mensajes a la estación remota. Xastir le permitirá escribir con
+anticipación, por lo que puede seguir escribiendo si no desea esperar los
+reconocimientos.
 
 Los mensajes en respuesta a los anteriores intentarán usar la ruta del mensaje
 recibido para evitar inundar el sistema con mensajes de difusión. Puede ajustar
 la ruta en el diálogo de envío de mensaje, o las rutas predeterminadas
-establecidas en el control de interfaz se usarán si deja esto en blanco. La
+establecidas en el control de interfaces se usarán si deja esto en blanco. La
 ruta se puede establecer para cada mensaje enviado, pero una vez que se envía
 un mensaje, la ruta permanece fija para ese mensaje en particular.
 
@@ -1616,34 +1640,36 @@ blanco a los indicativos originales, eliminando así la asignación):
 
     callsign-1=;callsign-2=;callsign-3=
 
-Borrar todos los mensajes salientes
+Anular todos los mensajes salientes
 Esto borrará todos los mensajes sin reconocer que ha enviado.
 
-Consulta General de Estaciones
+Pregunta General a Estaciones
 Esto envía un paquete ?APRS?, que debería hacer que todas las estaciones
-locales reporten su posición y/o estado. La mayoría del software ignora esta
-consulta, porque responder a ella causaría masivas inundaciones de datos.
+locales reporten su posición y/o estado. La mayoría del software ignora
+esta consulta, porque responder a ella causaría masivas inundaciones de
+datos.
 
-Consulta de Estaciones IGate
-Esto envía un paquete ?IGATE?, que debería hacer que todos los IGates locales
-respondan con sus capacidades.
+Pregunta a Estaciones I-Gate
+Esto envía un paquete ?IGATE?, que debería hacer que todos los I-Gates
+locales respondan con sus capacidades.
 
-Consulta de Estaciones WX
+Pregunta a Estaciones WX
 Esto envía un paquete ?WX?, que debería hacer que todas las estaciones
 meteorológicas locales reporten su posición y meteorología.
 
-Modificar Mensaje de Respuesta Automática
-Esto establecerá el mensaje que se envía como Respuesta Automática.
+Fijar Mensaje en Contestación Automática
+Esto establecerá el mensaje que se envía como Contestación Automática.
 
-Habilitar Mensaje de Respuesta Automática
-Esto activará una respuesta automática cuando se reciba un mensaje entrante.
+Activar Auto contestación de Mensaje
+Esto activará una contestación automática cuando se reciba un mensaje
+entrante.
 
-Modo de Reconocimiento de Satélite
+Satélite Modo de Reconocimiento
 Este modo deshabilita el envío de mensajes de reconocimiento en respuesta a
 mensajes recibidos. Los mensajes aún se reconocen utilizando el sistema de
 respuesta-reconocimiento. Cuando opera sobre un satélite, está claro que su
-mensaje llegó, porque lo escuchará repetido. La estación receptora que envía un
-reconocimiento independiente solo agrega QRM.
+mensaje llegó, porque lo escuchará repetido. La estación receptora que envía
+un reconocimiento independiente solo agrega QRM.
 
 HELP-INDEX>Menú de Interfaces
 
@@ -1651,18 +1677,19 @@ HELP-INDEX>Menú de Interfaces
 
 Este menú contiene opciones relacionadas con la interfaz.
 
-Control de Interfaz
-Esta opción muestra una ventana donde puede activar y desactivar sus interfaces
-configuradas, así como agregar, eliminar o configurar interfaces. Vea el tema
-de ayuda "Configurar Interfaces".
+Control de interfaces
+Esta opción muestra una ventana donde puede activar y desactivar sus
+interfaces configuradas, así como agregar, eliminar o configurar
+interfaces. Vea el tema de ayuda "Configurar Interfaces".
 
-Opciones Desactivar Transmisión
-Estas opciones desactivan la transmisión de todo, la propia posición u objetos
-propios. Estas son opciones globales y afectan todas las interfaces. La mayoría
-de las interfaces también tienen una opción para desactivar la transmisión en
-esa interfaz específica en sus menús de configuración.
+Opciones Desactivar Transmitir
+Estas opciones desactivan la transmisión de todo, la propia posición u
+objetos propios. Estas son opciones globales y afectan todas las
+interfaces. La mayoría de las interfaces también tienen una opción para
+desactivar la transmisión en esa interfaz específica en sus menús de
+configuración.
 
-Habilitar Puerto del Servidor
+Activar puertos de servidor
 Esto habilita/deshabilita sockets de escucha TCP y UDP en el puerto 2023. Puede
 conectar otros clientes APRS(tm) al puerto TCP para enviar/recibir datos
 APRS(tm). Una vez que se autentiquen, podrán enviar datos a Xastir. Sin
@@ -1696,45 +1723,46 @@ remoto usando la bandera -identify:
 
  xastir_udp_client localhost 2023 <callsign> <passcode> -identify
 
-Transmitir ahora
+Transmitir Ahora..!
 Hace que todas las interfaces que tengan habilitada la transmisión (vea
-configure|interfaces) transmitan un paquete de posición. Se desactivará si está
-seleccionada la opción Desactivar Transmisión: TODOS.
+Interfaces|Control de interfaces) transmitan un paquete de posición. Se
+desactivará si está seleccionada la opción "Desactivar Transmitir: TODOS".
 
-Si tiene GPSMan instalado, tiene estas opciones de menú adicionales mostradas:
+Si tiene GPSMan instalado, tiene estas opciones de menú adicionales
+mostradas:
 
-Obtener Pista GPS
+Obtener track del GPS
 Descargue un conjunto de puntos de pista de un GPS adjunto.
 
-Obtener Rutas GPS
+Obtener rutas del GPS
 Descargue un conjunto de rutas de un GPS adjunto.
 
-Obtener Puntos de Ruta GPS
-Descargue un conjunto de puntos de ruta de un GPS adjunto.
+Obtener waypoints del GPS
+Descargue un conjunto de waypoints de un GPS adjunto.
 
-Obtener Puntos de Ruta de Garmin RINO
-Agarre puntos de ruta de un Garmin RINO adjunto, cree Objetos APRS(tm) de
-cualquier punto de ruta que comience con "APRS".
+Obtener waypoints Garmin RINO
+Agarre waypoints de un Garmin RINO adjunto, cree Objetos APRS(tm) de
+cualquier waypoint que comience con "APRS".
 
 HELP-INDEX>Cuadro de información de la estación - Búsqueda de FCC y RAC
 
                   Cuadro de información de la estación - Búsqueda de FCC y RAC
 
-Información de la Estación mostrará cualquier dato decodificado por Xastir.
+"Info Estación" mostrará cualquier dato decodificado por Xastir.
 
-Puede asignar (solo localmente) indicativos tácticos a estaciones desde aquí,
-haciendo clic en el botón "Asignar Indicativo Táctico". Esto hará que la
-estación en la pantalla se muestre como el indicativo táctico en lugar de su
-indicativo. Asignar un indicativo táctico en blanco borra esta función, y
-también se puede borrar para todas las estaciones en el menú Estaciones. Esta
-función asigna indicativos tácticos solo a la estación Xastir local, pero vea
-abajo para publicarlos a otros.
+Puede asignar (solo localmente) llamadas tácticas a estaciones desde aquí,
+haciendo clic en el botón "Asignar llamada táctica". Esto hará que la
+estación en la pantalla se muestre como la llamada táctica en lugar de su
+indicativo. Asignar una llamada táctica en blanco borra esta función, y
+también se puede borrar para todas las estaciones en el menú Estaciones.
+Esta función asigna llamadas tácticas solo a la estación Xastir local, pero
+vea abajo para publicarlas a otros.
 
-Para publicar indicativos tácticos por el aire a otras estaciones Xastir y
-APRS+SA (así como asignarlos localmente), vea la sección de ayuda "Enviar
-Mensaje".
+Para publicar llamadas tácticas por el aire a otras estaciones Xastir y
+APRS+SA (así como asignarlas localmente), vea la sección de ayuda "Enviar
+Mensaje A".
 
-"Habilitar Actualizaciones Automáticas" hará que la ventana se actualice
+"Activar actualizaciones automáticas" hará que la ventana se actualice
 frecuentemente con la información más reciente.
 
 La información disponible puede incluir: Número de paquetes escuchados, el
@@ -1743,75 +1771,78 @@ comentarios de la estación, potencia/altura/ganancia de la estación,
 curso/distancia desde su estación, información meteorológica y posiciones
 actuales y anteriores.
 
-Para estaciones móviles, un registro de pista sigue con las entradas más
-recientes en la parte superior. Un '+' al frente indica que comienza una nueva
-pista en ese punto (si había un gran intervalo de tiempo o posición). Una
-estrella al final de una línea indica que esta estación podría ser escuchada
-directamente (sin digi) en esa posición específica. Las posiciones van seguidas
-del cuadrado de cuadrícula de Maidenhead de 6 dígitos en el que se ubicó la
-estación en ese punto.
+Para estaciones móviles, un registro de rastro sigue con las entradas más
+recientes en la parte superior. Un '+' al frente indica que comienza un
+nuevo rastro en ese punto (si había un gran intervalo de tiempo o
+posición). Una estrella al final de una línea indica que esta estación
+podría ser escuchada directamente (sin digi) en esa posición específica.
+Las posiciones van seguidas del cuadrado de cuadrícula de Maidenhead de 6
+dígitos en el que se ubicó la estación en ese punto.
 
-Para su propia estación, hay un campo "Echoed from", enumerando los últimos
-seis repetidores que lo escucharon directamente. Esto es útil para establecer
-rutas no genéricas.
+Para su propia estación, hay un campo "Repetido desde:", enumerando los
+últimos seis repetidores que lo escucharon directamente. Esto es útil para
+establecer rutas no genéricas.
 
-Actualmente, dos filas de cuatro botones aparecen en la ventana Información de
-la Estación. Algunas de las etiquetas en los botones cambian según el tipo de
-estación con la que esté tratando.
+Actualmente, dos filas de cuatro botones aparecen en la ventana "Info
+Estación". Algunas de las etiquetas en los botones cambian según el tipo
+de estación con la que esté tratando.
 
-Para objetos/elementos:
+Para objetos/artículos:
 
-Guardar    Modificar  En Blanco  Cerrar
-Pista      Objeto/
-           Elemento
+Almacenar  Modificar    En Blanco  Cerrar
+Rastro     Objeto/
+           Artículo
 
-Versión    Consulta   Mensajes   Consulta
-de         de Rastreo No         de Estaciones
-Estación              Reconocidos Directas
+Consulta   Preguntar    Consulta de Consulta de
+de versión rastro       mensajes    estaciones
+de estación             sin acuse   directas
 
 Para otras estaciones:
 
-Guardar    Enviar     Buscar     Cerrar
-Pista      Mensaje    Base de
-                      Datos FCC
-                      (RAC)
+Almacenar  Enviar       Consultar  Cerrar
+Rastro     mensaje      base FCC
+                        (RAC)
 
-Versión    Consulta   Mensajes   Consulta
-de         de Rastreo No         de Estaciones
-Estación              Reconocidos Directas
+Consulta   Preguntar    Consulta de Consulta de
+de versión rastro       mensajes    estaciones
+de estación             sin acuse   directas
 
-"Consulta de Versión de Estación" cambia a "Borrar Pista" para estaciones
-móviles. El botón Borrar Pista borrará cualquier pista de seguimiento de línea
-para esta estación que actualmente esté almacenada o se muestre en el mapa.
+"Consulta de versión de estación" cambia a "Limpiar Rastro" para estaciones
+móviles. El botón "Limpiar Rastro" borrará cualquier rastro de seguimiento
+de línea para esta estación que actualmente esté almacenada o se muestre
+en el mapa.
 
-"Guardar Pista" guardará la pista de la estación en un archivo en el disco. El
-formato es similar al utilizado por receptores GPS, pero su especificación
-podría cambiar (mejorarse) en futuras versiones. Actualmente, no hay forma de
-leer esos datos de pista, pero está planeado para el futuro. El objetivo es
-también leer y mostrar registros de pista GPS de manera similar. Estos archivos
-de registro de pista se colocarán en el directorio ~/.xastir/tracklogs con un
-nombre igual al indicativo de la estación con ".trk" como extensión. "Guardar
-Pista" guardará simultáneamente la pista de la estación como un archivo de
-Lenguaje de Marcado de Agujeros de Llave (.kml) con un nombre de archivo igual
-al indicativo de la estación, la fecha y hora actual y .kml como extensión. Si
-se ha incluido soporte de archivos de forma, la pista de la estación también se
-guardará como un conjunto de cuatro archivos (.dbf,.prj,.shp,.shx). Los
-presionamientos posteriores de Guardar Pista para la misma estación escribirán
-líneas adicionales en el archivo .trk y crearán nuevos archivos .kml (y de
-forma) (cada uno que contiene todas las posiciones en la pista de la estación).
+"Almacenar Rastro" guardará el rastro de la estación en un archivo en el
+disco. El formato es similar al utilizado por receptores GPS, pero su
+especificación podría cambiar (mejorarse) en futuras versiones.
+Actualmente, no hay forma de leer esos datos de rastro, pero está planeado
+para el futuro. El objetivo es también leer y mostrar registros de pista
+GPS de manera similar. Estos archivos de registro de rastro se colocarán
+en el directorio ~/.xastir/tracklogs con un nombre igual al indicativo de
+la estación con ".trk" como extensión. "Almacenar Rastro" guardará
+simultáneamente el rastro de la estación como un archivo KML (Keyhole
+Markup Language, .kml) con un nombre de archivo igual al indicativo de la
+estación, la fecha y hora actual y .kml como extensión. Si se ha incluido
+soporte de archivos de forma, el rastro de la estación también se guardará
+como un conjunto de cuatro archivos (.dbf,.prj,.shp,.shx). Los
+presionamientos posteriores de "Almacenar Rastro" para la misma estación
+escribirán líneas adicionales en el archivo .trk y crearán nuevos archivos
+.kml (y de forma) (cada uno que contiene todas las posiciones en el rastro
+de la estación).
 
-"Modificar Objeto/Elemento" abrirá la ventana Modificar Objeto.
+"Modificar Objeto/Artículo" abrirá la ventana Modificar Objeto.
 
-"Enviar mensaje" abrirá la ventana de mensaje y le permitirá enviar un mensaje
-a esta estación. Rellenará el indicativo para usted.
+"Enviar mensaje" abrirá la ventana de mensaje y le permitirá enviar un
+mensaje a esta estación. Rellenará el indicativo para usted.
 
-Si la base de datos de FCC (Comisión Federal de Comunicaciones de EE.UU.) o RAC
-(Radioaficionados de Canadá) está instalada y el indicativo parece ser un
-indicativo canadiense o de EE.UU., el botón "Buscar Base de Datos de FCC/RAC"
-se volverá activo, de lo contrario este botón estará inactivo. Los archivos de
-FCC y RAC deben colocarse en el directorio /usr/local/share/xastir/fcc, ¡y la
-mayúsculas/minúsculas es importante! Presionar este botón agrega el nombre y
-dirección de la estación al cuadro de Información de la Estación. Las
+Si la base de datos de FCC (Comisión Federal de Comunicaciones de EE.UU.) o
+RAC (Radioaficionados de Canadá) está instalada y el indicativo parece ser
+un indicativo canadiense o de EE.UU., el botón "Consultar base FCC" (o
+"Consultar base RAC") se volverá activo, de lo contrario este botón estará
+inactivo. Los archivos de FCC y RAC deben colocarse en el directorio
+/usr/local/share/xastir/fcc, ¡y la mayúsculas/minúsculas es importante!
+Presionar este botón agrega el nombre y dirección de la estación al cuadro
+de "Info Estación". Las
 instrucciones para instalar estas bases de datos se encuentran en la página
 "Scripts auxiliares" en el wiki,
 https://github.com/Xastir/Xastir/wiki/Helper-Scripts
@@ -1832,78 +1863,82 @@ indicación en la barra de estado cuando el registro esté habilitado.
 
 Todas estas opciones son accesibles a través del menú Archivo:
 
-Habilitar Registro de TNC
-Registra todos los datos de TNC recibidos y transmitidos. Estos registros se
-pueden reproducir usando la función "Abrir Archivo de Registro".
+Registro del TNC
+Registra todos los datos de TNC recibidos y transmitidos. Estos registros
+se pueden reproducir usando la función "Abrir registro".
 
-Habilitar Registro de Red
-Registra todos los datos de Internet recibidos y transmitidos. Estos registros
-se pueden reproducir usando la función "Abrir Archivo de Registro". Si no
-tiene interfaces iniciadas pero aún desea registrar sus posits y objetos
-localmente, esta es la opción para habilitar para eso también.
+Registro de Internet
+Registra todos los datos de Internet recibidos y transmitidos. Estos
+registros se pueden reproducir usando la función "Abrir registro". Si no
+tiene interfaces iniciadas pero aún desea registrar sus posiciones y
+objetos localmente, esta es la opción para habilitar para eso también.
 
-Habilitar Registro de IGate
-Registra todos los datos reenviados en ambas direcciones y reenvíos rechazados
-con razones de rechazo. Incluye mensajes NWS reenviados a RF.
+Registro del I-Gate
+Registra todos los datos reenviados en ambas direcciones y reenvíos
+rechazados con razones de rechazo. Incluye mensajes NWS reenviados a RF.
 
-Habilitar Registro WX
-Registra todos los datos meteorológicos recibidos de su estación meteorológica.
+Registro de WX
+Registra todos los datos meteorológicos recibidos de su estación
+meteorológica.
 
 
 HELP-INDEX>Reproducción de un registro
 
                               Reproducción de un registro
 
-Haga clic en "Archivo", luego "Abrir Archivo de Registro" y se mostrará una
-ventana de selector de archivos. Puede usarlo para explorar su disco duro y
+Haga clic en "Archivo", luego "Abrir registro" y se mostrará una ventana de
+selector de archivos. Puede usarlo para explorar su disco duro y
 seleccionar cualquier archivo que contenga datos TNC sin procesar como los
-creados por las opciones de registro de TNC y Red. Su estación seguirá
-funcionando de la misma manera, recibiendo y transmitiendo. Si estaba registrando
-datos, el lugar típico para buscar esos archivos sería ~/.xastir/logs/
+creados por las opciones de Registro del TNC y de Internet. Su estación
+seguirá funcionando de la misma manera, recibiendo y transmitiendo. Si
+estaba registrando datos, el lugar típico para buscar esos archivos sería
+~/.xastir/logs/
 
-NOTA: Esta función no lee los registros de pista de estación guardados.
+NOTA: Esta función no lee los registros de rastro de estación guardados.
 
 HELP-INDEX>Localización de una Estación
 
                              Localización de una Estación
 
-Haga clic en "Estaciones", luego "Encontrar Estación". Se abrirá una ventana.
-Ahora puede ingresar una llamada o parte de una llamada. Por defecto, buscará
-una coincidencia exacta (llamada completa, no parcial) y no distingue mayúsculas
-de minúsculas. Si busca una coincidencia parcial, "Coincidir Exacto" no debe
-estar seleccionado.
+Haga clic en "Estaciones", luego "Localizar Estación". Se abrirá una
+ventana. Ahora puede ingresar un indicativo o parte de un indicativo. Por
+defecto, buscará una coincidencia exacta (indicativo completo, no parcial)
+y no distingue mayúsculas de minúsculas. Si busca una coincidencia parcial,
+"Coincidencia exacta" no debe estar seleccionado.
 
-¡Para objetos que podrían contener letras minúsculas, debe marcar "Coincidir
-Mayúsculas"! Al contrario del nombre, sin "Coincidir Mayúsculas", el texto de
-búsqueda solo se convertirá a mayúsculas...
+¡Para objetos que podrían contener letras minúsculas, debe marcar
+"Distinguir mayús./minús."! Al contrario del nombre, sin "Distinguir
+mayús./minús.", el texto de búsqueda solo se convertirá a mayúsculas...
 
-Hacer clic en el botón "¡Localizar Ahora!" centrará la primera estación
+Hacer clic en el botón "¡Localizar ahora!" centrará la primera estación
 encontrada en el centro de su pantalla en el nivel de zoom actual.
 
-Hacer clic en "Búsqueda de FCC/RAC" buscará la información del usuario si la
+Hacer clic en "Consulta FCC/RAC" buscará la información del usuario si la
 base de datos de FCC o RAC, de esas bases de datos están instaladas.
 
 Hacer clic en "Cancelar" cerrará la ventana.
 
-Este diálogo aparecerá si una estación envía un paquete "¡Emergencia!" Mic-e,
-para alentar a los usuarios a localizar y quizás ayudar a la estación listada.
+Este diálogo aparecerá si una estación envía un paquete "¡Emergencia!"
+Mic-e, para alentar a los usuarios a localizar y quizás ayudar a la
+estación listada.
 
 HELP-INDEX>Crear y usar marcadores de pantalla de mapa
 
                   Crear y usar marcadores de pantalla de mapa
 
-Haga clic en "Mapas", luego "Marcadores de Pantalla de Mapa" y se abrirá una
-ventana. Si esta es la primera vez que lo usa, el cuadro no tendrá entradas en
-él. Para agregar un marcador a la lista: Coloque el mapa principal en el área
+Haga clic en "Mapas", luego "Ir a una ubicación" y se abrirá una ventana.
+Si esta es la primera vez que lo usa, el cuadro no tendrá entradas en él.
+Para agregar un marcador a la lista: coloque el mapa principal en el área
 y el nivel de zoom que desea utilizar. Ingrese un nombre único en el área
-"Nuevo Nombre", luego haga clic en agregar. Su entrada se agregará a la lista
-(en orden alfabético). Puede agregar tantos marcadores de pantalla de mapa como
-desee. Para usar uno de los marcadores, marque su nombre y haga clic en
-"¡Activar!". El mapa principal mostrará el área almacenada y el nivel de zoom.
-Puede eliminar un marcador de manera similar haciendo clic en el nombre del
-marcador y luego en el botón "Eliminar".
+"Nombre de Nueva Localización:", luego haga clic en "Agregar". Su entrada
+se agregará a la lista (en orden alfabético). Puede agregar tantos
+marcadores del mapa como desee. Para usar uno de los marcadores, marque
+su nombre y haga clic en "IR!". El mapa principal mostrará el área
+almacenada y el nivel de zoom. Puede eliminar un marcador de manera
+similar haciendo clic en el nombre del marcador y luego en el botón
+"Anular".
 
-"Mapas->Localizar Característica de Mapa" es otro método para saltar a una
+"Mapas->Localice rasgo del Mapa" es otro método para saltar a una
 ubicación, si se conoce el nombre de la ubicación y tiene archivos GNIS
 instalados.
 
@@ -1911,15 +1946,15 @@ HELP-INDEX>Rastreo de una Estación
 
                         Rastreo de una Estación
 
-Haga clic en "Estaciones", luego "Rastrear Estación". Ingrese el indicativo a
-rastrear (todo o parte) y luego haga clic en el botón "¡Rastrear Ahora!".
-Cuando la estación se mueva, permanecerá visible en la ventana del mapa
-principal. Cuando la estación comience a acercarse al borde de la ventana del
-mapa, la ventana se re-centrará para que el objeto siempre sea visible. Para
-dejar de rastrear esta estación, haga clic en el botón "Borrar Rastreo".
-Mientras el rastreo está activo, se muestra una "Tr" en la barra de estado junto
-al nivel de zoom. Si la estación aún no está en el mapa, el rastreo comenzará
-tan pronto como aparezca.
+Haga clic en "Estaciones", luego "Rastreo de Estación". Ingrese el
+indicativo a rastrear (todo o parte) y luego haga clic en el botón
+"¡Rastrear Ahora!". Cuando la estación se mueva, permanecerá visible en la
+ventana del mapa principal. Cuando la estación comience a acercarse al
+borde de la ventana del mapa, la ventana se re-centrará para que el objeto
+siempre sea visible. Para dejar de rastrear esta estación, haga clic en el
+botón "Limpiar Rastro". Mientras el rastreo está activo, se muestra una
+"Tr" en la barra de estado junto al nivel de zoom. Si la estación aún no
+está en el mapa, el rastreo comenzará tan pronto como aparezca.
 
 HELP-INDEX>Impresión
 
@@ -2052,46 +2087,47 @@ HELP-INDEX>Configurar Interfaces
 
                            Configurar Interfaces
 
-Haga clic en Interfaces, luego en Control de interfaz.
+Haga clic en Interfaces, luego en "Control de interfaces".
 
-Debería aparecer un cuadro de "Interfaces instaladas". Este cuadro le permitirá
-agregar, eliminar y modificar las propiedades de varios dispositivos que pueda
-querer usar con Xastir.
+Debería aparecer un cuadro de "Interfaces instaladas". Este cuadro le
+permitirá agregar, eliminar y modificar las propiedades de varios
+dispositivos que pueda querer usar con Xastir.
 
 Los tipos de interfaz soportados son:
-Serial TNC
-Serial TNC con GPS en cable HSP
-Serial GPS
-Serial WX
-Internet Server
+TNC vía el Puerto Serial
+TNC serial c/GPS (cable HSP)
+GPS vía Puerto Serial
+Est. Meteorológica vía Puerto Serial
+Conexión a un Servidor en Internet
 AX.25 TNC
-Networked GPS (vía gpsd)
-Networked WX
-Serial TNC con GPS en puerto AUX
-Serial KISS TNC
-Networked Database (No Implementada Aún)
-Networked AGWPE
-Serial Multi-Port KISS TNC
-SQL Databases (Experimental)
+GPS en red (vía gpsd)
+Est. Meteorológica Enlazada a una RED
+TNC serial c/GPS (puerto AUX)
+TNC KISS serial
+Base de datos en red (aún no implementada)
+Red AGWPE
+TNC KISS serial multipuerto
+Base de datos SQL (experimental)
 
-Para agregar un dispositivo, haga clic en el botón Agregar. Aparecerá un cuadro
-"Seleccionar tipo de interfaz". Haga clic en el tipo de dispositivo que desee agregar.
-Luego haga clic en el botón Agregar en el cuadro "Seleccionar tipo de interfaz". Las
-propiedades de ese dispositivo aparecerán. Complete la información solicitada y
-haga clic en Aceptar.
+Para agregar un dispositivo, haga clic en el botón "Agregar". Aparecerá un
+cuadro "Elegir tipo de interfaz". Haga clic en el tipo de dispositivo que
+desee agregar. Luego haga clic en el botón "Agregar" en el cuadro "Elegir
+tipo de interfaz". Las propiedades de ese dispositivo aparecerán. Complete
+la información solicitada y haga clic en Aceptar.
 
-Para eliminar el dispositivo, haga clic en el dispositivo que desee eliminar y
-luego haga clic en el botón Eliminar.
+Para eliminar el dispositivo, haga clic en el dispositivo que desee
+eliminar y luego haga clic en el botón "Anular".
 
-Para modificar las propiedades de un dispositivo, haga clic en el dispositivo que
-desee modificar, luego haga clic en el botón Propiedades. Las propiedades de ese
-dispositivo aparecerán. Cambie la información que quiera y haga clic en Aceptar.
+Para modificar las propiedades de un dispositivo, haga clic en el
+dispositivo que desee modificar, luego haga clic en el botón
+"Propiedades". Las propiedades de ese dispositivo aparecerán. Cambie la
+información que quiera y haga clic en Aceptar.
 
-Hay ayuda más específica disponible bajo los temas de ayuda de cada tipo de
-interfaz.
+Hay ayuda más específica disponible bajo los temas de ayuda de cada tipo
+de interfaz.
 
-Las SQL Databases solo aparecerán como una opción si tiene soporte de MySQL o
-Postgis compilado.
+Las bases de datos SQL solo aparecerán como una opción si tiene soporte de
+MySQL o Postgis compilado.
 
 HELP-INDEX>Configurar Dispositivos Serial TNC
 
@@ -2108,35 +2144,37 @@ de comunicación. Generalmente 4800 bps, 8 bits de datos, sin paridad y 1 bit de
 parada.
 
 Opciones del Puerto TNC:
-Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
-y configure las comunicaciones con él cuando el programa primero se inicia.
+Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+dispositivo y configure las comunicaciones con él cuando el programa
+primero se inicia.
 
-Seleccionar "Allow Transmitting" le dirá a Xastir que cualquier dato de RF
-saliente puede ser enviado a este dispositivo para difusión.
+Seleccionar "Permitir Transmisión?" le dirá a Xastir que cualquier dato de
+RF saliente puede ser enviado a este dispositivo para difusión.
 
-Seleccionar "Add Delay" le dirá a xastir que inserte un retraso de un segundo
-entre emitir el comando para entrar en modo "Converse" y los datos reales a
-enviar. Esta opción existe únicamente para tratar con el TNC Kantronics KAM,
-que a menudo fallará al entrar en modo converse si recibe datos inmediatamente
-después del comando converse. Si tiene un KAM, marque esta casilla; si no, déjela
-sin marcar.
+Seleccionar "Añadir retardo" le dirá a Xastir que inserte un retraso de un
+segundo entre emitir el comando para entrar en modo "Converse" y los datos
+reales a enviar. Esta opción existe únicamente para tratar con el TNC
+Kantronics KAM, que a menudo fallará al entrar en modo converse si recibe
+datos inmediatamente después del comando converse. Si tiene un KAM, marque
+esta casilla; si no, déjela sin marcar.
 
-El Puerto TNC es el dispositivo Unix al que está conectado el TNC (o TNC y GPS).
-Normalmente puede usar /dev/ttyS0 (com1), /dev/ttyS1 (com2), etc.
+El "Puerto TNC" es el dispositivo Unix al que está conectado el TNC (o TNC
+y GPS). Normalmente puede usar /dev/ttyS0 (com1), /dev/ttyS1 (com2), etc.
 
-El comentario le permitirá establecer un nombre amigable o comentario para el
-puerto.
+El comentario le permitirá establecer un nombre amigable o comentario para
+el puerto.
 
-Ahora establece la velocidad en baudios bajo la configuración del puerto y los
-parámetros bajo el estilo del puerto. La configuración del Estilo del Puerto
-8N1 se usa para 8 bits de datos, Sin paridad y 1 bit de parada. 7E1 se usa para
-7 bits de datos, paridad par y 1 bit de parada. 7O1 se usa para 7 bits de datos,
-paridad impar, y 1 bit de parada. Estos parámetros deben coincidir con su TNC
-y GPS.
+Ahora establece la velocidad en baudios bajo la configuración del puerto y
+los parámetros bajo el "Modo del Puerto". La configuración del Modo del
+Puerto "8,N,1" se usa para 8 bits de datos, Sin paridad y 1 bit de parada.
+"7,E,1" se usa para 7 bits de datos, paridad par y 1 bit de parada.
+"7,O,1" se usa para 7 bits de datos, paridad impar, y 1 bit de parada.
+Estos parámetros deben coincidir con su TNC y GPS.
 
-Elija la operación de IGate correcta para este dispositivo. Puede tener varios
-dispositivos TNC, y esta opción puede ser diferente para cada dispositivo. Si no
-está ejecutando un IGate déjelo en la opción predeterminada de "Disable".
+Elija la operación de I-Gate correcta para este dispositivo. Puede tener
+varios dispositivos TNC, y esta opción puede ser diferente para cada
+dispositivo. Si no está ejecutando un I-Gate déjelo en la opción
+predeterminada de "Desactiva todo el IGate tráfico".
 
 Ingrese hasta tres rutas UNPROTO. Xastir asumirá la parte XX VIA de la ruta
 UNPROTO. Se permiten tres rutas para que su señal se escuche si las condiciones
@@ -2149,44 +2187,45 @@ está en un área remota y su señal es difícil de sacar puede necesitar más.
 Consulte con un grupo local y pregunte qué ruta puede ser mejor para su área.
 Si no se ingresan rutas por defecto será WIDE2-2.
 
-Si está usando IGate a RF, puede ingresar una ruta específica a usar para
-los paquetes que envía a RF. Si deja esto en blanco, se utilizarán las rutas
-UNPROTO anteriores. Si las rutas UNPROTO están en blanco, se usará WIDE2-2.
+Si está usando I-Gate a RF, puede ingresar una ruta específica a usar para
+los paquetes que envía a RF. Si deja esto en blanco, se utilizarán las
+rutas UNPROTO anteriores. Si las rutas UNPROTO están en blanco, se usará
+WIDE2-2.
 
-Archivos de Inicio y Apagado de TNC. Estos campos especifican un nombre de
+Archivos de Configuración del TNC. Estos campos especifican un nombre de
 archivo que se ubica en el directorio /usr/local/share/xastir/config. Cada
 archivo es un archivo de texto estándar que contiene cualquier comando que
-quiera enviar a su TNC en el momento en que se activa el dispositivo (archivo
-de inicio) o se apaga.
+quiera enviar a su TNC en el momento en que se activa el dispositivo
+("Arreglar Archivo del TNC") o se apaga ("Archivo de apagar TNC").
 
 HELP-INDEX>Configurar Serial TNC con GPS en Cable HSP o Puerto AUX
 
                 Configurar Serial TNC con GPS en Cable HSP o Puerto AUX
 
 Estos tipos de interfaz híbridos implementan las opciones tanto de TNCs en
-Serie como de GPSs en Serie. Por favor, consulte la ayuda de configuración tanto
-para Serial TNCs como para Serial Gpsd para más información sobre la
+Serie como de GPSs en Serie. Por favor, consulte la ayuda de configuración
+tanto para Serial TNCs como para Serial GPS para más información sobre la
 configuración de estos dispositivos.
 
-"¿Enviar Control-E para obtener Datos de GPS?"
+"¿Enviar Control-E para obtener datos GPS?"
 
-Esta casilla de verificación controla si Xastir envía un Control-E al TNC cada
-vez que necesita datos de GPS.
+Esta casilla de verificación controla si Xastir envía un Control-E al TNC
+cada vez que necesita datos de GPS.
 
-Algunos TNCs que soportan un GPS en un puerto auxiliar requieren que Xastir
-envíe un Control-E al TNC para obtener los datos de GPS cada vez que se
-necesita. Dispositivos en esta clase incluyen el Kantronics KPC-3+.
+Algunos TNCs que soportan un GPS en un puerto auxiliar requieren que
+Xastir envíe un Control-E al TNC para obtener los datos de GPS cada vez
+que se necesita. Dispositivos en esta clase incluyen el Kantronics KPC-3+.
 
 Algunos dispositivos, como radios APRS Kenwood (D700, etc.) NO requieren
-esto, y de hecho el Control-E interfiere con el funcionamiento correcto de
-estos dispositivos.
+esto, y de hecho el Control-E interfiere con el funcionamiento correcto
+de estos dispositivos.
 
-Debido a que Control-E era requerido por los TNCs más comunes que tenían un
-puerto auxiliar para GPS en el momento en que se escribió este tipo de interfaz,
-este es el comportamiento predeterminado de Xastir. Si tiene una radio Kenwood
-que está usando de esta forma, debe DESELECCIONAR la casilla de verificación
-"¿Enviar Control-E para obtener Datos de GPS?" en el diálogo de configuración
-para este tipo de interfaz.
+Debido a que Control-E era requerido por los TNCs más comunes que tenían
+un puerto auxiliar para GPS en el momento en que se escribió este tipo de
+interfaz, este es el comportamiento predeterminado de Xastir. Si tiene
+una radio Kenwood que está usando de esta forma, debe DESELECCIONAR la
+casilla de verificación "¿Enviar Control-E para obtener datos GPS?" en el
+diálogo de configuración para este tipo de interfaz.
 
 HELP-INDEX>Configurar Serial KISS TNC
 
@@ -2200,34 +2239,37 @@ puramente KISS, como el descrito en el número de noviembre de 2000 de QST, sin 
 programa separado o módulo del kernel.
 
 Opciones
-Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
-y configure las comunicaciones con él cuando el programa primero se inicia.
+Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+dispositivo y configure las comunicaciones con él cuando el programa
+primero se inicia.
 
-Seleccionar "Allow Transmitting" le dirá a Xastir que cualquier dato de RF
-saliente puede ser enviado a este dispositivo para difusión.
+Seleccionar "Permitir Transmisión?" le dirá a Xastir que cualquier dato de
+RF saliente puede ser enviado a este dispositivo para difusión.
 
-Seleccionar "Digipeat?" le dirá a Xastir que repita el tráfico de digipeater.
-Lo hará si el primer call de digipeater no utilizado en la ruta coincide con su
-call o un call listado en su archivo de configuración de Xastir (línea
-"RELAY_DIGIPEAT_CALLS", por defecto es "WIDE1-1"). Esta opción solo se
-recomienda para estaciones base en regiones donde hay pocos otros digipeaters de
-relleno en el área. Consulte con un grupo local sobre la mejor configuración
-para su región. Puede editar manualmente el archivo de configuración de Xastir
-cuando Xastir no está en ejecución para cambiar esta cadena para que coincida
-con sus recomendaciones locales. En EE.UU., "WIDE1-1" es la configuración
+Seleccionar "¿Digipeat?" le dirá a Xastir que repita el tráfico de
+digipeater. Lo hará si el primer call de digipeater no utilizado en la
+ruta coincide con su call o un call listado en su archivo de configuración
+de Xastir (línea "RELAY_DIGIPEAT_CALLS", por defecto es "WIDE1-1"). Esta
+opción solo se recomienda para estaciones base en regiones donde hay
+pocos otros digipeaters de relleno en el área. Consulte con un grupo
+local sobre la mejor configuración para su región. Puede editar
+manualmente el archivo de configuración de Xastir cuando Xastir no está
+en ejecución para cambiar esta cadena para que coincida con sus
+recomendaciones locales. En EE.UU., "WIDE1-1" es la configuración
 recomendada.
 
-El Puerto TNC es el dispositivo serial Unix al que está conectado el TNC.
-Normalmente puede usar /dev/ttyS0 (com1), /dev/ttyS1 (com2), etc.
+El "Puerto TNC" es el dispositivo serial Unix al que está conectado el
+TNC. Normalmente puede usar /dev/ttyS0 (com1), /dev/ttyS1 (com2), etc.
 
-El comentario le permitirá establecer un nombre amigable o comentario para el
-puerto.
+El comentario le permitirá establecer un nombre amigable o comentario
+para el puerto.
 
 Ahora establece la velocidad en baudios bajo la configuración del puerto.
 
-Elija la operación de IGate correcta para este dispositivo. Puede tener varios
-dispositivos TNC, y esta opción puede ser diferente para cada dispositivo. Si no
-está ejecutando un IGate déjelo en la opción predeterminada de "Disable".
+Elija la operación de I-Gate correcta para este dispositivo. Puede tener
+varios dispositivos TNC, y esta opción puede ser diferente para cada
+dispositivo. Si no está ejecutando un I-Gate déjelo en la opción
+predeterminada de "Desactiva todo el IGate tráfico".
 
 Ingrese hasta tres rutas UNPROTO. Xastir asumirá la parte XX VIA de la ruta
 UNPROTO. Se permiten tres rutas para que su señal se escuche si las condiciones
@@ -2240,9 +2282,10 @@ está en un área remota y su señal es difícil de sacar puede necesitar más.
 Consulte con un grupo local y pregunte qué ruta puede ser mejor para su área.
 Si no se ingresan rutas por defecto será WIDE2-2.
 
-Si está usando IGate a RF, puede ingresar una ruta específica a usar para
-los paquetes que envía a RF. Si deja esto en blanco, se utilizarán las rutas
-UNPROTO anteriores. Si las rutas UNPROTO están en blanco, se usará WIDE2-2.
+Si está usando I-Gate a RF, puede ingresar una ruta específica a usar para
+los paquetes que envía a RF. Si deja esto en blanco, se utilizarán las
+rutas UNPROTO anteriores. Si las rutas UNPROTO están en blanco, se usará
+WIDE2-2.
 
 A continuación configura los parámetros KISS: TXdelay es el tiempo (en unidades
 de 10ms) necesario entre el cierre de la radio y cuando está lista para enviar
@@ -2260,38 +2303,42 @@ HELP-INDEX>Configurar Dispositivos AX.25 TNC
                         Configurar Dispositivos AX.25 TNC
 
 Esta sección cubre la adición o modificación de dispositivos AX.25 TNC. Los
-dispositivos AX.25 pueden ser cualquier dispositivo que use los controladores
-Linux AX.25. Este es un controlador a nivel del kernel, y dispositivos como
-un Baycom o un módem de sonido pueden usarse como TNC. Estos dispositivos
-deben estar configurados y en funcionamiento antes de que Xastir pueda usarlos.
+dispositivos AX.25 pueden ser cualquier dispositivo que use los
+controladores Linux AX.25. Este es un controlador a nivel del kernel, y
+dispositivos como un Baycom o un módem de sonido pueden usarse como TNC.
+Estos dispositivos deben estar configurados y en funcionamiento antes de
+que Xastir pueda usarlos.
 
-Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
-y configure las comunicaciones con él cuando el programa primero se inicia.
+Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+dispositivo y configure las comunicaciones con él cuando el programa
+primero se inicia.
 
-Seleccionar "Allow Transmitting" le dirá a Xastir que cualquier dato de RF
-saliente puede ser enviado a este dispositivo para difusión.
+Seleccionar "Permitir Transmisión?" le dirá a Xastir que cualquier dato de
+RF saliente puede ser enviado a este dispositivo para difusión.
 
-Seleccionar "RELAY Digipeat?" le dirá a Xastir que repita el tráfico de
-digipeater. Lo hará si el primer call de digipeater no utilizado en la ruta
-coincide con su call o un call listado en su archivo de configuración de Xastir
-(línea "RELAY_DIGIPEAT_CALLS", por defecto es "WIDE1-1"). Esta opción solo se
-recomienda para estaciones base en regiones donde hay pocos otros digipeaters de
-relleno en el área. Consulte con un grupo local sobre la mejor configuración
-para su región. Esto solo es necesario si no está usando ningún otro software
-que realice esta función, como aprsdigi o DIGI_NED. Puede editar manualmente el
-archivo de configuración de Xastir cuando Xastir no está en ejecución para
-cambiar esta cadena para que coincida con sus recomendaciones locales. En
-EE.UU., "WIDE1-1" es la configuración recomendada.
+Seleccionar "¿Digipeat?" le dirá a Xastir que repita el tráfico de
+digipeater. Lo hará si el primer call de digipeater no utilizado en la
+ruta coincide con su call o un call listado en su archivo de configuración
+de Xastir (línea "RELAY_DIGIPEAT_CALLS", por defecto es "WIDE1-1"). Esta
+opción solo se recomienda para estaciones base en regiones donde hay
+pocos otros digipeaters de relleno en el área. Consulte con un grupo
+local sobre la mejor configuración para su región. Esto solo es
+necesario si no está usando ningún otro software que realice esta
+función, como aprsdigi o DIGI_NED. Puede editar manualmente el archivo
+de configuración de Xastir cuando Xastir no está en ejecución para
+cambiar esta cadena para que coincida con sus recomendaciones locales.
+En EE.UU., "WIDE1-1" es la configuración recomendada.
 
-Ingrese el nombre del Dispositivo AX.25 que especificó en el archivo axports
+Ingrese el "AX.25 nombre de puerto" que especificó en el archivo axports
 para este dispositivo.
 
-El comentario le permitirá establecer un nombre amigable o comentario para el
-puerto.
+El comentario le permitirá establecer un nombre amigable o comentario
+para el puerto.
 
-Elija la operación de IGate correcta para este dispositivo. Puede tener varios
-dispositivos TNC y esta opción puede ser diferente para cada dispositivo. Si no
-está ejecutando un IGate déjelo en la opción predeterminada de "Disable".
+Elija la operación de I-Gate correcta para este dispositivo. Puede tener
+varios dispositivos TNC y esta opción puede ser diferente para cada
+dispositivo. Si no está ejecutando un I-Gate déjelo en la opción
+predeterminada de "Desactiva todo el IGate tráfico".
 
 Ingrese en hasta tres rutas UNPROTO. Xastir asumirá la parte XX VIA de la ruta
 UNPROTO. Se permiten tres rutas para que su señal se escuche si las condiciones
@@ -2304,9 +2351,10 @@ está en un área remota y su señal es difícil de sacar puede necesitar más.
 Consulte con un grupo local y pregunte qué ruta puede ser mejor para su área.
 Si no se ingresan rutas por defecto será WIDE2-2.
 
-Si está usando IGate a RF, puede ingresar una ruta específica a usar para
-los paquetes que envía a RF. Si deja esto en blanco, se utilizarán las rutas
-UNPROTO anteriores. Si las rutas UNPROTO están en blanco, se usará WIDE2-2.
+Si está usando I-Gate a RF, puede ingresar una ruta específica a usar para
+los paquetes que envía a RF. Si deja esto en blanco, se utilizarán las
+rutas UNPROTO anteriores. Si las rutas UNPROTO están en blanco, se usará
+WIDE2-2.
 
 NOTA: Para usar dispositivos AX.25 con Xastir necesitará ejecutar el programa
 como "root". Si quiere ejecutar Xastir como otro usuario puede querer
@@ -2322,78 +2370,85 @@ HELP-INDEX>Configurar Dispositivos Serial GPS
 Establece el dispositivo de puerto serial para su unidad GPS. Puede usar
 valores comunes de /dev/ttyS0 (COM1) o /dev/ttyS1 (COM2).
 
-El comentario le permitirá establecer un nombre amigable o comentario para el
-puerto.
+El comentario le permitirá establecer un nombre amigable o comentario
+para el puerto.
 
-Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
-y configure las comunicaciones con él cuando el programa primero se inicia.
+Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+dispositivo y configure las comunicaciones con él cuando el programa
+primero se inicia.
 
-Seleccionar "Set system clock from GPS data" le dirá a Xastir que intente
-establecer el reloj del sistema a la señal de tiempo altamente preciso del
-receptor GPS. Esto requiere privilegios de root en la mayoría de los sistemas.
+Seleccionar "Fije el tiempo del sistema del GPS" le dirá a Xastir que
+intente establecer el reloj del sistema a la señal de tiempo altamente
+preciso del receptor GPS. Esto requiere privilegios de root en la mayoría
+de los sistemas.
 
-Ahora establece la velocidad en baudios bajo la configuración del puerto y los
-parámetros bajo el estilo del puerto. La configuración del Estilo del Puerto
-8N1 se usa para 8 bits de datos, Sin paridad y 1 bit de parada. 7E1 se usa para
-7 bits de datos, paridad par y 1 bit de parada. 7O1 se usa para 7 bits de datos,
-paridad impar, y 1 bit de parada. Estos parámetros deben coincidir con su GPS.
-La mayoría de unidades GPS usarán 4800 bps y 8,n,1.
+Ahora establece la velocidad en baudios bajo la configuración del puerto
+y los parámetros bajo el "Modo del Puerto". La configuración del Modo del
+Puerto "8,N,1" se usa para 8 bits de datos, Sin paridad y 1 bit de parada.
+"7,E,1" se usa para 7 bits de datos, paridad par y 1 bit de parada.
+"7,O,1" se usa para 7 bits de datos, paridad impar, y 1 bit de parada.
+Estos parámetros deben coincidir con su GPS. La mayoría de unidades GPS
+usarán 4800 bps y 8,N,1.
 
 HELP-INDEX>Configurar Dispositivos GPS en Red
 
                     Configurar Dispositivos GPS en Red
-Si necesita compartir los datos de GPS con diferentes programas o máquinas,
-esta opción es la mejor. Xastir trabajará con gpsd que le permitirá varias
-conexiones para compartir sus datos de GPS.
+Si necesita compartir los datos de GPS con diferentes programas o
+máquinas, esta opción es la mejor. Xastir trabajará con gpsd que le
+permitirá varias conexiones para compartir sus datos de GPS.
 
-Establece el nombre de host (o dirección IP) y el número de puerto para el
-host gpsd en su red.
+Establece el nombre de host (o dirección IP) y el número de puerto para
+el host gpsd en su red.
 
-El comentario le permitirá establecer un nombre amigable o comentario para el
-puerto.
+El comentario le permitirá establecer un nombre amigable o comentario
+para el puerto.
 
-Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
-y configure las comunicaciones con él cuando el programa primero se inicia.
+Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+dispositivo y configure las comunicaciones con él cuando el programa
+primero se inicia.
 
-Seleccionar "Reconnect on failure" le dirá a Xastir que intente reconectar
+Seleccionar "Reconectar en fallo?" le dirá a Xastir que intente reconectar
 cuando el flujo de datos ha fallado.
 
-Seleccionar "Set system clock from GPS data" le dirá a Xastir que intente
-establecer el reloj del sistema a la señal de tiempo altamente preciso del
-receptor GPS. Esto requiere privilegios de root en la mayoría de los sistemas.
+Seleccionar "Fije el tiempo del sistema del GPS" le dirá a Xastir que
+intente establecer el reloj del sistema a la señal de tiempo altamente
+preciso del receptor GPS. Esto requiere privilegios de root en la mayoría
+de los sistemas.
 
 HELP-INDEX>Configurar el Servidor de Internet
 
                          Configurar el Servidor de Internet
 
-Los Servidores de Internet le permiten enviar y recibir datos para todo el
-mundo.
+Los Servidores de Internet le permiten enviar y recibir datos para todo
+el mundo.
 
-Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
-y configure las comunicaciones con él cuando el programa primero se inicia.
+Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+dispositivo y configure las comunicaciones con él cuando el programa
+primero se inicia.
 
-Seleccionar "Allow Transmitting" le dirá a Xastir que cualquier dato saliente
-de Internet puede ser enviado a este dispositivo.
+Seleccionar "Permitir Transmisión?" le dirá a Xastir que cualquier dato
+saliente de Internet puede ser enviado a este dispositivo.
 
-Ingrese el nombre de host (o dirección IP) y el número de puerto del Servidor
-de Internet que desea contactar.
+Ingrese el nombre de host (o dirección IP) y el número de puerto del
+Servidor de Internet que desea contactar.
 
-Ingrese un código de acceso válido para validar su conexión; esto le permitirá
-que sus datos se transmitan a través de un IGate. Si no tiene un código de
-acceso, use el programa "callpass" incluido para generar uno. Tenga en cuenta que
-los códigos de acceso dependen de los indicativos. Desde el directorio src,
-"make callpass" debería crear el ejecutable si no está ya compilado.
+Ingrese un código de acceso válido para validar su conexión; esto le
+permitirá que sus datos se transmitan a través de un I-Gate. Si no tiene
+un código de acceso, use el programa "callpass" incluido para generar
+uno. Tenga en cuenta que los códigos de acceso dependen de los
+indicativos. Desde el directorio src, "make callpass" debería crear el
+ejecutable si no está ya compilado.
 
 Ingrese cualquier parámetro de filtro. Esto causa que se envíe un mensaje
 especial al servidor solicitando que los datos se filtren de una manera
-determinada. El formato exacto de este campo está completamente especificado;
-por favor consulte APRSSIG para más información.
+determinada. El formato exacto de este campo está completamente
+especificado; por favor consulte APRSSIG para más información.
 
-El comentario le permitirá establecer un nombre amigable o comentario para el
-puerto.
+El comentario le permitirá establecer un nombre amigable o comentario
+para el puerto.
 
-Seleccionar "Reconnect on failure" le dirá a Xastir que intente reconectar
-cuando el flujo de datos ha fallado.
+Seleccionar "¿Reconectar en fallo de la RED?" le dirá a Xastir que intente
+reconectar cuando el flujo de datos ha fallado.
 
 HELP-INDEX>Configurar una Estación Serial WX
 
@@ -2402,22 +2457,24 @@ HELP-INDEX>Configurar una Estación Serial WX
 Establece el dispositivo de puerto serial para su unidad WX. Puede usar
 valores comunes de /dev/ttyS0 (COM1) o /dev/ttyS1 (COM2).
 
-El comentario le permitirá establecer un nombre amigable o comentario para el
-puerto.
+El comentario le permitirá establecer un nombre amigable o comentario
+para el puerto.
 
-Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
-y configure las comunicaciones con él cuando el programa primero se inicia.
+Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+dispositivo y configure las comunicaciones con él cuando el programa
+primero se inicia.
 
-Ahora establece la velocidad en baudios bajo la configuración del puerto y los
-parámetros bajo el estilo del puerto. La configuración del Estilo del Puerto
-8N1 se usa para 8 bits de datos, Sin paridad y 1 bit de parada. 7E1 se usa para
-7 bits de datos, paridad par y 1 bit de parada. 7O1 se usa para 7 bits de datos,
-paridad impar, y 1 bit de parada. Estos parámetros deben coincidir con su unidad
-WX. La opción Tipo de Datos le permitirá anular qué tipo de datos seriales el
-programa buscará. La característica de detección automática primero buscará datos
-climáticos en un tipo binario como el que usa Weather Station WX-200 de Radio
-Shack. Si no se encuentra datos binarios en el flujo, Xastir buscará un tipo
-ASCII de estación WX (como Peet Bros.).
+Ahora establece la velocidad en baudios bajo la configuración del puerto
+y los parámetros bajo el "Modo del Puerto". La configuración del Modo del
+Puerto "8,N,1" se usa para 8 bits de datos, Sin paridad y 1 bit de parada.
+"7,E,1" se usa para 7 bits de datos, paridad par y 1 bit de parada.
+"7,O,1" se usa para 7 bits de datos, paridad impar, y 1 bit de parada.
+Estos parámetros deben coincidir con su unidad WX. La opción "Tipo de
+Data" le permitirá anular qué tipo de datos seriales el programa buscará.
+La característica de "Auto detección" primero buscará datos climáticos en
+un tipo binario como el que usa Radio Shack WX-200 de la Estación
+Meteorológica. Si no se encuentra datos binarios en el flujo, Xastir
+buscará un tipo ASCII de estación WX (como Peet Bros.).
 
 Ahora establece el factor de corrección de la lluvia. Xastir requiere que el
 medidor de lluvia reporte en incrementos de .01 pulgadas. Si la unidad reporta
@@ -2427,23 +2484,24 @@ para obtener mediciones precisas.
 HELP-INDEX>Configurar una Estación WX en Red
 
                    Configurar una Estación WX en Red
-Xastir puede usar servidores de datos WX tales como wx200d. wx200d permitirá
-varias conexiones de red, por lo tanto compartiendo los datos climáticos con
-varios programas u ordenadores.
+Xastir puede usar servidores de datos WX tales como wx200d. wx200d
+permitirá varias conexiones de red, por lo tanto compartiendo los datos
+climáticos con varios programas u ordenadores.
 
-Ingrese el nombre de host (o dirección IP) y el número de puerto del servidor de
-datos WX que desea contactar.
+Ingrese el nombre de host (o dirección IP) y el número de puerto del
+servidor de datos WX que desea contactar.
 
-El comentario le permitirá establecer un nombre amigable o comentario para el
-puerto.
+El comentario le permitirá establecer un nombre amigable o comentario
+para el puerto.
 
-Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
-y configure las comunicaciones con él cuando el programa primero se inicia.
+Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+dispositivo y configure las comunicaciones con él cuando el programa
+primero se inicia.
 
-Seleccionar "Reconnect on failure" le dirá a Xastir que intente reconectar
-cuando el flujo de datos ha fallado.
+Seleccionar "¿Reconectar en fallo de la RED?" le dirá a Xastir que intente
+reconectar cuando el flujo de datos ha fallado.
 
-Como antes, el Tipo de Datos anulará la detección automática.
+Como antes, el "Tipo de Data" anulará la detección automática.
 
 Ahora establece el factor de corrección de la lluvia. Xastir requiere que el
 medidor de lluvia reporte en incrementos de .01 pulgadas. Si la unidad reporta
@@ -2488,10 +2546,11 @@ usuario con una contraseña y derechos para acceder a la base de datos. Para
 bases de datos postgis también puede necesitar configurar apropiadamente el
 usuario en pg_hba.conf
 
-Las opciones de configuración en el diálogo de bases de datos SQL incluyen:
+Las opciones de configuración en el diálogo de bases de datos SQL
+incluyen:
 Base de datos: MySQL (lat/long) para bases de datos MySQL muy antiguas,
-          Postgis para postgresql + postgis, y
-          MySQL (Spatial) para bases de datos MySQL actuales.
+          Postgreql with Postgis para postgresql + postgis, y
+          MySQL (spatial) para bases de datos MySQL actuales.
 Con tablas para: Actualmente solo el esquema simple de Xastir - una tabla
           muy básica que contiene información mínima sobre estaciones.
 Host: Dirección IP o nombre de host para el servidor de base de datos; el
@@ -2514,8 +2573,8 @@ Activar al iniciar: Intenta conectar a esta base de datos y comienza a
 almacenar datos de estaciones escuchadas tan pronto como Xastir se inicia (si
 Almacenar datos entrantes también está seleccionado).
 
-Almacenar datos entrantes: Almacena cada reporte de estación (incluyendo objetos e
-items) como un registro en la base de datos. Todas las estaciones escuchadas en
+Almacenar datos entrantes: Almacena cada reporte de estación (incluyendo objetos y
+artículos) como un registro en la base de datos. Todas las estaciones escuchadas en
 todas las interfaces serán almacenadas en la base de datos - si está conectado
 a fuentes de internet y deja xastir ejecutándose esto fácilmente puede ser un
 millón de registros por día.

--- a/help/help-Spanish.dat
+++ b/help/help-Spanish.dat
@@ -244,7 +244,7 @@ debe crear un archivo ~/.xastir/data/nws-stations.txt que enumere cada
 indicativo o estación NWS (como "PHISVR") que desee transmitir por RF. Esta
 función también funciona para enrutar indicativos específicos a RF.
 
-"Comprimir datos objeto/artículo cuando transmita?", si está seleccionado,
+"¿Comprimir datos objeto/artículo cuando transmita?", si está seleccionado,
 transmitirá objetos y artículos en el formato comprimido más nuevo. La
 precisión máxima de la posición transmitida es mayor, y la transmisión es
 más corta, pero algunos programas más antiguos no decodifican este formato.
@@ -263,7 +263,7 @@ o Bloqueo de mayúsculas está activado. Algunos usuarios reportan que la
 pantalla se oscurece y problemas similares cuando intentan usar Xastir con
 una de estas teclas de modificador activada.
 
-También puede seleccionar "Activar Red Alternada?" y elegir un indicativo
+También puede seleccionar "¿Activar Red Alternada?" y elegir un indicativo
 altnet de este diálogo. Altnet le permite tener una red APRS(tm) privada
 entre las estaciones que también tienen altnet configurado y tienen el mismo
 altnet ingresado.
@@ -304,13 +304,14 @@ HELP-INDEX>Configurar Temporización
 
 Haga clic en Archivo, luego Configurar, luego Cronómetro.
 
-"TX Posición Intérvalo (minutos)" especifica con qué frecuencia se transmitirá
-la posición de su estación. Para estaciones fijas, una buena recomendación es
+"Intervalo TX de posición (min)" especifica con qué frecuencia se
+transmitirá la posición de su estación. Para estaciones fijas, una buena
+recomendación es
 cada 30 minutos, y definitivamente no menos de 10 minutos. Las estaciones
 móviles pueden desear usar una velocidad más rápida. Tenga en cuenta que si
 está usando Baliza Inteligente, este control deslizante se ignora.
 
-"Objeto/Artículo TX Max Intérvalo (minutos)" es el intervalo máximo usado
+"Intervalo TX máx de Objeto/Artículo (min)" es el intervalo máximo usado
 para enviar objetos y artículos. Intente mantener estos intervalos
 razonables, ya que transmitir a una ruta larga cada 5 minutos realmente
 consumirá mucho tiempo de aire. Se activa un algoritmo de intervalo
@@ -318,16 +319,18 @@ decreciente cada vez que se crea, modifica o elimina un objeto. El intervalo
 de transmisión aumentará hasta que alcance el intervalo máximo indicado por
 el control deslizante.
 
-"Chequeo Intérvalo del GPS (segundos)" establecerá el intervalo de tiempo
-para verificar el GPS en busca de nuevos datos. Esto está disponible para
+"Intervalo de comprobación del GPS (seg)" establecerá el intervalo de
+tiempo para verificar el GPS en busca de nuevos datos. Esto está
+disponible para
 estaciones que utilizan un HSP o cable compartido con su TNC.
 
-"Descanso Conteo-Muerto (minutos)" ajusta cuánto tiempo se supone que una
-posición es válida para el propósito de estimar su posición actual.
+"Tiempo de espera de navegación estimada (minutos)" ajusta cuánto tiempo se
+supone que una posición es válida para el propósito de estimar su posición
+actual.
 
-"Nuevo Tiempo Rastro (min)" ajusta cuántos minutos deben transcurrir antes
-de que se inicie un nuevo rastro separado. Precaución: establecer este
-valor en 0 desactivará la visualización de todos los rastros.
+"Tiempo para nuevo rastro (min)" ajusta cuántos minutos deben transcurrir
+antes de que se inicie un nuevo rastro separado. Precaución: establecer
+este valor en 0 desactivará la visualización de todos los rastros.
 
 "Intervalo RINO -> Objetos (min), 0 = desactivado" ajusta la frecuencia con
 la que se descargan los puntos de referencia de una unidad de radio/GPS
@@ -335,24 +338,24 @@ Garmin RINO conectada. Se crean Objetos APRS(tm) a partir de cualquier punto
 de referencia que comience con "APRS". El prefijo "APRS" se elimina al crear
 los nombres de los Objetos.
 
-"Desvanecimiento de la Estación (minutos)" especifica el intervalo de
-desvanecimiento. Las estaciones que no se han escuchado en el período dado
-aparecerán desvanecidas en la pantalla.
+"Desvanecer estación luego de (minutos)" especifica el intervalo de
+desvanecimiento. Las estaciones que no se han escuchado en el período
+dado aparecerán desvanecidas en la pantalla.
 
-"Limpiar Tiempo de la Estación (horas)" especifica cuándo se eliminará una
+"Limpiar estación luego de (horas)" especifica cuándo se eliminará una
 estación de la pantalla.
 
-"Borrar Tiempo de la Estación (días)" especifica el número de días completos
+"Borrar estación luego de (días)" especifica el número de días completos
 antes de que los datos de una estación se eliminen completamente de la base
 de datos de Xastir.
 
 "Retardo serial entre caracteres (ms)" especifica un tiempo de espera en
 milisegundos entre cada carácter enviado a un TNC conectado.
 
-"Nuevo Interval Rastro (grados)" especifica la distancia en grados de
-lat/long en la cual se inicia un nuevo segmento de rastro. Precaución:
-establecer este valor a 0 grados desactivará la visualización de todos los
-rastros.
+"Intervalo para nuevo rastro (grados)" especifica la distancia en grados
+de lat/long en la cual se inicia un nuevo segmento de rastro. Precaución:
+establecer este valor a 0 grados desactivará la visualización de todos
+los rastros.
 
 "Intervalo de instantáneas (min)" especifica con qué frecuencia se escribirán
 archivos de instantánea si se selecciona Archivo->Activa PNG Instantánea o
@@ -1002,7 +1005,7 @@ Menú Configurar:
   Esto le permite especificar un esquema que rodea los iconos de estación. Esto
   ayuda a mejorar la visibilidad en varios fondos.
 
-Desactive todos los Mapas
+Desactivar todos los Mapas
 Esta opción deshabilita la carga de cualquier mapa. Es más útil cuando se hace
 zoom rápido o desplazamiento, porque ahorra la necesidad de cargar los mapas
 en cada redibujado. Tenga en cuenta que esta opción no se guarda entre sesiones.
@@ -1505,7 +1508,7 @@ Este submenú permite el filtrado de los datos mostrados:
   Mostrar atributos DF: cuando está habilitado, se mostrarán todos los
   círculos/líneas de DF en la pantalla.
 
-  Activar Conteo-Muerto: cuando está habilitado, las posiciones de las
+  Activar navegación estimada: cuando está habilitado, las posiciones de las
   estaciones se estiman en función del curso y la velocidad pasados. La
   velocidad de recálculo debería ser razonable, pero se puede ajustar en el
   archivo de configuración.
@@ -1643,17 +1646,17 @@ blanco a los indicativos originales, eliminando así la asignación):
 Anular todos los mensajes salientes
 Esto borrará todos los mensajes sin reconocer que ha enviado.
 
-Pregunta General a Estaciones
+Consulta general de estaciones
 Esto envía un paquete ?APRS?, que debería hacer que todas las estaciones
 locales reporten su posición y/o estado. La mayoría del software ignora
 esta consulta, porque responder a ella causaría masivas inundaciones de
 datos.
 
-Pregunta a Estaciones I-Gate
+Consulta de estaciones I-Gate
 Esto envía un paquete ?IGATE?, que debería hacer que todos los I-Gates
 locales respondan con sus capacidades.
 
-Pregunta a Estaciones WX
+Consulta de estaciones WX
 Esto envía un paquete ?WX?, que debería hacer que todas las estaciones
 meteorológicas locales reporten su posición y meteorología.
 
@@ -1723,7 +1726,7 @@ remoto usando la bandera -identify:
 
  xastir_udp_client localhost 2023 <callsign> <passcode> -identify
 
-Transmitir Ahora..!
+¡Transmitir Ahora..!
 Hace que todas las interfaces que tengan habilitada la transmisión (vea
 Interfaces|Control de interfaces) transmitan un paquete de posición. Se
 desactivará si está seleccionada la opción "Desactivar Transmitir: TODOS".
@@ -1933,7 +1936,7 @@ y el nivel de zoom que desea utilizar. Ingrese un nombre único en el área
 "Nombre de Nueva Localización:", luego haga clic en "Agregar". Su entrada
 se agregará a la lista (en orden alfabético). Puede agregar tantos
 marcadores del mapa como desee. Para usar uno de los marcadores, marque
-su nombre y haga clic en "IR!". El mapa principal mostrará el área
+su nombre y haga clic en "¡IR!". El mapa principal mostrará el área
 almacenada y el nivel de zoom. Puede eliminar un marcador de manera
 similar haciendo clic en el nombre del marcador y luego en el botón
 "Anular".
@@ -2144,11 +2147,11 @@ de comunicación. Generalmente 4800 bps, 8 bits de datos, sin paridad y 1 bit de
 parada.
 
 Opciones del Puerto TNC:
-Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+Seleccionar "¿Activar en Inicio?" le dirá a Xastir que busque este
 dispositivo y configure las comunicaciones con él cuando el programa
 primero se inicia.
 
-Seleccionar "Permitir Transmisión?" le dirá a Xastir que cualquier dato de
+Seleccionar "¿Permitir Transmisión?" le dirá a Xastir que cualquier dato de
 RF saliente puede ser enviado a este dispositivo para difusión.
 
 Seleccionar "Añadir retardo" le dirá a Xastir que inserte un retraso de un
@@ -2239,11 +2242,11 @@ puramente KISS, como el descrito en el número de noviembre de 2000 de QST, sin 
 programa separado o módulo del kernel.
 
 Opciones
-Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+Seleccionar "¿Activar en Inicio?" le dirá a Xastir que busque este
 dispositivo y configure las comunicaciones con él cuando el programa
 primero se inicia.
 
-Seleccionar "Permitir Transmisión?" le dirá a Xastir que cualquier dato de
+Seleccionar "¿Permitir Transmisión?" le dirá a Xastir que cualquier dato de
 RF saliente puede ser enviado a este dispositivo para difusión.
 
 Seleccionar "¿Digipeat?" le dirá a Xastir que repita el tráfico de
@@ -2309,11 +2312,11 @@ dispositivos como un Baycom o un módem de sonido pueden usarse como TNC.
 Estos dispositivos deben estar configurados y en funcionamiento antes de
 que Xastir pueda usarlos.
 
-Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+Seleccionar "¿Activar en Inicio?" le dirá a Xastir que busque este
 dispositivo y configure las comunicaciones con él cuando el programa
 primero se inicia.
 
-Seleccionar "Permitir Transmisión?" le dirá a Xastir que cualquier dato de
+Seleccionar "¿Permitir Transmisión?" le dirá a Xastir que cualquier dato de
 RF saliente puede ser enviado a este dispositivo para difusión.
 
 Seleccionar "¿Digipeat?" le dirá a Xastir que repita el tráfico de
@@ -2373,7 +2376,7 @@ valores comunes de /dev/ttyS0 (COM1) o /dev/ttyS1 (COM2).
 El comentario le permitirá establecer un nombre amigable o comentario
 para el puerto.
 
-Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+Seleccionar "¿Activar en Inicio?" le dirá a Xastir que busque este
 dispositivo y configure las comunicaciones con él cuando el programa
 primero se inicia.
 
@@ -2403,11 +2406,11 @@ el host gpsd en su red.
 El comentario le permitirá establecer un nombre amigable o comentario
 para el puerto.
 
-Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+Seleccionar "¿Activar en Inicio?" le dirá a Xastir que busque este
 dispositivo y configure las comunicaciones con él cuando el programa
 primero se inicia.
 
-Seleccionar "Reconectar en fallo?" le dirá a Xastir que intente reconectar
+Seleccionar "¿Reconectar en fallo?" le dirá a Xastir que intente reconectar
 cuando el flujo de datos ha fallado.
 
 Seleccionar "Fije el tiempo del sistema del GPS" le dirá a Xastir que
@@ -2422,11 +2425,11 @@ HELP-INDEX>Configurar el Servidor de Internet
 Los Servidores de Internet le permiten enviar y recibir datos para todo
 el mundo.
 
-Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+Seleccionar "¿Activar en Inicio?" le dirá a Xastir que busque este
 dispositivo y configure las comunicaciones con él cuando el programa
 primero se inicia.
 
-Seleccionar "Permitir Transmisión?" le dirá a Xastir que cualquier dato
+Seleccionar "¿Permitir Transmisión?" le dirá a Xastir que cualquier dato
 saliente de Internet puede ser enviado a este dispositivo.
 
 Ingrese el nombre de host (o dirección IP) y el número de puerto del
@@ -2460,7 +2463,7 @@ valores comunes de /dev/ttyS0 (COM1) o /dev/ttyS1 (COM2).
 El comentario le permitirá establecer un nombre amigable o comentario
 para el puerto.
 
-Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+Seleccionar "¿Activar en Inicio?" le dirá a Xastir que busque este
 dispositivo y configure las comunicaciones con él cuando el programa
 primero se inicia.
 
@@ -2494,7 +2497,7 @@ servidor de datos WX que desea contactar.
 El comentario le permitirá establecer un nombre amigable o comentario
 para el puerto.
 
-Seleccionar "Activar en Inicio?" le dirá a Xastir que busque este
+Seleccionar "¿Activar en Inicio?" le dirá a Xastir que busque este
 dispositivo y configure las comunicaciones con él cuando el programa
 primero se inicia.
 

--- a/help/help-Spanish.dat
+++ b/help/help-Spanish.dat
@@ -1,1878 +1,2647 @@
-HELP-INDEX>LÉAME PRIMERO - Licencia
+HELP-INDEX>LÉEME PRIMERO - Licencia
 
-           LÉAME PRIMERO - Licencia
+                          LÉEME PRIMERO - Licencia
 
-!!! NOTA: ¡Este Documento se actualizó en Fecha 04/09/02 !!
+Para la información más actual, por favor lea el archivo README.md en el
+directorio de Xastir. También vea los archivos LICENSE y COPYING para
+información adicional.
 
-Para la información más actualizada por favor
-lea el archivo README.1ST en el directorio de Xastir.
-
-Recuerde que este programa es usado por la comunidad HAM, en los EE.UU
-la FCC le restringe de transmitir sobre RF si usted no es un HAM con licencia.
-Usuarios autorizados en otros países fuera de los EE.UU.
-Deben buscar sus restricciones gubernamentales locales. 
+Recuerde que este programa está destinado a ser utilizado por la comunidad
+de radioaficionados, en los EE.UU. la FCC le impide transmitir por RF si no
+es un radioaficionado licenciado. Los usuarios en países fuera de los EE.UU.
+deben buscar las restricciones de su gobierno local.
 
 LICENCIA:
 
-XASTIR, Estación de Aficionado de Rastreo y Reportes de Información.
-Copyright (C) 1999-2000 Frank Giannandrea
-Copyright (C) 2000-2026 The Xastir Group
+XASTIR, Amateur Station Tracking and Information Reporting
+Derechos de autor (C) 1999,2000 Frank Giannandrea
+Derechos de autor (C) 2000-2026 The Xastir Group
 
-Este programa es software libre; usted puedes redistribuirlo y/o
-modificarlo bajo los términos del GNU Licencia Pública General
-como publicado por la Fundación del Software Libre; cualquier versión 2
-de la Licencia, o (a su opción) cualquier versión más atrazada.
+Este programa es software libre; puede redistribuirlo y/o modificarlo bajo
+los términos de la Licencia Pública General de GNU tal como se publica por
+Free Software Foundation; ya sea la versión 2 de la Licencia, o (a su
+opción) cualquier versión posterior.
 
-pero SIN NINGUNA GARANTIA; aún sin la garantía implícita de
-COMERCIABILIDAD o APTITUD PARA UN PROPOSITO PARTICULAR.
-Vea el (GNU) Licencia Pública General para más detalles.
+sin GARANTÍA de ningún tipo; sin siquiera la garantía implícita de
+COMERCIALIZACIÓN o APTITUD PARA UN PROPÓSITO PARTICULAR. Consulte la
+Licencia Pública General de GNU para obtener más detalles.
 
-Usted debes de haber recibido una copia del GNU Licencia Pública General
-junto con este programa; si no, escriba al Software Libre
-Fundación, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, EE.UU..
+Debería haber recibido una copia de la Licencia Pública General de GNU
+junto con este programa; si no es así, escriba a la Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-Más información sobre el programa puede encontrarse en:
+Puede encontrar más información sobre el programa en:
 
-http://www.xastir.org/
-http://github.com/Xastir/Xastir
+ https://github.com/Xastir/Xastir
+ https://github.com/Xastir/Xastir/wiki
+ https://www.xastir.org
 
-Hay algunos Forum de discusiones disponibles que son específicamente sobre Xastir.
-Usted puedes subscribirse en uno o en ambos de ellos para recibir las últimas
-informaciones y novedades sobre el desarrollo de Xastir.
-Visite esta dirección para subscribirse en http://www.xastir.org/.
+Hay algunas listas de correo disponibles que son específicas de Xastir.
+Por favor, suscríbase a una o ambas para obtener la información más reciente
+de Xastir. Vea https://www.xastir.org para suscribirse.
 
-Para más información sobre la Licencia GNU busque en:
-
-http://www.gnu.org/
+Para más información sobre la Licencia de GNU, consulte:
+https://www.gnu.org
 
 
-HELP-INDEX>Bienvenido! y Notas de los Autores
+HELP-INDEX>¡Bienvenido! y Notas de los Autores
 
                       ¡Bienvenido! y Notas de los Autores
 
-XASTIR, Significa, X-ventanas Estación de Aficionado de Rastreo y Reportes de Información.
-
-               El significado en inglés es como sigue:
-XASTIR, or (X)windows (A)mateur (S)tation (T)racking and (I)nformation (R)eporting.
-
-Es un APRS(tm) como programa que es Fuente Abierta y libre para usarlo y pasarlo a otros. 
-Actualmente este programa está en desarrollo y no debe verse 
-como un producto finalizado! Su ayuda será necesaria para hacer de este 
-un mejor programa.  
-
-Si usted tienes habilidades programando y/o puede escribir documentación, 
-su ayuda puede ser necesaria! Yo tengo muchas ideas pero el tiempo muy corto. 
-Así que si usted piensas que usted puedes anexar algo al esfuerzo déjemelo saber!
-
-73,
-Frank Giannandrea
-fgiannan@eazy.net
-
-
-APRS[tm] es una Marca de fábrica de Bob Bruninga, 
-su página está en "http://web.usna.navy.mil/~bruninga/aprs.html" 
-Por favor note que mucha de la información sobre APRS(tm) puede encontrarse  
-en la documentación de APRSdos escrita por Bob Bruninga.  Una adicional  
-fuente de información es el APRS(tm) especificación, disponible en  
-http://www.tapr.org
-
-HELP-INDEX>What's new in Xastir 2.0.9
-
-The "What's New" section of this help file has been long neglected,
-and has not been updated in every release.
-
-In general, the best way to see what has changed in Xastir is to view
-the git log.  What follows is an abbreviated summary, long after the
-fact, of what has changed since the last time this "What's New" was
-updated for release 2.0.1 (which was in 2012!).
-
-The Xastir project has migrated from SourceForge and CVS to Github and
-git.  This changes how Xastir releases are distributed, and also how
-one accesses the latest development code.  The Xastir project is now hosted at
-https://github.com/Xastir/Xastir, and the wiki is still at http://xastir.org.
-
--Added support for IPv6 in both Xastir server code and APRS-IS connection code.
--Added "wxnowsrv.pl" script to support feeding Xastir weather data via the
- WXNOW.TXT mechanism.
--Fixed compressed weather alert handling.
--Added correct dbfawk files for most recent NWS shapefiles.
--Added a few on line maps from geograits.gc.ca.
--Fixed area computation of CAD objects.
--Added support for proportional fonts in map labels.
--New scripts added to support feeding ADS-B and AIS data into Xastir.
--Many old GEO files for online maps stopped working when servers they
- referenced were taken down.  Most of these have been removed.  If you
- find other .geos that don't work, please report this on the xastir
- mailing list.
--Added new fosm OpenStreetmaps tile server GEO.
--Map cache code updated to work with any version of Berkeley db after 4.1
- (including the 5.x series).
-
-HELP-INDEX>What's new in Xastir 2.0.1
-(Changes between 1.7 and 2.0.0 were never recorded here,this block
-describes a few of the changes from 1.9.8 to 2.0.0 that occured right
-before release of 2.0.0, but otherwise documents only changes from 2.0.0 
-to 2.0.1)
-
-Added tiling for OpenStreetMaps (2.0.0).
-Added "setlocale()" calls to assure we aren't confused by user 
-LANG variable settings.
-Improved speed of config file processing.
-Fixes for new One-Wire-Daemon protocol, allowing both old and 
-new to work with Xastir.
-Fixed segfaults that could happen when closing list dialogs.
-Fix OSM code to support 16-bit quanta in Graphics/ImageMagick.
-Fixed broken makefile that was ignoring DESTDIR.
-Fixed broken build so internal shapelib builds correctly when
-proj.4 is not installed.
-Add dbfawk files for several generations of new NWS shapefiles.
-Update get-NWSdata to pull current NWS shapefiles.
-Add start/stop files for Kenwood D72 and D710 radios.
-Added a script to convert GeoPDF files to usable GeoTIFF files.
-Make the command to set a TNC into CONVERSE mode a run-time
-configurable option in the TNC Interface Properties dialog.
-Add support for Australian Bureau of Metrology weather alerts.
-Fixes for Davis APRS Data Logger, Davis Meteo and LaCrosse 
-support so it gets rain totals correct.
-Allow "posit interval" in File->Configure->Timing to go all the
-way to zero, meaning "never send posits on a schedule."
-Add signal support so that Xastir will emit a posit when it 
-receives SIGUSR2.  Combined with zero "posit interval," this
-allows Xastir to emit a posit only when told to by an external
-script.
-Fixed error in logic for band-opening alerts (speech and audio
-alarms) so it does not incorrectly report third party traffic
-as a band opening.
-Add "Send Control-E to get GPS data?" to TNC interface 
-properties for the "Serial TNC w/ GPS on AUX port" interface
-type.  Defaults to enabled, which is correct for KPC-3+ TNCs,
-but should be turned off for any TNC that automatically
-streams GPS NMEA strings, such as Kenwood APRS radios.
-Update GPSMAN support to reflect changes in the gpsman command 
-line.
-Add a small delay between sending the converse-mode command
-and sending data for transmission, because KAM TNCs don't
-work if you send the data immediately.
-Fix a bug in the OSM tile download loop that could prevent
-further downloading of tiles if any one tile download fails.
-Fixed a thread-unsafeness bug that could cause Xastir to start
-using corrupted file names when multiple logging options
-(TNC, NET, WX, IGATE, etc.) selected simultaneously.
-Fixed get-fcc-rac.pl script to reflect changes in RAC download
-site.
-
-
-
-
-HELP-INDEX>What's new in Xastir 1.7
-Added REGRESSION_TESTS in order to test interoperability of the
-configure-time flags.
-Added a replacement for malloc() for those cases where the OS
-provides a faulty one.
-Added more to the summary.log file:  The tests and results from
-config.log.
-GDAL configure probe now uses gdal-config if it's in the user's
-path.
-Tweaked configure so that dependent libraries cause other library
-searches to fail, and to provide more user output.
-Added ASCII-art drawing to INSTALL showing most of the library
-dependencies.
-Updated symbols.dat to more closely correspond to the current spec.
-Implemented EMERGENCY BEACON transmit capability under the Help
-menu.
-Added decoding for "EMERGENCY" anywhere in the packet plus any of
-these in the TO: field:  ALARM, ALERT, WARNING, WXALARM, EM.  Any of
-these will invoke the normal emergency popup dialog.
-Waypoint symbols now have a line drawn between them and the station
-transmitting them, per the spec.
-Now using font metrics to determine size of font.  We use that to
-determine size of black rectangle to draw underneath.
-Fixed the Fetch Findu Trail function so that it matches what Findu
-can provide.
-Fixed track->shapefile function so that it works on Cygwin too.
-Added reset button to Change Debug Levels dialog.
-Enable WX Alerts menu item is now grey'ed out if Shapelib isn't
-installed.
-RINO Download timing slider is now visible but grey'ed out if gpsman
-isn't installed.
-Added a custom zoom option to the right-click zoom levels menu.
-Moved the center & zoom dialog to the map menu.
-Changed a memcpy() to an xastir_snprintf() function in alert.c to
-assure that a string is terminated.
-Free'ing some malloc'ed space for cases where hash inserts fail.
-Added probe for sighandler_t definition.
-Changed includes, added leak_detector.h.
-A few small changes here and there to get rid of compiler warnings.
-Freeing some malloc'ed space for the cases where hash inserts fail.
-Fixed initializers for awk_rule[].
-Changed hash add functions so that they do a delete first instead of
-replacing hash values.
-Moved some wx-alert related code to debug level 2.
-Changed leak detect interval from 5 minutes to 60 seconds.
-Fixed a big memory leak in draw_nice_string() function.
-Changed include files around so memory leak detection stuff is in
-leak_detection.h.
-Added new compiler flags and cleaned up the code to eliminate many
-warnings created.
-Fixed Incoming Data dialog code so that packets transmitted to local
-interfaces would appear there.
-TNC/NET toggles work for those now too.
-Fixed memory leak in font metrics code.
-Simplfied get_long()  and get_int() functions and callouts.
-Tweaks for sighandler_t and sigjmp_buf.
-Added a sign-on message for server connects.
-FCC/RAC lookup or Locate Now buttons don't destroy the dialog
-anymore.
-Fixing up strings.h includes.
-Added a new popup for EMERGENCY packets.
-Changed signal() with SIG_IGN to sigignore for some cases.
-Added a test for sigignore() to configure.ac.
-Changes to allow different versions of "gv" to be used.
-Moved "-lgdal" to end of link line to avoid conflict with other
-libraries.
-Added UDP server and client.
-Added more language strings for previously hard-coded values.
-Changed config file get_int and get_long functions to provide better
-output when config file entries are missing or out-of-range.
-We now allow gating to the internet and to RF for user-defined
-packets and telemetry packets.
-Changing to <CR><LF> for the TCP server signon message.
-Changing to timestamp per packet for log files, with long int
-seconds at the beginning.
-Added icon.
-Added support for -geometry command-line parameter.
-Added fast creation of standard SAR objects via mouse menu,
-including adding digits to the end of the object name if name would
-conflict with pre-existing objects.
-
-
-
-HELP-INDEX>What's new in Xastir 1.6
-Fix for DF lines having incorrect angles at times.
-Configurable display of layers for USGS topo maps.
-Better Map Feature Search:  Shows up to 50 matches, user selects
-which one to center map on.
-Configurable "relay" digipeater calls:  Up to 50 callsigns can be
-specified in the Xastir config file to use for relay digipeating.
-"WIDE1-1" is now the default.
-Added support for Web Map Service (WMS).
-Tweaked the GPGGA and GPRMC GPS sentence decoding.
-Added speed-ups for lat/long geotiff's.
-Added Aloha circle.
-Added new #defines in interface.h for specifying "conv" or 'k'
-command to TNC.
-Added new tnc-startup file for TAPR-2 style TNC's.
-Added transparency capability to WMS.
-Fixed digpeating code for "wide1-1,wide2-1" case.
-Fixed some compile errors that are seen on FC4 and OSX Tiger.
-Added new terraserver .geo file options.
-Changed Map Properties "fill" option to allow NO/YES/AUTO.
-Auto uses dbfawk if present, no/yes force fill to that state.
-Fixed some #ifdefs here and there so that compiles will work if
-some libraries aren't present.
-Added map caching for nearly all internet maps, plus two new toggles
-on the map menu for clearing out current-view maps or all maps from
-the cache.
-Moved Tigermap timeout slider to main timing dialog, renamed it, and
-made it function for ALL internet map fetches.
-Added timestamps to x_spider log messages.
-A fix for the emacs tempfile bug w.r.t. dbfawk files went in, but
-hasn't been verified to have fixed the problem yet.
-More bulletproofing added to the map_cache code.
-Fixed a compile problem that happens if ImageMagick isn't installed.
-Changed stipple style to solid for polygons drawn with dbfawk.
-Another fix so that linking works without map caching. 
-
-
-
-HELP-INDEX>What's new in Xastir 1.5
-Optional Rtree shapefile extent caching
-Optional berkelydb-based internet map caching
-Modifier keys fix
-Improvements to the message GUI
-Tactical call support re-written, hashtable based
-Warnings on crazy paths
-Hashtable weather alert speedups
-Dead-reconing for Objects/items
-Igate of specific stations (in the nws-stations.txt)
-Fixed DF object properties
-Measure function more accurate
-Decoding for "Position with Timestamp no APRS messaging" packets.
-More thorough checking for scanf/sscanf/fscanf function calls
-Fixing 100% humidity for some weather stations, plus added more data for Davis stations
-Changed active internet connection check from 1 min to 5 minutes
-Fixed decoding of compressed DF objects
-Fixes to allow new WHO-IS server to be used from Xastir
-Got rid of extra 0x00 byts between transmitted KISS frames
-Tweak to not start an interface upon changing its properties
-Tweaks to allow use of http proxy servers for online map accesses (.netrc file)
-
-
-
-HELP-INDEX>What's new in Xastir 1.4
-Comment fields for interfaces
-split_gnis and ozi2geo scripts, need to add to section on scripts
-serial mkiss interface
-move objects without confirm
-new timing params w.r.t. trails, need to add to config|timing part
-geo-coder (already in docs)
-exponential/random back-off for almost everything
-dbfawk default, memory leaks fixed
-click+drag zoom boxes
-tactical callsign support
-numerous small memory leaks, uninitialized data uses, and similar bugs fixed. 
-GPS quality info
-RINO waypoints downloading
-label trackpoints
-comment/status timestamps
-listener socket/ability to act like a limited internet server
-
-
-HELP-INDEX>Iniciando a Xastir por primera vez
-
-               Iniciando a Xastir por primera vez
-
-Cuando Xastir se inicie por primera vez, usted debes ejecutarlo en una ventana 
-terminal asi que cualquier mensaje de advertencia o error puedan verse.
-
-En la mayoría de los sistemas una ruta es configurada para correr el programa 
-en /usr/local/bin y todo lo que usted necesitas hacer es tipear "xastir" 
-en la línea de comando.
-
-En sistemas que no tienen este tipo de ruta instalado "/usr/local/bin/xastir" 
-para empezar el programa.
-
-Usted también puedes poner la opción del Idioma en este momento. 
-Para poner el idioma o cambiar el idioma actual, use ésta línea:
-
-xastir -l  
-
-
-Los Idomas Actuales son:
-
-Alemán  (German)
-Español  (Spanish)
-Francés  (French)
-Holandés  (Dutch)
-Inglés  (English)
-Italiano  (Italian)
-ElmerFudd (English)
-MuppetsSwedishChef (English)
-OldeEnglish (English)
-PigLatin (English)
-PirateEnglish (English)
-
-Si Usted quieres correr el Xastir en español use ésta línea:
-
-Ej: xastir -lSpanish o xastir -l Spanish
-
-Esta opción será guardada en el archivo de  configuración de usuario 
-para que la próxima vez que Xastir se ejecute corra con el idioma Español. 
-
-En nueva instalación xastir tendrá como valor predefinido el idioma inglés 
-a menos que usted uses ésta opción de línea de comando.
-
-NOTA: En menús, se seleccionan artículos que son encanecido,
-como en las opciones del ON/OFF, si 'ON' es seleccionado
-se opacará o se pondrá transparente (encanecido).
-
-HELP-INDEX>Configurando la información de la Estación
-
-           Configure la Información de la Estación   
-
-Pulse el botón del ratón en Archivo luego Configurar después en Estación  
-llene la casilla con su Indicativo de Radioaficionado.
-
-llene su posición de la estación si usted no estás usando Xastir con una unidad de GPS. 
-Si usted no la conoce, usted puedes localizar su posición general en el mapa 
-con Xastir y puedes usar la posición dada por colocar el puntero del ratón sobre el mapa.
-
-Esta posición será visible en la barra del fondo de Xastir cuadro 2
-de la izquierda. Si usted tienes un GPS usted puedes saltar esta opción.
-
-Los símbol/grupo de la estación pueden configurarse aquí. Pulse seleccionar gráficamente y  
-escoja un símbolo, o manualmente rellene los campos. Una descripción de texto de cada uno  
-de los símbolos pueden encontrarse en la "Tabla de símbolo" tema de ayuda. Las cubiertas son cumplidas seleccionando un símbolo
- de la tabla alternada, y poniendo el campo de la tabla a  
-el carácter que usted desea recubrir encima del símbolo. Letras mayúsculas y  
-los números pueden ser recubierto. El APRS(tm) especificación sólo permite cubiertas sobre  
-símbolos específicos; Xastir no forza esto, pero algunos otros programas pueden.  
-Note que no todos los símbolos se han llevado a cabo en el selector gráfico  
-todavía, y algunos de ellos no están por el APRS(tm) especificación todavía.  
-
-Luego, entre en los datos para la potencia/altura/ganancia de su estación. Esta es  
-una información útil pero no se requiere; absolutamente seleccione "Desactive PHG"  
-desactivarlo. Estas opciones presentan una representación granular de su estación.  
-Seleccione la combinación de valores cerca a la descripción de su estación.  
-
-Otra opción sería especificar el RNG en el campo de comentario en millas  
-en lugar de usar PHG. Vea el APRS(tm) especificación para detalles.  
-  
-Por favor use altura sobre el promedio del  terreno para el valor de altura.  No  
-use el promedio de altura sobre el nivel del mar o altura sobre tierra.  
-  
-Para el uso de Ganancia la ganancia de su antena en dBi.   
-¿(CORRIGEME:  dBd? la especificación no es clara, 
-yo pienso que está implicando dBi porque dice "en ausencia de cualquier datos,
-las estaciones son asumida a estar corriendo 10w a un 3dB omni en  20pies.
-Una antena omni típica es sólo 3dBi.....)   
-Para Altura, use el HAAT (altura sobre el promedio del terreno) de su estación,  
-NO la altura sobre el nivel del mar o altura sobre geo-id.  
-
-Nota: La ganancia puesta es realmente pensada para las antenas verticales; la ganancia  
-puesta para una antena direcional debería ser por debajo de la ganancia hacia delante de una antena direcional.  
-Esto es porque con la direccionabilidad puesta, el círculo de PHG es compensado sólo a través de 1/3rd  
-de su tamaño hacia la dirección especificada. Poniendo la Ganancia más alta agrandará  
-el círculo entero no-realisticamente, en lugar del aumentado direccionalmente.  
-Había charla hace varios años sobre el enmendando las especificaciones para mejorar  
-trato con antenas direccional, pero nada fue cambiado.  
-  
-Entrar un comentario, no requerido pero agregará visión en su estación.  
-Una cosa común para entrar aquí es su dirección de e-mail preferida.  Que  
-será transmitido a lo largo con su postula.  
-  
-La ambigüedad de la posición permitirá usted controlar que tan exacto usted transmite su  
-posición. Si usted no pone nada, xastir permitirá a su estación transmitir la exacta  
-posición que usted ha entrado o ha recibido de un GPS. Las otras opciones lo pondrán  
-en alguna parte en el rango de la opción que usted seleccionó.  Note que  
-esto puede tirar estaciones dóciles a alguna no-especificación para un bucle.  Findu.com  
-no entiende la ambigüedad de posición.  
-  
-Pulsando el botón "Aceptar" guardarás sus cambios.
-Pulsando el botón en "Cancelar" conservarás las actuales configuraciones.
-
-HELP-INDEX>Configurar Operación Predefinida
-
-              Configurar Operación Predefinida  
-  
-Pulse el botón en Archivo después en Configurar luego en Predefinidos
-  
-Esta página prepara algunos valores por defecto normales para el funcionamiento 
-del programa. Viejas estaciones se desplegarán con un icono fantasma, 
-y el sendero correspondiente se fragmentará.  
-
-El primer juego de botones de barra especifica el intervalo de desdoblamiento.  El segundo  
-juego de botones que especifica cuando una estación será removida de la pantalla.  
-Las estaciones también son removida del banco de datos interno en el doble este tiempo,  
-así si usted lo pusiera durante 6 horas, se anularán estaciones del banco de datos  
-a las 12 horas.  
-  
-El tercer juego de botones especifica qué a menudo la identificación de su estación será  
-transmitido.  Para las estaciones fijas una recomendación buena es cada 30 minutos,  
-y definitivamente ninguno menos de 10 minutos.  
-Las estaciones móviles pueden desear una más rápida proporción.
-
-Este intervalo también se usa para mandar objetos y artículos.  Pruebe  
-mantener este intervalo algo razonable, como transmitir hacia un largo camino,  
-cada 30 segundo realmente subirá mucho el tiempo aéreo.
-
-GPS Tiempo pondrá el intervalo de tiempo mirar el GPS por nuevos datos.  
-Esto es disponible para estaciones que usan un cable compartido HSP con su TNC.  
-  
-La Opción Trasmite Estación fija el tipo de paquete que su estación transmitirá sus datos como.
-Transmite datos Raw WX  si seleccionado también enviará un paquete que contiene Datos raw
-de una Estación Meteorológica. Esto es útil en los tipos de ASCII de estaciones WX, como la Peet Bros.
-
-Estación WX. Las Opciones de IGate prepararán su estación como un portal de Internet-RF.
-Esta opción podría ser usada con cuatela, Como un HAM usted es responsable
-por el data que viene vía el Internet y es transmitido hacia el Puerto de RF. 
-
-Usted también necesitará   
-escoger una opción del igate en cada interface para que el igate funcione.  
-Si usted quiere tener su igate envíe NWS alarmas WX  hacia el RF, usted debe  
-crear un archivo ~/.xastir/data/nws-stations.txt listando cada llamada o estación de NWS  
-(como "PHISVR") que le gustaría transmitir vía RF.
-    
-"Transmitir datos de WX RAW", si seleccionado, también enviará un paquete que contiene crudo (raw)  
-Datos de estación meteorológica. Esto es útil en los tipos de ASCII de estaciones WX,   
-como la Peet Bros. estación meteorológica.
-
-"Los datos de posición comprimida pueden ser transmitida"?, si es seleccionado, transmitirá en  
-el más nuevo formato comprimido. Este formato reducirá la cantidad de datos en  
-el aire, por eso aumentando la capacidad de la red APRS(tm). La máxima  
-precisión de la posición transmitida también es más alta. Algunos programas más viejos,  
-incluyendo las recientes versiones de WinAPRS, no decodificará este formato todavía.  
-Findu.com también podrían tener problema con el.
-
-Activar Red Alternada ?
-esta opción se usa para desplegar grupos de estaciones que muestran
-en el unproto en el campo '>To' la versión del software como el Xastir
-que muestra la versión en el unproto como esto: HI8GN>APX090.
-
-Usted también puede seleccionar Altnet y puede escoger una llamada del altnet de este diálogo.
-Altnet le permite tener un privado APRS(tm) red entre las estaciones que también  
-tenga altnet configurado, y tiene la misma llamada del altnet entrada.
-
-Si cambiamos el valor por defecto que es XASTIR por ejemplo por APX110
-desplegará toda las estaciones que tengan versiones de APX11x
-donde valor de 'x' puede ser desde 0-9.
-
-HELP-INDEX>Configurando las Alarmas de Audio
-
-                         Configurando las alarmas de Audio
-
-Para usar esta opción usted debes tener una tarjeta de sonido y un programa que 
-reproduzcan los archivos wav. El programa reproductor de Audio debe tener 
-comando el cual usted quieres ejecutar para tocar el audio archivo (y cualquier 
-opción en la línea de comando).
-
-Los campos tendrán el nombre del archivo a reproducir, campos bajo la opción 
-pondrá parámetros para la opción.
-
-Las opciones Actuales son:
-
-  Reproducir mensaje al encontrar una nueva estación. 
-
-  Reproducir mensaje al recibir un nuevo mensaje.
-
-  Reproducir mensaje de datos recibidos de una estación dentro de la distancia  
- min/max de su proximidad.
-
-  Reproducir mensaje de datos recibidos de una estación (vía TNC) con la 
-distancia de min/max de su banda abrierta.
-
-HELP-INDEX>Configurar el Sintetizador de Voz
-
-                         Configurar el Sintetizador de Voz
-
-Para usar esta opción del sintetizador de voz usted debes tener una tarjeta de sonido
-configurada para poder reproducir sonido.
-
-También usted necesita tener instalado y corriendo al Servidor Festival más
-el Speech_tools con su biblioteca de soporte para el Sistema Festival de Voz Síntetizada
-
-y asi poder escuchar el sintetizador de voz anunciar
-nuevas estaciones y aperturas de banda proximidad de una estacián. 
-
-El sistema de alarmas de sonidos ha sido también retenido.
-
-Con el Sintetizador de Voz adaptado por Curt Mills (we7u) 
-
-ajuste las casillas en las cuales usted quieres ejecutar el sintetizador para las alarmas
-
-(y cualquier opción en la línea de comando).
-
-Los campos tendrán el nombre del archivo a reproducir, campos bajo la opción 
-pondrá parámetros para la opción.
-
-Las opciones Actuales son:
-
-  Anunciar un mensaje al encontrar una nueva estación. 
-  Anunciar un mensaje al recibir un nuevo mensaje.
-  Anunciar un mensaje al recibir el cuerpo un nuevo mensaje.
-  Anunciar un mensaje de datos recibidos de una estación dentro de la distancia  
-  min/max de su proximidad.
-
-  Anunciar un mensaje de datos recibidos de una estación (vía TNC o INET)
-  con la distancia de min/max de su banda abierta.
-
-  Anunciar un mensaje al recibir una nueva alerta sobre el tiempo climatológico.
-
-Info sobre Festival puede ser obtenida desde: http://www.speech.cs.cmu.edu/festival/
-
-HELP-INDEX>Configurando las Unidades de Medida
-
-                    Configure Unidades de Medida  
-  
-La selección predefinida es para el Sistema Métrico, mm, cm, KPH, etc. 
-Seleccionar Inglés, pulgadas, pies, MPH, etc. Pulse el botón de Configurar, 
-luego en Unidades, después la unidad de medida que usted quieres usar.
-Recuerde encanecida opciones son selecciona actualmente. 
-
-HELP-INDEX>Salvar Configuración Ahora!
-
-                      Salvar Configuración Ahora!
-
-Este botón salvará todas la configuración actual al archivo de configuración.  
-Note que cuando Xastir está cerrado, también salva configuración al archivo
-de configuración.
-
-HELP-INDEX>Barra de Estado de fondo
-
-                         Barra de Estado de fondo  
-  
-En el fondo de la ventana varios mensajes de estado están disponibles:  
-  
-En la primera parte en la barra de estados general los mensajes son desplegados.
-
-La segunda parte se muestra la posición lat/long
-actual moviendo el ratón sobre el mapa.
-
-En la tercera parte es usada para mostrar
-cuántas estaciones están en el banco de datos.
-
-La cuarta parte de la barra desplegará el nivel de enfoque actual y desplegará
-"Tr" si el rastreo de estación está encendida (on).   
-  
-El última área desplegará el estado de dispositivo para cada interfáz. Cada una  
-desplegará en orden primero hasta el último o de 0 a 9. El estado de la interface está separado  
-en tres áreas, tipo de dispositivo cima, datos de centro fluyendo, y interface de fondo  
-estado operacional. El tipo de dispositivo mostrará qué interfaces se configuraron.  
-El color mostrará qué tipo de dispositivo de la interface se configuró. Azul  
-es para los varios dispositivos TNC; Verde mostrará los dispositivos de GPS; Amarillo para los   
-Servidores de Internet; Naranja para las interfaces de WX. El centro mostrará que los datos fluyen en rx (flecha que apunta a l
-a izquierda) o los datos fluyen fuera tx (flecha que apunta a la derecha) para eso interface. Una caja verde al fondo mostrará 
-si esa interface es activa.  
-Una caja roja mostrará si la interface es activa pero en una condición de error.  
-Por otra parte nada mostrará si la interface no está activa.  
-
-Las últimas dos partes mostrarán el estado del tnc y de la red. Una "=>" 
-indicará si el dato está siendo enviado, y una "<=" si el dato está entrando 
-desde la interfaz.
-
-  
-HELP-INDEX>Moviendo el Mapa y el Menú de Opciones
-
-                    Moviendo el Mapa y el Menú de Opciones  
-  
-Movimiento en el mapa es muy simple, la facilidad y rapidez de movimiento son dependientes de  
-la velocidad de su procesador y la cantidad de detalle que usted carga.  
-  
-Subiendo verticalmente:  
-Subiendo verticalmente puede ser logrado por pulsar el botón derecho de ratón sobre el mapa (y sosteniendo el botón abajo). Est
-o planteará un menú de opciones, con opciones para hacer subir verticalmente o fuera a un solo nivel, o para cambiar a uno de l
-os niveles del enfoque prefijado.  
-  
-Todas las funciones de enfoque desde el menú de opciones harán acercarse o alejarse al punto  
-en el mapa donde usted pulsó el botón del ratón correcto. El  nivel de enfoque tiene una menú en  cascada. Niveles 1-64 son par
-a las áreas muy locales y niveles 256 y superior es para  
-áreas grandes. El número más bajo del nivel, la área más local.  
-  
-Una función de enfoque más rápida es empujar y sostener el botón del ratón izquierdo, arrástrelo  
-por el área de interés y permitida vaya.  El mapa hará subir verticalmente aproximadamente a  
-el tamaño del cuadrado usted apenas descrito con el ratón la función de arrastre.  
-El programa usa el componente vertical para decidir en el nivel de enfoque, y el  
-componentes verticales y horizontales para computar el nuevo centro del mapa.  El "movimiento"  
-y "medida" que deben desactivarse checkboxes de la bara de herramienta de este rasgo para trabajar.  
-  
-El mapa también puede acercarse con el teclado las llaves de PageUp/PageDown.  El  
-acercar en este caso guarda el mismo centro del mapa.   
-  
-Paneando/Centrando:  
-El mapa puede centrarse a una situación específica por pulsar el botón izquierdo del ratón.  
-Pulsando el botón los enfoques del botón medio aleja con un factor de 2, centrando donde usted  
-pulsó el botón.  
-  
-Paneando también es cumplido usando el menú de opciones, o usando la flecha  
-botones en la tope de la pantalla. La posición del mapa cambiará una porción de  
-pantalla. Bastantes datos de pantalla anterior deben estar disponibles reorientarlo  
-.  
-  
-El mapa también puede ser paneado con las llaves de flecha del teclado.  
-  
-Más Sobre el Menú de Opciones:  
-La selección de "Estación Info" en el menú de opciones buscará la estación  
-cerca a donde usted pulsó el botón derecho del ratón. Si más de una estación está  
-cerca de esa posición un "escogedor de Estación" de lista aparecerá, entonces usted puede  
-escoger los datos de qué estación que usted quiere ver. Si sólo una estación es vista entonces el indicador del ratón es cerrad
-o y los datos de esa estación se desplegarán inmediatamente. Note  
-que expiradas estaciones todavía tienen sus datos guardados en el banco de datos de Xastir, y  
-si uno sabe la situación anterior de una estación, uno todavía puede ver su info de esta  
-manera. También es posible desplegar estaciones viejas encendiendo el "el Despliegue  
-de Datos Expirados" opción en el menú de las estaciones. CORRIGEME: Si no es completamente verdad.  Esto sólo despliega algunos
- de los datos que desaparecen como estaciones fantasma,   
-Velocidad/altitud, etc.,  
-  
-Para información de Objeto y Artículo, por favor vea el tema de ayuda "Objetos y Artículos"  
+XASTIR, o X Amateur Station Tracking and Information Reporting.
+
+Xastir es un programa APRS(tm) que es de Código Abierto y libre de usar y
+distribuir a otros. Actualmente este programa está en desarrollo y no debe
+verse como un producto terminado. ¡Se necesitará su ayuda para mejorar este
+programa! Si tiene habilidades de programación y/o puede escribir
+documentación, ¡su ayuda puede ser necesaria! Tenemos muchas ideas pero muy
+poco tiempo, así que si cree que puede agregar algo al esfuerzo ¡déjenos
+saber!
+
+
+
+APRS(tm) fue creado por Bob Bruninga y originalmente marcado como marca
+registrada por él. Actualmente es una marca registrada de la Tucson Amateur
+Radio Packet Corporation. Cuando Bob Bruninga falleció, el mantenimiento y
+la documentación de APRS para la comunidad fueron asumidos por la APRS
+Foundation, cuyo sitio web es https://how.aprs.works/. Esta es la mejor
+fuente moderna para obtener información actual sobre APRS.
+
+Una copia histórica del sitio web original de APRS de Bob Bruninga se
+mantiene en https://aprs.org/.
+
+
+HELP-INDEX>Novedades en Xastir
+
+La sección "Novedades" de este archivo de ayuda ha sido descuidada durante
+mucho tiempo y no ha sido actualizada en cada versión. A partir de la
+versión 2.2.4 hemos eliminado todas las entradas antiguas y no continuaremos
+actualizándola.
+
+La mejor forma de ver las novedades en cualquier versión de Xastir es ver
+las notas de la versión que proporcionamos con cada lanzamiento en Github.
+Estas se pueden ver en:
+https://github.com/Xastir/Xastir/releases.
+
+
+HELP-INDEX>Iniciando Xastir por primera vez
+
+                    Iniciando Xastir por primera vez
+
+Al ejecutar Xastir por primera vez, debe iniciarlo desde una ventana de
+terminal para que se puedan ver los mensajes de advertencia o error. En la
+mayoría de los sistemas se configura una ruta para ejecutar programas en
+/usr/local/bin y todo lo que necesita hacer es escribir "xastir &" en el
+símbolo del sistema. En sistemas que no tienen esta ruta instalada escriba
+"/usr/local/bin/xastir &" para iniciar el programa. El carácter '&' hará que
+Xastir se inicie en segundo plano, dejando la ventana del terminal disponible
+para otros usos.
+
+También puede establecer la opción de idioma en este momento. Para establecer
+el idioma o cambiar la opción de idioma actual, llame a Xastir con la opción
+'-l':
+
+    xastir -lEnglish
+
+Las opciones de idioma son:
+    xastir -l Dutch
+    xastir -l English
+    xastir -l French
+    xastir -l German
+    xastir -l Italian
+    xastir -l Portuguese
+    xastir -l Spanish
+    xastir -l ElmerFudd
+    xastir -l MuppetsSwedishChef
+    xastir -l OldeEnglish
+    xastir -l PigLatin
+    xastir -l PirateEnglish
+
+El idioma elegido se almacenará en su archivo de configuración, por lo que
+se conservará para la próxima vez que llame a Xastir. Para nuevas
+instalaciones, Xastir usará Inglés de forma predeterminada hasta que cambie
+el idioma con esta opción de línea de comandos.
+
+Se puede acceder a los menús en la parte superior con el ratón o con
+atajos de teclado. Los atajos de teclado pueden no funcionar correctamente
+con el bloqueo de números activado.
+
+Necesitará configurar interfaces para usar realmente Xastir. La configuración
+de interfaces se detalla en el tema de ayuda "Configurar Interfaces" y sus
+subtemas.
+
+Si está operando en una situación donde un sistema de coordenadas distinto
+del sistema predeterminado DD MM.MMMM sería útil, puede seleccionar su
+sistema preferido yendo a Archivo|Configurar|Sistema de coordenadas. Se puede usar
+cualquiera de los sistemas de coordenadas soportados como entrada utilizando
+la Calculadora de Coordenadas.
+
+HELP-INDEX>Configurar la Información de la Estación
+
+                         Configurar la Información de la Estación
+
+Haga clic en Archivo, luego Configurar, luego Estación.
+
+Ingrese su indicativo de Estación de Radioaficionado.
+
+Ingrese la posición de su estación si no está utilizando Xastir con una
+unidad GPS. Puede ubicar su posición general en el mapa con Xastir y usar
+la posición dada por la colocación del cursor sobre el mapa. Esta posición
+será visible en el cuadro en la parte inferior de la pantalla de Xastir, 2º
+desde la izquierda, cada vez que el ratón esté sobre el área de dibujo.
+También puede seleccionar "Mover Mi Estación Aquí" en el menú del botón derecho
+mientras su ratón está sobre su ubicación. Si tiene un GPS puede omitir esto
+y configurar el GPS más tarde.
+
+"Send Compressed posits", si está seleccionado, transmitirá en el formato
+comprimido más nuevo. Este formato reducirá la cantidad de datos en el aire,
+aumentando así la capacidad de la red APRS(tm). La precisión máxima de la
+posición transmitida también es mayor. Algunos programas más antiguos,
+incluidas versiones recientes de WinAPRS, aún no decodifican este formato.
+Findu.com también podría tener problemas con él. Transmitimos rumbo/velocidad
+en este formato pero no altitud. Para enviar rumbo/velocidad Y altitud se
+requiere agregar nueve caracteres al paquete, lo que anula parte de la razón
+para usar posiciones comprimidas.
+
+Para seleccionar un símbolo a usar para su estación, debe especificar un
+grupo y un carácter de símbolo. Puede rellenar manualmente estos campos, o
+presionar seleccionar para elegir gráficamente un símbolo. Hay dos grupos de
+símbolos disponibles. Una descripción de texto de cada símbolo se puede
+encontrar en el tema de ayuda "symbol table".
+
+Para algunos símbolos del grupo secundario puede especificar una superposición.
+Con eso, un símbolo se mostrará junto con un carácter de superposición
+adicional, por ejemplo, un símbolo de auto con la superposición del número 1
+encima del símbolo.
+
+Para usar superposiciones, debe seleccionar un símbolo de la tabla de símbolos
+secundaria e ingresar el carácter de superposición a mostrar en el campo
+group/overlay. Solo se permiten números y caracteres en mayúsculas como
+caracteres de superposición. De acuerdo con la especificación APRS(tm), no
+todos los símbolos pueden tener superposición; Xastir no lo impone, pero
+algunos otros programas pueden. Tenga en cuenta que no todos los símbolos han
+sido implementados en el selector gráfico aún, y algunos de ellos no cumplen
+con la especificación APRS(tm) aún.
+
+A continuación, ingrese los datos de potencia/altura/ganancia de su estación.
+Esta es información útil pero no es obligatoria; simplemente seleccione
+"Disable PHG" para deshabilitarlo. Estas opciones presentan una representación
+granular del rango de su estación. Seleccione la combinación de valores más
+cercana a la descripción de su estación. Por favor, use la altura sobre el
+terreno promedio (HAAT) para el valor de altura. NO use la altura promedio
+sobre el nivel del mar o la altura sobre el suelo. Todos los valores deben
+especificarse si desea transmitir información PHG.
+
+Otra opción sería especificar RNG en el campo de comentario en millas en lugar
+de usar PHG. Vea la especificación APRS(tm) para más detalles.
+
+Para Ganancia, use la ganancia de su antena en dBi.
+(FIXME: ¿dBd? la especificación es poco clara, creo que implica dBi porque
+dice "en ausencia de cualquier dato, se supone que las estaciones funcionan con
+10w en un omni de 3dB a 20ft. Un omni típico es solo 3dBi.....)
+
+Nota: La configuración de ganancia está realmente destinada a antenas
+verticales; la configuración de ganancia para una antena directiva debe ser
+bastante inferior a la ganancia frontal de la antena. Esto se debe a que con la
+directividad establecida, el círculo PHG solo se desplaza por 1/3 de su tamaño
+hacia la dirección especificada. Establecer una ganancia más alta agrandará
+todo el círculo de manera poco realista, en lugar de aumentar la directividad.
+Hace varios años hubo conversaciones sobre enmendar las especificaciones para
+tratar mejor con antenas directivas, pero no se cambió nada.
+
+Ingrese un comentario, no es obligatorio pero agregará información sobre su
+estación. Un comentario común es su dirección de correo electrónico preferida.
+Se transmitirá junto con sus posiciones.
+
+La ambigüedad de posición le permitirá controlar cuán precisamente transmite su
+posición. Una configuración de ninguno permitirá que su estación transmita la
+posición exacta que ha ingresado o recibido de un GPS. Las otras opciones lo
+colocarán en algún lugar dentro del rango de la opción que seleccionó. Tenga en
+cuenta que esto puede confundir a algunas estaciones que no cumplen con las
+especificaciones. Findu.com no entiende la ambigüedad de posición.
+
+Hacer clic en OK guardará los cambios, Hacer clic en Cancel mantendrá los
+ajustes anteriores.
+
+HELP-INDEX>Configurar Funcionamiento Predeterminado
+
+                        Configurar Funcionamiento Predeterminado
+
+Haga clic en Archivo, luego Configurar, luego Predefinidos.
+
+Esta página configura algunos valores predeterminados estándar para la
+operación del programa.
+
+Transmit Station Option establece el tipo de paquete que su estación
+transmitirá sus datos.
+
+IGate Options configurará su estación como una puerta de enlace Internet-RF.
+Esta opción debe usarse con cuidado; Como radioaficionado es responsable de
+los datos que ingresan por Internet y se transmiten por RF. También deberá
+elegir una opción IGate en cada interfaz para que IGate funcione. Si desea que
+su IGate reenvíe alertas meteorológicas de NWS a RF, debe crear un archivo
+~/.xastir/data/nws-stations.txt que enumere cada llamada o estación NWS (como
+"PHISVR") que desee transmitir por RF. Esta función también funciona para
+enrutar llamadas específicas a RF.
+
+"Transmit Compressed objects/items?", si está seleccionado, transmitirá
+objetos e elementos en el formato comprimido más nuevo. La precisión máxima
+de la posición transmitida es mayor, y la transmisión es más corta, pero
+algunos programas más antiguos no decodifican este formato. Actualmente esto
+solo comprime objetos/elementos "estándar" con velocidad/curso opcionales. No
+comprimirá objetos/elementos de área, poste indicador o DF, y actualmente no
+representará altitud en objetos/elementos "estándar".
+
+"Pop up new Bulletins", si está seleccionado, hará que Xastir abra el diálogo
+de boletín cuando se reciban boletines dentro del rango configurado. "View
+zero-distance bulletins" hará que los boletines sin ubicación conocida no se
+muestren ni causen pop-ups.
+
+"Warn if Modifier keys" hará que Xastir imprima una advertencia si intenta usar
+Xastir mientras Bloqueo de números, Bloqueo de desplazamiento o Bloqueo de
+mayúsculas está activado. Algunos usuarios reportan que la pantalla se oscurece
+y problemas similares cuando intentan usar Xastir con una de estas teclas de
+modificador activada.
+
+También puede seleccionar "Activate alternate net?" y elegir una llamada altnet
+de este diálogo. Altnet le permite tener una red APRS(tm) privada entre las
+estaciones que también tienen altnet configurado y tienen el mismo altnet
+ingresado.
+
+"Disable Posit Dupe-Checks" desactiva la verificación de copias duplicadas de
+una posición. Esto solo debe usarse cuando una estación podría volver a la
+misma posición exacta (dentro de aproximadamente 60' para posiciones no
+comprimidas) y desea ver las posiciones duplicadas y/o pistas mostradas en el
+mapa. Esta opción casi nunca es necesaria en la práctica, pero puede ser útil
+para eventos especiales como operaciones de búsqueda y rescate.
+
+"My Trails in one color" muestra todas las pistas con su indicativo pero con
+diferentes ssids en el mismo color. Con Mi Trails en un color seleccionado,
+micall-1 y micall-2 se muestran en el mismo color. Con Mi Trails en un color
+sin marcar, micall-1 y micall-2 se muestran en colores diferentes.
+
+"Load predefined objects from file" y la lista de selección que le sigue le
+permite reemplazar la lista de Objetos predefinidos que son accesibles desde el
+menú de clic derecho con su propia lista de objetos. Se proporcionan un conjunto
+de objetos de Búsqueda y Rescate estándar y un conjunto de objetos de eventos
+públicos típicos en los archivos predefined_SAR.sys y predefined_EVENT.sys.
+También puede usar estos archivos como plantilla para crear un archivo
+predefined_USER.sys. Consulte las instrucciones en el archivo predefined_SAR.sys
+y predefined_EVENT.sys para obtener detalles sobre cómo definir objetos para un
+menú de objetos predefinidos personalizado. Si tanto "Load predefined objects
+from file" está seleccionado como un archivo que existe en el directorio
+xastir/config/ está seleccionado, entonces los objetos definidos en ese archivo
+se mostrarán en el menú Objetos predefinidos. El archivo predefined_SAR.sys
+inalterado define los mismos objetos que el menú predeterminado.
+
+
+HELP-INDEX>Configurar Temporización
+
+                            Configurar Temporización
+
+Haga clic en Archivo, luego Configurar, luego Cronómetro.
+
+Posit TX Interval especifica con qué frecuencia se transmitirá la posición de
+su estación. Para estaciones fijas, una buena recomendación es cada 30 minutos,
+y definitivamente no menos de 10 minutos. Las estaciones móviles pueden desear
+usar una velocidad más rápida. Tenga en cuenta que si está usando
+SmartBeaconing, este control deslizante se ignora.
+
+Object/Item Max TX Interval es el intervalo máximo usado para enviar objetos e
+elementos. Intente mantener estos intervalos razonables, ya que transmitir a
+una ruta larga cada 5 minutos realmente consumirá mucho tiempo de aire. Se
+activa un algoritmo de intervalo decreciente cada vez que se crea, modifica o
+mata un objeto. El intervalo de transmisión aumentará hasta que alcance el
+intervalo máximo indicado por el control deslizante.
+
+GPS Check Interval establecerá el intervalo de tiempo para verificar el GPS en
+busca de nuevos datos. Esto está disponible para estaciones que utilizan un HSP
+o cable compartido con su TNC.
+
+Dead-Reckoning Timeout ajusta cuánto tiempo se supone que una posición es válida
+para el propósito de estimar su posición actual.
+
+New Track Time ajusta cuántos minutos deben transcurrir antes de que se inicie
+una nueva pista separada. Precaución: establecer el tiempo de nueva pista en 0
+desactivará la visualización de todas las pistas.
+
+RINO -> Objects Interval ajusta la frecuencia con la que se descargan los
+puntos de referencia de una unidad de radio/GPS Garmin RINO conectada. Se
+crean Objetos APRS(tm) a partir de cualquier punto de referencia que comience
+con "APRS". El prefijo "APRS" se elimina al crear los nombres de los Objetos.
+
+Station Ghosting Time especifica el intervalo de fantasma. Las estaciones que no
+se han escuchado en el período dado aparecerán como fantasma en la pantalla.
+
+Station Clear Time especifica cuándo se eliminará una estación de la pantalla.
+
+Station Delete Time especifica el número de días completos antes de que los
+datos de una estación se eliminen completamente de la base de datos de Xastir.
+
+Serial Inter-Char Delay especifica un tiempo de espera en milisegundos entre
+cada carácter enviado a un TNC conectado.
+
+New Track Interval (degrees) especifica la distancia en grados de lat/long en
+la cual se inicia un nuevo segmento de pista. Precaución: establecer el nuevo
+intervalo de pista a 0 grados desactivará la visualización de todas las pistas.
+
+Snapshot Interval (minutes) especifica con qué frecuencia se escribirán
+archivos de instantánea si se selecciona Archivo->Activa PNG Instantánea o
+Archivo->Instantáneas KML.
+
+HELP-INDEX>Configurar Alarmas de Audio
+
+                           Configurar Alarmas de Audio
+
+Haga clic en Archivo, luego Configurar, luego Alarmas de Audio.
+
+Para usar esta opción debe tener una tarjeta de sonido y un programa que
+reproduzca archivos wav. El Audio Play Command debe contener el programa que
+desea ejecutar para reproducir el archivo de audio (y cualquier opción de
+línea de comandos). Por supuesto, esto no funciona si la única tarjeta de
+sonido en el sistema se usa para un soundmodem...
+
+Cada tipo de alerta tiene una casilla de verificación para habilitarla. Los
+campos contendrán el nombre del archivo a reproducir. Los campos bajo la
+opción establecerán parámetros para la opción.
+
+Las opciones actuales son:
+Reproducir mensaje al escuchar una estación nueva.
+Reproducir mensaje al recibir un mensaje nuevo.
+Reproducir mensaje al recibir datos de una estación dentro de la distancia
+     mín/máx de su configuración de proximidad.
+Reproducir mensaje al recibir datos de una estación (vía TNC) dentro de la
+     distancia mín/máx de su configuración de apertura de banda.
+Reproducir mensaje al recibir y mostrar una alerta meteorológica nueva.
+
+Hay un conjunto estándar de sonidos disponibles en la mayoría de los lugares
+donde se puede obtener Xastir, por favor vea el archivo INSTALL.md para más
+información.
+
+HELP-INDEX>Configurar síntesis de voz
+
+                    Configurar síntesis de voz
+
+Para usar esta opción debe tener una tarjeta de sonido e instalado el
+software de síntesis de voz 'festival'. Instale Festival e inícielo en modo
+'server' antes de iniciar XASTIR. El comando normal para esto es
+"festival_server &". Si usa la opción "festival --server" (método antiguo),
+puede experimentar problemas con conexiones rechazadas por el servidor.
+
+Una vez que tenga festival instalado, Xastir tendrá la capacidad de hablar
+usando las siguientes opciones:
+
+New Station       - Anunciar la indicación de una estación nueva.
+New Message Alert - Anunciar la llegada de un nuevo mensaje.
+New Message Body  - Leer el contenido de un mensaje.
+Proximity Alert   - Anunciar cuando se recibe datos de una estación dentro del
+    rango mín./máx. de su configuración de proximidad. Esta opción utiliza la
+    configuración de proximidad encontrada en el menú Alarmas de Audio.
+Tracked station Proximity Alert - Anunciar cuando se recibe datos de una
+    estación dentro del rango mín./máx. de la estación monitoreada. Esta opción
+    utiliza la configuración de proximidad encontrada en el menú Alarmas de Audio.
+Band Opening      - Anunciar cuando se recibe datos de una estación (vía TNC)
+    dentro del rango mín./máx. de su configuración de apertura de banda. Esta
+    opción utiliza la configuración de distancia encontrada en el menú Audio
+    Alarms.
+New Weather Alert - Aún no implementado.
+
+Información sobre Festival se puede obtener de:
+https://www.cstr.ed.ac.uk/projects/festival/
+
+
+HELP-INDEX>Configurar SmartBeaconing
+
+Haga clic en Archivo, luego Configurar, luego Baliza Inteligente.
+
+El "Activar SmartBeaconing(tm)" principal hará que Xastir transmita posiciones
+a diferentes velocidades y ubicaciones basadas en el movimiento de la estación.
+Crea senderos más realistas y hace que la predicción de movimiento sea mucho
+más precisa. Esta opción solo es útil en una estación móvil con un GPS
+conectado.
+
+Hay varias opciones disponibles para personalizar la operación de
+SmartBeaconing:
+
+High rate
+El intervalo (en segundos) en el cual se envían beacons cuando la velocidad
+está por encima de la configuración de High speed. Este parámetro también se
+utiliza para calcular una tasa de beacon basada en la velocidad cuando se
+viaja entre velocidades altas y bajas.
+
+High speed
+El umbral de velocidad que causará beacons a la velocidad especificada
+anteriormente.
+
+Low rate
+El intervalo (en minutos) en el cual se envían beacons cuando la velocidad
+está por debajo de la configuración de Low speed. Básicamente considere esto
+como la tasa de beacon cuando está detenido.
+Este parámetro no se utiliza en absoluto cuando se viaja a una velocidad mayor
+que "Low speed".
+
+Low speed
+El umbral de velocidad que causará beacons a la velocidad especificada
+anteriormente.
+
+Minimum Turn
+Los grados mínimos que el corner pegging puede ocurrir en "High speed" o
+superior. Las velocidades más bajas requerirán más grados de giro para
+activar una posición, basado en el valor de "Turn Slope" a continuación.
+
+Turn Slope
+Factor de ajuste para hacer los giros menos sensibles a velocidades más bajas.
+El parámetro no tiene unidades. Termina siendo no lineal en el rango de
+velocidad de la manera en que funciona el algoritmo SmartBeaconing(tm)
+original.
+
+Wait Time
+El tiempo en segundos entre beacons de corner-pegging, previene múltiples
+beacons en sucesión corta.
+
+HELP-INDEX>Configurar unidades de medida
+
+                     Configurar unidades de medida
+
+La selección predeterminada es para el Sistema Métrico: mm, cm, km/h, etc.
+Para seleccionar unidades inglesas, pulgadas, pies, MPH, etc. Haga clic en
+File, luego Configure, luego active la casilla de verificación "Enable
+English Units".
+
+HELP-INDEX>¡Guardar configuración ahora!
+
+                    ¡Guardar configuración ahora!
+
+Este botón guardará toda la configuración actual en el archivo de
+configuración. Tenga en cuenta que cuando Xastir se cierra, también guarda
+la configuración en el archivo de configuración.
+
+HELP-INDEX>Barra de estado inferior
+
+                        Barra de estado inferior
+
+En la parte inferior de la ventana hay varios mensajes de estado disponibles:
+
+En el primer cuadro a la izquierda se muestran mensajes de estado general
+por un corto tiempo.
+
+El segundo cuadro muestra la lat/long actual o posición de cuadrícula
+UTM y Maidenhead del ratón sobre el mapa. Si file|configure|Dist/Bearing
+Status está seleccionado, este cuadro también contendrá el curso y el
+acimut de esta posición en relación a su estación.
+
+Un tercer cuadro se utiliza para mostrar cuántas estaciones hay en pantalla
+y cuántas hay en la base de datos.
+
+El cuarto cuadro mostrará el nivel de zoom actual y mostrará "Tr" si
+el seguimiento de estación está activado. En algunos niveles de zoom el
+Tr no se muestra correctamente debido al tamaño del cuadro.
+
+El quinto cuadro indica si el registro está habilitado.
+
+El área final mostrará el estado del dispositivo para cada interfaz. Cada
+uno se mostrará en orden de primero a último o 0 a 9. El estado de la
+interfaz está dividido en tres áreas: tipo de dispositivo superior, flujo
+de datos central y estado operativo de interfaz inferior.
+
+El tipo de dispositivo mostrará qué interfaces están configuradas. El color
+mostrará qué tipo de dispositivo está configurada la interfaz. Los azules
+son para los diversos dispositivos TNC; los verdes mostrarán los dispositivos
+GPS; amarillo para servidores de internet; naranja para interfaces WX.
+
+El centro mostrará flujo de datos entrante (flecha apuntando a la izquierda)
+o flujo de datos saliente (flecha apuntando a la derecha) para esa interfaz.
+
+Un cuadro verde en la parte inferior mostrará si esa interfaz está activa.
+Un cuadro rojo mostrará si la interfaz está activa pero en una condición de
+error. De lo contrario, no se mostrará nada si la interfaz no está activa.
+
+HELP-INDEX>Mover el mapa y el menú de opciones
+
+                Mover el mapa y el menú de opciones
+
+El movimiento del mapa es muy simple, la facilidad y rapidez del movimiento
+depende de la velocidad de su procesador y de la cantidad de detalle que
+cargue. Consejo: Puede deshabilitar todos los mapas en el menú de mapas para
+moverse rápidamente, luego habilitar mapas nuevamente.
+
+Zoom:
+El zoom se puede lograr haciendo clic derecho en el mapa (y manteniendo el
+botón presionado). Esto traerá un menú de opciones, con opciones para ampliar
+o reducir un solo nivel, o cambiar a uno de los niveles de zoom preestablecidos.
+
+Todas las funciones de zoom del menú de opciones ampliarán o reducirán en el
+punto del mapa donde hizo clic con el botón derecho del ratón. Los niveles de
+zoom tienen un menú en cascada. Los niveles 1-64 son para áreas muy locales y
+los niveles 256 y superiores son para grandes áreas. Cuanto menor sea el número
+del nivel, más local es el área.
+
+Una función de zoom más rápida es presionar y mantener presionado el botón
+izquierdo del ratón, arrastrarlo sobre el área de interés y soltarlo. El mapa
+se ampliará aproximadamente al tamaño del cuadrado que acaba de describir con
+la operación de arrastre del ratón. Las casillas de verificación "move" y
+"measure" en la barra de herramientas deben estar deshabilitadas para que esta
+función funcione. Hacer clic en el botón del medio amplía con un factor de 2,
+centrándose también donde hizo clic.
+
+El mapa también se puede ampliar con las teclas Página hacia arriba/Página
+hacia abajo del teclado, o con los botones "In" y "Out" en la barra de
+herramientas. El zoom en este caso mantiene el mismo centro del mapa (sin
+centrado).
+
+Desplazamiento/Centrado:
+El mapa se puede centrar en una ubicación específica eligiendo center en el
+menú de opciones de clic derecho.
+
+El desplazamiento también se logra usando el menú de opciones, o usando los
+botones de flecha en la barra de herramientas. La posición del mapa se
+desplazará una porción de una pantalla. Suficientes datos de la pantalla
+anterior deberían estar disponibles para reorientarse.
+
+El mapa también se puede desplazar con las teclas de flecha del teclado.
+
+Más sobre el menú de opciones:
+
+Marcadores del mapa
+Consulte el tema de ayuda "Crear y usar marcadores de pantalla de mapa"
+
+La selección "Info Estación" en el menú de opciones buscará la estación más
+cercana a donde hizo clic con el botón derecho del ratón. Si más de una
+estación está cerca de esa posición, aparecerá una lista "Seleccionar Estación",
+luego puede elegir qué datos de estación desea ver. Si solo una estación está
+cerca del puntero del ratón, los datos de esa estación se mostrarán
+inmediatamente. Para estaciones móviles con muchos datos de seguimiento, esto
+podría necesitar tiempo en computadoras lentas. Tenga en cuenta que las
+estaciones expiradas aún tienen sus datos almacenados en la base de datos de
+Xastir, y si se conoce una ubicación anterior de una estación, aún se puede
+ver su información de esta manera. Use la opción "Incluir Datos Expirados" para
+mostrar algunos datos que desaparecen para estaciones fantasma, como
+velocidad/altitud, etc.
+
+Con "Última pos./zoom del mapa" puede restaurar la vista del mapa anterior restaurando los
+valores anteriores de zoom y centrado del mapa.
+
+Para información de Objetos y Artículos, consulte el tema de ayuda "Objetos y
+Artículos"
+
+Dibuje Objetos CAD le permite crear polígonos en la pantalla, para uso táctico o
+de presentación. Esta función aún está en construcción.
+
+"Mover Mi Estación Aquí" le permite mover su estación a una ubicación de mapa
+especificada sin editar la configuración de la estación.
 
 HELP-INDEX>Objetos y Artículos
 
-                                Objetos y Artículos
+Una estación podría colocar varios objetos diferentes en el mapa, con su
+posición transmitida a otras estaciones. Los nombres de los objetos son menos
+restrictivos que los nombres de estaciones normales.
 
-La opción de crear Objeto/Artículo en el botón derecho pulsado el menú traeará un diálogo  
-con la posición de basado objeto en donde usted pulsó el botón del ratón.  
-Usted puede rellenar los detalles, y agregar un objeto/artículo desde este menú.  
-  
-La opción de modificar Objeto/Artículo le traerá un diálogo de modificación de objeto.  
-Es similar al diálogo de creación de objeto, excepto por la actual información de objeto que  
-ya están publicada, y el nombre del objeto y unas de las pocas otras opciones que no pueden ser cambiada.  
-  
-Los objetos son retransmitido dentro de la proporción de posición de la estación reportada, configurada en Archivo|Configurar|P
-redefinidos, y cesará la retransmisión después doblar el  
-tiempo de despliegue de la estación, también configurada allí. "muerta" los objetos también son  
-retransmitido de esta manera, hasta que ellos expiren desde la cola.  
-  
-Generalmente se usan los objetos para movimiento o cosas inconstantes como tormentas,  
-mientras que los artículos generalmente son usando para las cosas más inanimadas, como agua,  
-estaciones. Cualquiera puede moverse con el ratón si el "Movimiento" el checkbox en la  
-barra de botones se habilita.  Note que los artículos no pueden ser descifrados por uno cuantos  programas APRS(tm) .  
-  
-Las área de objetos son útiles para una variedad de funcionamientos en lo que usted quiere dibujar  
-o resaltar una área de interés en el mapa. Ellos también pueden ser personalizados para dibujar  
-rastros/caminos/fronteras, sitios de vijilancia para mal el tiempo, las pistas de aterrizaje, perímetros, de una área de búsque
-da o de un evento de servicio público, áreas de daño, áreas para quedarse fuera de, edificios que no están en el mapa, la tabla
- checker/chess para juego por dinero en APRS(tm).: -) Note que las área de objetos no son llevada a cabo en todas las versiones
- de programas APRS(tm), y algunos de los detalles de cómo ellos se despliegan también pueden  
-ser diferente en otros programas.  
-  
-Nombre  
-Éste es el nombre del objeto o artículo. Puede depender de hasta 9 carácteres. Cuando  
-modifica un objeto, este no puede ser cambiado. Para renombrar un objeto usted debe  
-anular el original y entonces crear un nuevo objeto. Note que si usted selecciona  
-Signpost/Area Object/DF Objeto que este campo y quizás otros serán aclarado.  
-Entre en el nombre DESPUÉS que usted ha seleccionado el tipo de objeto que volverá.  
-  
-Poste indicador  
-Este hace al objeto un poste indicador de objeto. Estas señales pueden ser 3 carácteres,  
-visible en un poste indicador a la locación cuando el enfoque es acercado. (CORRIGEME: Nosotros no hacemos el despliegue de los
- postes indicadores todavía de esta manera).  
-  
-Objeto del área  
-Esto hace un objeto del área al objeto, y habilita los mandos de objeto de área  
-descrito debajo.  
-  
-Objeto DF  
-Éste es un informe de contrada-dirección. Habilitándolo le permite escoger reporte Omni o  
-direccional, y le permite poner en el especifico para cada uno.  Vea:  
-    http://web.usna.navy.mil/~bruninga/dfing.html  
-y la documentación de APRSdos para los detalles en estas técnicas útiles.  
-(CORRIGEME: la sección Separada en las técnicas de DFing?)  
-  
-Símbolo Estación  
-Usted puede seleccionar un símbolo para el objeto. Pulse seleccionar para escoger gráficamente,  
-o ver la sección tabla de ayuda de símbolo para las descripciones de cada símbolo. Note  
-que no todos los símbolos se han llevado a cabo todavía en el escogedor de gráficos,  
-y algunos no están por el APRS(tm) especificación. También note esa área de objeto, poste indicador de objetos, y los objetos d
-e DF tienen símbolos fijos especiales y por consiguiente no pueden ser seleccionado aquí.  
-  
-Localización  
-La localización del objeto se especifica aquí. Si usted seleccionara "Crear   
-Objeto/Artículo" pulsando el botón derecho del menú, la locación que usted pulsado se llenará  
-. Si usted moviera un objeto con el ratón, la nueva posición estará en esos campos.  Usted también puede teclear en una posició
-n, por ejemplo usted puede estar poniendo un  
-objeto de un informe de voz sobre el aire.  
-  
-Opciones genéricas  
-Usted puede especificar la velocidad, dirección, y altitud de objetos aquí. Algunos tipos de objetos  
-no pueden tener una velocidad o dirección en tales casos los campos son desgrisado  
-.  
-  
-Objeto del poste indicador  
-Si el objeto es un objeto de poste indicador, usted puede especificar de 1 a 3 carácter  
-de mensaje que aparece en la señal aquí.  Note que Xastir no despliega los objetos  
-de poste indicador a propiamente todavía.  
-  
-Objeto área  
-Se usan Objetos de área para resaltar partes específicas del mapas, o para dibujar excepcionalmente detalle dentro de los mapas
-.  
-  Color luminoso.  
-    Use la versión más luminosa de los colores permitidos.  
-  Colorido  
-    El área debe llenarse, no sólo perfilado. Esto puede ser útil para  
-    excluir una área de una búsqueda u otro evento.  
-  Tipo de objeto  
-    Escoge desde las formas geométricas permitidas.  
-  Color del objeto  
-    Escoge el color en el que el objeto se desplegará. Esto también es afectado  
-    por el "Color Luminoso" la opción anteriormente.  
-  El objeto Compensado  
-    En centésima de un grado latitud.  Un detalle infortunado de la especificación,  
-    y duro de calcular fácilmente.  Basta decir que usted puede cambiar  
-    el tamaño del objeto una vez usted lo ponga.  
-  El Desplazamiento izquierdo del objeto excepto /  
-    En centésima de un grado latitud.  Vea anteriormente.  
-  Objeto corredor  
-    Éste es el ancho de una línea de área de objeto. Util para las pistas de aterrizaje, tiempo  
-    watchboxes, describiendo una área de interés o una área de exclusión, etc.,  
-(CORRIGEME: Escriba esta parte! (el área objeto) La especificación es incierta a mí, el código,  
-es incierto a mí, pero en el futuro yo lo deduciré todos!)  
-  
-¡Siempre anule sus objetos y artículos cuando usted halla terminado con ellos!  
-No les permita simplemente expirar desde su escondite, como ellos pueden colgarse  
-alrededor de las pantallas de otras personas por un periodo extendido.  
-    
+Objects y Items son casi lo mismo, pero su uso podría diferir un poco. Los
+Objects se utilizan generalmente para cosas móviles o variables como
+tormentas, mientras que los Items se utilizan generalmente para cosas más
+inanimadas, como estaciones de agua. Debido a que algunos sabores de programas
+APRS(tm) no pueden decodificar Items, los Objects se usan a menudo para cosas
+inanimadas también.
 
-HELP-INDEX>Menú Visualizador
+Además de los objetos normales con un símbolo en su posición hay algunos
+objetos especiales disponibles. Los Area Objects son útiles para una variedad
+de operaciones en las que desea dibujar o resaltar un área de interés en el
+mapa. También se pueden usar para dibujar senderos/carreteras/límites, cajas
+de vigilancia para clima severo, pistas, perímetro de un área de búsqueda o de
+un evento de servicio público, áreas de daño, áreas para evitar, edificios que
+no están en el mapa, tableros de damas/ajedrez para juegos en APRS(tm). :-)
+Tenga en cuenta que los Area Objects no se implementan en todas las versiones
+de programas APRS(tm), y algunos de los detalles de cómo se muestran también
+pueden ser diferentes en otros programas.
+Para los otros tres, círculos de probabilidad, señalización y objetos DF,
+vea abajo.
 
-                     Opciones del Menú de Visualizar  
-  
-El menú de Visualizar presenta varias maneras de ver datos en Xastir.  
-  
-Boletines  
-Éste es el APRS(tm) tabla de anuncios, donde importantes anuncios son puesto.  
-Si usted se conecta con la interfáz del internet, es una buena idea para poner el  
-rango del campo a unas cientas millas, para ignorar postes de otras porciones del  
-mundo. "0" es el rango del campo, significa el mundo entero. Pulse el botón "Cambio de rango"  
-pulse para hacer cambios a este campo eficaz. Xastir actualmente no soporta el envío de boletines.  
-  
-Datos de paquete entrantes  
-Esto despliega los datos entrantes en su TNC o interfáz del internet. Los botones radio  
-debajo selecciona si usted quiere ver sólo datos de TNC, sólo datos del internet, o  
-ambos.  
-  
-Estaciones móviles  
-Ésta es una lista de estaciones que se están moviendo. Las estaciones califican para esta lista si  
-ellas se han movido (más de una posición recibida para ellas), el símbolo de  
-la estación no es considerada. Información mostrada incluyendo curso, velocidad, altitud,  
-posición, número de paquetes recibido, número de satélites de GPS visibles, curso,  
-de su estación, y distancia de su estación.   
-  
-Todas las Estaciones  
-Esta opción despliega una tabla de todas las estaciones ordenada alfabéticamente. Incluyendo  
-el número de paquetes oído, el tiempo que la estación fue oída última vez, el camino   
-más reciente paquete tomado, el PHG, y el comentario de la estación.  
-  
-Estaciones locales  
-Esta opción despliega sólo estaciones que se oyen vía su TNC. Incluye  
-el número de paquetes oído, el tiempo que la estación fue oída última vez, el camino  
-más reciente paquete tomado, el PHG, y el comentario de la estación.  
-  
-Ultimas Estaciones  
-Esta opción despliega una tabla de todas las estaciones ordenada recientemente oída  
-a menor recientemente escuchada. Incluye el número de paquetes oído, el tiempo,  
-la estación fue oída última vez, el camino que el más reciente paquete tomó, el PHG,  
-y el comentario de la estación.  
-  
-Estación WX  
-Esta opción despliega una tabla de todo el APRS(tm) estaciones del tiempo y sus datos.  
-El datos incluyen curso del viento, velocidad del viento, velocidad de ráfaga dle viento, temperatura, humedad, presión baromét
-rica, lluvia en la última hora, lluvia medianoche subsecuentemente, y lluvia en las últimas 24 horas.  
-  
-Estación Meteorológica Propia  
-Despliega sus datos del tiempo si usted tiene una estación del tiempo y la ha configurado  
-Xastir para accederla.  
-  
-Alerta del Tiempo  
-Los despliegues alarmas recibidas, incluso las banderas de alertas, la alerta fuente/tipo,  
-destino alerta, expiración, mensaje, y efectuada situación. Esto datos  
-se usa por el resalto de condado, y no es particularmente humanamente-leíble.  
-Usted generalmente puede deducir el estado y condado para la mayoría de las alarmas.  
-  
-Tráfico de mensaje  
-Muestras todo el tráfico de mensaje mientras la ventana está abierta. Incluye la fuente,  
-destino, interfáz, y mensaje. La opción de rango puede limitar este despliegue  
-a las estaciones cercanas, mucho como el mando del rango en boletines. Un rango de 0  
-causas todos los mensajes a ser desplegados.  
-  
-SobreHora  
-Muestras la cantidad de tiempo pasado subsecuentemente que Xastir fue iniciado.  
-  
-HELP-INDEX>Mapas Opciones y Seleccionar Mapas
+Objects/Items se retransmiten a una tasa decreciente hasta el intervalo máximo
+especificado en Archivo|Configurar|Cronómetro. Los objetos/items "killed" también se
+retransmiten de esta manera hasta que expiren de la cola (actualmente 20
+transmisiones). Objects/Items persisten en sesiones de Xastir y se almacenan
+en ~/.xastir/config/object.log. Este archivo puede borrarse seleccionando
+"Limpiar Historia de Objeto/Artículo" desde el menú Estaciones.
 
-              Mapas Opciones y Seleccionar Mapas
+La opción Crear Objeto/Artículo en el menú de clic derecho traerá un diálogo con
+la posición de su objeto rellenada según donde hizo clic con el ratón. Puede
+rellenar los detalles y agregar un objeto/item desde este menú.
 
-Mapas Opciones:
+La opción Modificar Objeto/Artículo le trae el diálogo de modificación de
+objetos. Es similar al diálogo de creación de objetos, excepto que la
+información actual del objeto ya está rellenada, y el nombre del objeto y
+algunas de las otras opciones no se pueden cambiar. También podría eliminar el
+objeto con esta opción.
 
-Auto mapas (on/off)
- Cuando cualquier mapa es encontrado, en el directorio de mapas
-(o cualquier directorio bajo él) será desplegado,
-si el cae dentro de la región de despliegue actual.
+Objects e Items se pueden mover con el ratón si la casilla de verificación
+"Move" en la barra de herramientas está habilitada.
 
-Usted puedes agregar cualquier número de niveles de directorios bajo
-el directorio del mapa principal para sus mapas.
-El Auto mapa pasará por todos ellos y hallará que mapa (o parte) debe desplegarse.
+La opción Objetos predefinidos en el menú de clic derecho le permite colocar
+rápidamente objetos de Búsqueda y Rescate estándar sin tener que pasar por el
+diálogo de creación de Object/Item. Estos objetos incluyen símbolos del Sistema
+de Comando de Incidentes estándar para ICP, Staging, Base y Helibase, así como
+objetos SAR para PLS, IPP (con 4 círculos de área) y LKP. Si un objeto con el
+mismo nombre que un objeto que selecciona de la lista ya existe, se creará un
+nuevo objeto con un número añadido al final. Por ejemplo, la primera vez que
+selecciona Staging del menú Objetos predefinidos, se creará un objeto llamado
+Staging. Si luego crea un objeto Staging adicional del menú Objetos predefinidos,
+se llamará Staging2.
+Heli- (y objetos definidos por el usuario que terminan en un "-") se crearán
+como Heli-1, Heli-2, Heli-3, etc. Si ha recibido uno de estos objetos
+estándar transmitido por otra estación, su primer objeto tendrá un número
+añadido. Puede que desee asignar un llamado táctico a su objeto en esta
+situación (por ejemplo, reemplazando ICP2 con un llamado táctico).
 
-Todos los Mapas se unirán en el área de visión.
-Si usted tienes una cantidad grandes de mapas, mapas muy detallados
-o una computadora muy lenta, esto puede ser mostrado bastante lento.
+El menú Objetos predefinidos es personalizable modificando los archivos
+predefined_SAR.sys, predefined_EVENT.sys y predefined_USER.sys, y luego
+seleccionando uno de estos archivos a través del diálogo Archivo/Configurar/
+Predefinidos.
+Consulte el archivo predefined_SAR.sys para obtener detalles.
 
-Cuando esta opción está apagada, se desplegarán mapas seleccionados
-con el selector de Mapas.
+Descripción de las entradas en el diálogo de objetos:
 
-Rejillas sobre Mapa (on/off)
- Cuando esté en 'ON', esta opción desplegará una línea de reja cada 10 grados.
+= Signpost =
+Esto hace que el objeto sea un objeto de señalización. Estos signos pueden
+contener uno a tres caracteres y actualmente aparecen en Xastir como un signo
+en blanco. Info Estación muestra el valor contenido en el signo.
 
- Niveles de mapas (on/off)
- Cuando esté en 'ON', esta opción intentará filtrar fuera los datos cuando el 
-nivel de enfoque muesta grandes áreas. Esto no trabajará con todos los mapas 
-pero trabajará con los mapas generados de 'Tiger line maps'  en el sitio de 
-aprs.rutgers.edu.
+= Area Object =
+Esto hace que el objeto sea un Area Object e habilita los controles de Area
+Object descritos a continuación.
 
-Areas rellena en colores (on/off)
-Esta opcion controla el relleno del vector del mapa. En ciertos casos, usted
-podria querer enliminar el relleno para ver el mapa bajo el tope de mapas.
-Los mapas son cargados en orden alfabertico por tipo, asi que renombrando
-mapas es un segundo pero la via es menos elegante archivar la vista deseada.
+= DF Object =
+Este es un informe de búsqueda de dirección. Habilitarlo le permite elegir
+Omni o Beam report, y le permite poner en los detalles específicos de cada
+uno. Vea:
+    https://www.aprs.org/dfing.html
+para la discusión de Bob Bruninga sobre cómo usar estas técnicas.
+(FIXME: Sección separada sobre técnicas DF'ing?)
 
-Seleccionar Mapas
-Esta se presentará con una lista de todos los archivos en su directorio de 
-mapas. Cualquier mapa que usted desearías incluirlo en los datos desplegados, 
-simplemente tiene que pulsar el botón del ratón sobre el nombre.
-Esto resaltará el nombre del mapa, Usted puedes seleccionar cualquier número de mapas.
-Pulsando en el botón "Aceptar"  se desplegarán los mapas seleccionados.
-Oprimiendo el Botón de "Cancelar" abandonaría cualquier cambio.
+= Probability Circles =
+Esto le permite definir el radio (en millas) de dos círculos centrados en el
+objeto o item. Min es el radio (en millas) del círculo interior más pequeño, y
+Max es el radio (en millas) del círculo exterior más grande. Estos círculos se
+dibujan en rojo. Se pueden usar para ayudar en la planificación de operaciones
+de Búsqueda y Rescate. Para crear más de dos círculos, agregue objetos de
+círculo de probabilidad adicionales en la misma ubicación. Es posible que otros
+software de cliente no muestren círculos de probabilidad.
 
-Tambien hay botones de atajo para seleccionar todos de un cierto tipo de mapa,
-o de-seleccionar todos los mapas de una vez.
+= Name =
+Este es el nombre del objeto o item. Puede tener hasta 9 caracteres de largo,
+con espacios permitidos dentro del nombre. Al modificar un objeto, esto no se
+puede cambiar. Para cambiar el nombre de un objeto debe eliminar el original y
+luego crear un nuevo objeto. Tenga en cuenta que si selecciona Signpost/Area
+Object/DF Object, este campo y posiblemente otros se borran. Ingrese el nombre
+DESPUÉS de haber seleccionado el tipo de objeto en el que se convertirá.
 
-Una nota sobre mapas: Muchos de los actuales mapas de vectores disponibles para
-los EE.UU. fueron creado en NAD 1927 datum, mientras Xastir y otros programas de APRS
-usan el WGS 1984 datum. 
-Si es enfocado hacia una área pequeña en el mapa la variacián del datum
-puede ser muy notable. Los mapas topo USGS tienen sus datum corregido por Xastir
-como ellos son desplegados,
-asi que la posiciones generalmente serán más exacta con los mapas topo.
+= Station Symbol =
+Puede seleccionar un símbolo para el objeto. Presione select para elegir
+gráficamente, o consulte la sección de ayuda de la tabla de símbolos para
+descripciones de cada símbolo. Tenga en cuenta también que los objetos de
+Area, signpost y DF tienen símbolos fijos especiales y por lo tanto no se
+pueden seleccionar aquí. Esos símbolos particulares se asignan automáticamente
+cuando cambia a ese tipo de objeto.
 
-HELP-INDEX>Archivos Mapas, Dos, Windows, Pixmaps, geoTIFF y Condados WX  
+= Location =
+La ubicación del objeto se especifica aquí. Si seleccionó "Create Object/Item"
+del menú de clic derecho, la ubicación en la que hizo clic se rellenará. Si
+movió un objeto con el ratón, la nueva ubicación estará en estos campos. También
+puede escribir una ubicación, por ejemplo, puede estar colocando un objeto desde
+un informe de voz sobre el aire.
 
-             Archivos mapas, Dos, Windows, Pixmaps, geoTIFF y Condados WX  
+= Generic Options =
+Puede especificar la velocidad, dirección y altitud de los objetos aquí. Algunos
+tipos de objetos no pueden tener una velocidad o dirección, en cuyo caso los
+campos están atenuados.
 
-Tipos de mapas  
-Xastir trabajará con varios tipos archivos de mapas.
-Todo el Dos, Windows/MacAPRS[TM] son archivos de  Mapas que son soportados.
+= Signpost Text =
+Si el objeto es un objeto de señalización, puede especificar aquí el número de
+1 a 3 dígitos que aparece en el signo. Tenga en cuenta que Xastir aún no
+muestra correctamente los objetos de señalización.
 
-Un nuevo formato de Pixmap se ha agregado en versión 0.3.2.
-Xastir también soportará mapas para las Alertas de condados WX.  
-El último formato de mapa soportado es geoTIFF, tales mapas como son
-USGS DRG topo mapas.
+= Area Object =
+Los Area Objects se utilizan para resaltar partes específicas de mapas, o para
+dibujar detalles adicionales en mapas. Esto se hará con las siguientes
+entradas:
+  = Bright Color =
+    Use la versión más brillante de los colores permitidos.
+  = Color-Fill =
+    El área debe ser rellenada, no solo perfilada. Esto puede ser útil para
+    excluir un área de una búsqueda u otro evento.
+  = Object Type =
+    Elija entre las formas geométricas permitidas.
+  = Object Color =
+    Elija el color en el cual se mostrará el objeto. Esto también se ve
+    afectado por la opción "Bright Color" anterior.
+  = Object Offset Up =
+    En 1/1500 de un grado de latitud. Un detalle desafortunado de la
+    especificación, y difícil de calcular fácilmente. Baste decir que puede
+    cambiar el tamaño del objeto una vez que lo coloque.
+  = Object Offset Left except / =
+    En 1/1500 de un grado de longitud. Vea arriba.
+  = Object corridor =
+    Este es el ancho de una línea de Area Object. Útil para pistas, cajas de
+    vigilancia de clima, describiendo un área de interés o un área de
+    exclusión, etc.
 
-Locaciones de Mapas 
-Cualquier Dos, Windows/Mac o archivo Pixmap y geoTIFF, deben guardarse en el  
-Directorio de /usr/local/share/xastir/maps en su computadora.
-Usted puedes crear cualquier números de directorios bajo este directorio
-para ayudar a separar sus datos.
-Por ejemplo usted puedes querer crear un directorio de USA.
-y después uno por cada estado bajo el Directorio de USA.
-O tiene un directorio separado para DOS o Pixmaps y geoTIFF.
+¡Siempre elimine sus objetos e items cuando haya terminado con ellos! No los
+deje simplemente expirar de su caché, ya que pueden permanecer en las pantallas
+de otras personas durante un período prolongado.
 
 
-                          /usr/local/share/xastir/maps/
-                                                /usa/
-                                                /usa/CO/
-                                                /usa/NJ/
-                                                /dos/CO/
-                                                /dos/NJ/
-                                                /pixmaps/CO/
-                                                /pixmaps/NJ/
+Descripción de las cajas de vigilancia meteorológica:
 
+Watch boxes y "areas of maximum concern" (AOMC) generadas por el WXSVR
+(https://www.aprs-is.net/WX/Default.aspx) están coloreadas como sigue:
 
-Pixmaps realmente son una combinación de dos archivos, un archivo de dato con un,  
-pixmap (.xpm), gráfico y un archivo de locación (.geo).
-El archivo .xpm es una estructura de gráfico normal,
-con una imagen de cualquier tipo.
+  Yellow dashed = Severe Thunderstorm Watch (parece cinta de escena de crimen)
+   Yellow solid = AOMC for Severe Thunderstorm Warning
+     Red dashed = Tornado Watch
+      Red solid = AOMC for Tornado Warning.
+   Green dashed = Mesoscale (larger) discussion area
+    Blue dashed = Test Watch
+     Blue solid = Test Warning
 
-Usted puedes usar XView para convertir gif, jpg, y tif imágenes en este formato.
-El archivo geo es un archivo de dato que atará la imagen a una locación en el mundo.
-Aquí está un ejemplo de mi archivo world1.geo
+HELP-INDEX>Objetos CAD
 
+                     Objetos CAD
+El soporte de CAD Objects es preliminar en este momento. Las características y
+la interfaz de usuario están sujetas a cambios.
 
-ARCHIVO   world1.xpm
+Los CAD Objects son formas arbitrarias que puede dibujar en mapas en xastir,
+pero no puede transmitir por APRS.
+
+Los CAD Objects actualmente soportados son:
+Polygons: Áreas cerradas de al menos tres puntos.
+
+Para crear un CAD Object, primero presione el botón de radio Draw en la barra
+de herramientas. Esto cambiará el cursor a un lápiz. Comience a dibujar un
+polígono haciendo clic con el botón central del ratón (o ambos botones en un
+ratón de dos botones, para lo cual necesitará tener habilitada la emulación de
+ratón de tres botones). Esto coloca un punto en el mapa. Ahora mueva el cursor
+a otro lugar (las funciones normales de navegación y zoom de clic izquierdo/
+derecho funcionan normalmente) y haga clic en el botón central del ratón
+nuevamente. Esto dibuja una línea entre los dos puntos que ha seleccionado.
+Haga clic central nuevamente para dibujar otro segmento de línea y repita hasta
+que haya dibujado todos excepto el segmento de línea de cierre de su polígono.
+Para cerrar el polígono, seleccione Map/Draw CAD Objects/Close Polygon. Esto
+cerrará su polígono y traerá un diálogo que le permitirá ingresar un nombre,
+comentario y probabilidad del polígono.
+
+Cuando haya terminado de dibujar CAD Objects, salga del modo de dibujo CAD
+deseleccionando el botón de radio Draw en la barra de herramientas.
+
+Los CAD Objects se pueden editar desde el menú View/CAD Polygons y desde el
+menú Map/Draw CAD Objects/CAD Polygons. Los CAD Objects se pueden eliminar
+desde el menú Map/Draw CAD Objects/Erase CAD Polygons.
+
+HELP-INDEX>Menú Visualizar
+
+                   Opciones del menú Visualizar
+
+El menú Ver presenta varias formas de ver datos en Xastir.
+
+Boletines
+Este es el tablero de anuncios APRS(tm), donde se publican anuncios importantes.
+Si está conectado con la interfaz de internet, es una buena idea establecer el
+campo de rango a algunas cientos de millas, para ignorar publicaciones de otras
+partes del mundo. "0" en el campo de rango significa el mundo entero. Haga clic
+en el botón "Change range" para que los cambios en este campo sean efectivos.
+Xastir actualmente no admite el envío de boletines. Los boletines entrantes
+abrirán este diálogo automáticamente si selecciona "Mostrar boletines nuevos" en el
+diálogo Configurar|Predefinidos. El botón "Ver boletines de distancia cero" habilita la
+visualización de boletines para los cuales aún no tiene un rango (no han enviado
+una posición aún, pero recibió un boletín de ellos). Si esto no está marcado,
+debe obtener una posición de una estación, y la estación debe estar dentro del
+rango seleccionado (o el rango debe establecerse en cero), para poder ver el
+boletín.
+
+Datos de paquetes entrantes
+Esto muestra los datos entrantes en su TNC o interfaz de internet. Los botones
+de radio a continuación seleccionan si desea ver solo datos de TNC, solo datos
+de internet, o ambos.
+
+Estaciones Móviles
+Esta es una lista de estaciones que se están moviendo. Las estaciones califican
+para esta lista si se han movido (más de una posición recibida para ellas), el
+símbolo de la estación no se considera. La información mostrada incluye curso,
+velocidad, altitud, posición, número de paquetes recibidos, número de satélites
+GPS visibles, curso desde su estación y distancia desde su estación.
+
+Todas las Estaciones
+Esta opción muestra una tabla de todas las estaciones ordenadas alfabéticamente.
+Incluye el número de paquetes escuchados, la hora en que se escuchó por última
+vez la estación, la ruta que tomó el paquete más reciente, el PHG y el
+comentario de la estación.
+
+Estaciones Locales
+Esta opción muestra solo estaciones que se escuchan a través de su TNC. Incluye
+el número de paquetes escuchados, la hora en que se escuchó por última vez la
+estación, la ruta que tomó el paquete más reciente, el PHG y el comentario de
+la estación.
+
+Últimas Estaciones
+Esta opción muestra una tabla de todas las estaciones ordenadas de más
+recientemente escuchadas a menos recientemente escuchadas. Incluye el número de
+paquetes escuchados, la hora en que se escuchó por última vez la estación, la
+ruta que tomó el paquete más reciente, el PHG y el comentario de la estación.
+
+Objetos y Artículos
+Esta opción muestra solo objetos e artículos. Incluye el número de paquetes
+escuchados, la hora en que se escuchó por última vez el objeto/item, la ruta
+que tomó el paquete más reciente, el PHG y el comentario del objeto/item.
+
+Objetos y Artículos Propio
+Esta opción muestra solo objetos e artículos que controla (es decir, ha enviado la
+actualización más reciente para). Incluye el número de paquetes escuchados, la
+hora en que se escuchó por última vez el objeto/item, la ruta que tomó el
+paquete más reciente, el PHG y el comentario del objeto/item. Un icono
+atenuado indica que el objeto ha sido eliminado.
+
+Estaciones Meteorológicas
+Esta opción muestra una tabla de todas las estaciones meteorológicas APRS(tm)
+y sus datos. Los datos incluyen curso del viento, velocidad del viento,
+velocidad de ráfaga del viento, temperatura, humedad, presión barométrica,
+lluvia en la última hora, lluvia desde la medianoche y lluvia en las últimas
+24 horas.
+
+Su Estación Meteorológica
+Muestra sus datos meteorológicos si tiene una estación meteorológica y ha
+configurado Xastir para acceder a ella.
+
+Alerta del tiempo
+Muestra las alertas meteorológicas recibidas, incluidas las banderas de alerta,
+fuente/tipo de alerta, destino de alerta, vencimiento, mensaje y ubicación
+afectada. Estos datos se utilizan para el resaltado de alertas. Hacer doble
+clic en una alerta solicitará más información al respecto a través de finger
+desde el WXSVR en línea. Esto solo funciona si tiene acceso a internet; las
+versiones futuras pueden acceder a estos datos por radio también.
+
+Tráfico de mensajes
+Muestra todo el tráfico de mensajes mientras la ventana esté abierta. Incluye
+la fuente, destino, interfaz y mensaje. La opción de rango puede limitar esta
+pantalla a estaciones cercanas, similar al control de rango en los boletines.
+Un rango de 0 causa que se muestren todos los mensajes.
+
+Estado del GPS
+Muestra el estado de su unidad GPS, incluido el tipo de corrección y el número
+de satélites adquiridos.
+
+Tiempo en ejecución del programa
+Muestra la cantidad de tiempo transcurrido desde que se inició Xastir.
+
+HELP-INDEX>Menú Mapas y el selector de mapas
+
+                   Menú Mapas y el selector de mapas
+
+Menú Mapas:
+
+Selección de Mapa
+Esto le presentará una lista de directorios de mapas y/o archivos en su
+directorio de mapas. Marcar la opción "Expandir dirs" alterna la expansión de
+directorios en archivos de mapas individuales. El diálogo de propiedades
+permite controles más avanzados, y se describe a continuación. Haga clic en
+nombres de mapas para resaltarlos, esto hará que se muestren cuando haga clic
+en el botón OK. Puede seleccionar cualquier número de mapas. Hacer clic en
+"Limpiar" no seleccionará mapas, hacer clic en "Vectores" seleccionará solo mapas
+vectoriales. Las tres opciones "topo" seleccionarán automáticamente todas las
+imágenes GeoTIFF del tamaño listado. Hacer clic en el botón OK mostrará los
+mapas seleccionados. Cancel abandonará cualquier cambio.
+
+  Propiedades de la Selección de Mapa
+  Hacer clic en el botón Properties traerá un diálogo donde puede especificar
+  la capa en la cual aparecen los mapas, y en qué niveles de zoom aparecen.
+  Los números de capas más altos se muestran encima de los números más bajos.
+  El rango puede especificarse de -99999 a 99999; se sugiere que espacie ampliamente
+  los números de capas para permitir la inserción posterior de capas de mapas
+  adicionales. Desde este diálogo puede especificar si un mapa vectorial se
+  dibuja con rellenos de color. Esta es una configuración por mapa; la opción de
+  deshabilitación global en el menú Mapas puede reemplazar esto. La configuración
+  Filled se ignora para mapas raster (imágenes). Una configuración de "auto"
+  permite que un archivo dbfawk controle este parámetro directamente (usable solo
+  si dbfawk está compilado y el mapa en cuestión es un Shapefile). También puede
+  seleccionar si un mapa es considerado por la característica "Activar Auto Mapas" aquí.
+  Finalmente, puede especificar los niveles de zoom mínimo y máximo en los cuales
+  se muestra un mapa. Esto es útil para evitar que mapas locales muy detallados
+  se carguen en posiciones de zoom muy amplias, y viceversa. Un zoom mínimo de
+  10 significa que un mapa se mostrará en todos los zooms incluyendo y por encima
+  de 10. Del mismo modo, un zoom máximo de 256 significa que un mapa se mostrará
+  en todos los zooms por debajo e incluyendo 256.
+
+Marcadores del mapa
+Consulte el tema de ayuda "Crear y usar marcadores de pantalla de mapa"
+
+Localice rasgo del Mapa
+Esta opción trae un diálogo de búsqueda donde puede buscar a través de las
+etiquetas en un archivo GNIS para encontrar una ubicación específica. Centrará
+el mapa en la nueva ubicación si se encuentra. La entrada "GNIS File:" se
+guarda entre llamadas y entre invocaciones de Xastir. Debe poner archivos GNIS
+en el directorio xastir/GNIS para usar esta función.
+
+Buscar ubicación
+Esta característica generalmente requiere una conexión a internet.
+
+Esta opción trae un diálogo de búsqueda donde puede ingresar una dirección
+o nombre de un negocio o ubicación. Generará una solicitud de internet a un
+servidor "Nominatim" que consulta datos de OpenStreetMap para encontrar la
+ubicación. Si se encuentran algunos, el diálogo se rellenará con una lista de
+ubicaciones coincidentes. Elija uno haciendo clic en él y luego haga clic en
+"Go To" o "Mark". Cualquiera de las opciones centrará el mapa en la ubicación
+elegida, el botón "Mark" también colocará una gran "X" azul sobre la ubicación.
+
+Calculadora de coordenadas
+Esta opción abre una calculadora simple que puede convertir entre sistemas de
+coordenadas. Esto es útil para convertir posiciones a los diversos formatos
+utilizados por diferentes grupos de personas. Se puede llamar a esta misma
+calculadora con el botón Calc en algunos de los otros diálogos. Es útil para
+ingresar coordenadas en otros formatos.
+
+Menú Configurar:
+  Color de fondo
+  Esta opción controla el color del fondo detrás de los mapas que tiene
+  mostrados. El color de fondo a menudo está completamente oculto por mapas
+  rellenos (ver abajo).
+
+  Intensidad del Mapa
+  Esto controla el brillo de cualquier gráfico utilizado como mapas. Esta
+  opción solo aparece si ha compilado con soporte GeoTIFF.
+
+  Adjust Gamma Correction
+  Esto le permite aplicar corrección gamma a todos los gráficos de mapas
+  cargados. Los mapas se pueden ajustar individualmente en sus archivos .geo,
+  consulte la sección sobre .geos en "Archivos de mapas y condados WX". Esta opción
+  solo aparece si ha compilado con soporte GraphicsMagick, y no se aplica a
+  mapas GeoTIFF; vea la opción anterior.
+
+  Fuentes
+  Esto le permite establecer el estilo y tamaño de fuente utilizados para
+  etiquetas de mapas.
+
+  Estilo de texto de estación
+  Controla qué fuente y estilo usar para texto de estación y otros.
+
+  Estilo del contorno del icono
+  Esto le permite especificar un esquema que rodea los iconos de estación. Esto
+  ayuda a mejorar la visibilidad en varios fondos.
+
+Desactive todos los Mapas
+Esta opción deshabilita la carga de cualquier mapa. Es más útil cuando se hace
+zoom rápido o desplazamiento, porque ahorra la necesidad de cargar los mapas
+en cada redibujado. Tenga en cuenta que esta opción no se guarda entre sesiones.
+
+Activar Auto Mapas
+
+NOTA: ¡"Activar Auto Mapas" es una característica deprecated que es mejor dejarla
+desactivada!
+
+Cuando está habilitado, cualquier mapa encontrado en el directorio de mapas
+(o cualquier directorio debajo de él) se mostrará si cae dentro de la región
+de pantalla actual. Puede agregar cualquier número de niveles de directorio
+debajo del directorio de mapas principal para sus mapas. Auto maps pasará por
+cualquiera que tenga Activar Auto Mapas habilitado (en el diálogo Propiedades de la Selección de Mapa), los verificará todos y encontrará qué mapa (o parte) debería
+mostrarse. Todos los Mapas se fusionarán en el área de visualización. Si tiene
+una gran cantidad de mapas, mapas muy detallados o una computadora más lenta,
+esto puede ser bastante lento. Cuando esta opción está apagada, se mostrarán
+los mapas seleccionados con Selección de Mapa.
+
+Auto Mapa - Desactivar Mapas de Trama
+Esta opción evita que Auto Maps cargue mapas que son gráficos (imágenes). Solo
+se mostrarán mapas vectoriales en este caso.
+
+Rejillas sobre Mapa
+Cuando está habilitado, esta opción mostrará una cuadrícula en el mapa. Si el
+sistema de coordenadas es UTM, se mostrará una cuadrícula UTM. Si el sistema de
+coordenadas es latitud/longitud, se mostrará una cuadrícula de latitud y
+longitud. A medida que se amplía, la cuadrícula cambia a una resolución más
+fina. El espaciado de la cuadrícula de latitud y longitud se puede ajustar
+manualmente con las teclas "+" y "-".
+
+Activar borde del mapa
+Cuando tanto Enable Map Grid como Enable Map Border están habilitados, se dibuja
+un borde blanco estrecho alrededor del mapa y las líneas de cuadrícula se
+etiquetan usando el sistema de coordenadas seleccionado (File/Configure/
+Coordinate System), y la fuente de borde seleccionada (Map/Configure/Map Labels
+font/Border Font). Si se seleccionan los sistemas de coordenadas UTM o MGRS, las
+líneas de cuadrícula se etiquetarán solo con valores de este y norte en niveles
+de zoom más pequeños que aproximadamente 2048.
+
+Niveles de Mapas
+Cuando está habilitado, esta opción intentará filtrar datos cuando el nivel de
+zoom muestra áreas grandes. Esto no funciona bien con todos los mapas pero
+funcionará con mapas generados a partir de mapas Tiger Line en el sitio
+aprs.rutgers.edu, y con mapas ESRI Shapefile. Esto no reduce mucho los tiempos
+de carga de los mapas, simplemente reduce el desorden de pantalla.
+
+Etiquetas de Mapas
+Esta opción alterna la visualización de etiquetas de mapas incrustadas en
+DosAPRS, WinAPRS, GNIS y formatos de mapas ESRI Shapefile.
+
+Activar áreas coloreadas
+Esta opción controla el relleno de mapas vectoriales. En ciertos casos, puede
+desear eliminar el relleno para ver mapas debajo de los mapas superiores. Este
+es un control global, los mapas pueden tener el relleno de color alternado
+individualmente en el diálogo de propiedades de Selección de Mapa.
+
+Alerta Mapa WX
+
+Esto alterna la visualización de mapas de área de advertencia de condados para
+clima severo. Estos mapas se pueden obtener e instalar de acuerdo con las
+indicaciones en
+https://github.com/Xastir/Xastir/wiki/Xastir-Mapping-Overview y sus diversos
+enlaces. Se muestran en pantalla cuando se reciben mensajes especiales de alerta
+meteorológica, y expiran después de un tiempo o se pueden cancelar remotamente.
+El texto de alerta meteorológica se puede ver en Visualizar|Alerta del tiempo. El
+directorio xastir/Counties debe estar poblado con los archivos correctos de
+NOAA y Shapelib debe estar compilado en Xastir para habilitar esta funcionalidad.
+
+Crear índice de mapas al inicio
+Esta opción controla si el archivo de índice de mapas se crea en el inicio. La
+mayoría de los usuarios deben dejar esto habilitado. Si la marca de tiempo del
+archivo de mapa es más nueva que el archivo de índice de mapas, el mapa se
+indexará.
+
+Índice: agregar mapas nuevos
+Esta opción agrega cualquier nuevo mapa al índice máximo. Las mismas reglas que
+la característica Index New Maps anterior, pero un método manual de invocación.
+
+Índice: reconstruir TODOS los mapas
+Esta opción comienza desde cero, indexando todos los mapas que reconoce en el
+directorio de mapas. Esto es útil si la función Add New Maps está omitiendo
+algunos mapas, tal vez debido a marcas de tiempo antiguas en los archivos de
+mapas. Esta función puede tomar bastante tiempo para completarse si tiene muchos
+mapas.
+
+Menú Contextual del Ratón
+Esta opción trae el menú de opciones normalmente disponible por clic derecho.
+
+Una nota sobre los mapas: Muchos de los mapas vectoriales históricos para los
+EE.UU. fueron creados en datum NAD 1927, mientras que Xastir y otros programas
+APRS(tm) utilizan datum WGS 1984. Si se amplía a un área pequeña en el mapa,
+el cambio de datum puede ser muy notorio. Los mapas topográficos del USGS
+tienen su datum corregido por Xastir mientras se muestran, por lo que las
+posiciones generalmente serán más precisas con esos mapas topográficos.
+
+HELP-INDEX>Archivos de mapas y condados WX
+
+                    Archivos de mapas y condados WX
+
+Tipos de mapas
+Xastir trabajará con varios tipos de archivos de mapas. Todos los archivos de
+mapas DosAPRS, Windows/Mac APRS(tm) se soportan sin necesidad de bibliotecas
+externas adicionales.
+Xastir también puede ser compilado para usar bibliotecas externas para soportar
+imágenes XPixmap (XPM), mapas topográficos GeoTIFF y mapas ESRI Shapefile. La
+capacidad de manejo gráfico de Xastir puede ser muy ampliada compilando con
+soporte GraphicsMagick, habilitando soporte para muchos formatos gráficos como
+mapas. Xastir soporta mapas de alertas meteorológicas en formato ESRI Shapefile,
+disponibles de NOAA. Consulte la página del wiki Github
+https://github.com/Xastir/Xastir/wiki/Installing-Xastir para obtener detalles.
+
+Los detalles de ubicaciones para obtener muchos de los tipos de mapas anteriores
+se encuentran en el archivo
+https://github.com/Xastir/Xastir/wiki/Xastir-Mapping-Overview y enlaces debajo
+de él.
+
+Ubicaciones de mapas
+Cualquier archivo de mapa debe almacenarse en el directorio
+/usr/local/share/xastir/maps en su computadora. Esta ubicación puede ser
+diferente en algunos sistemas, según cómo se compiló/instaló Xastir. Puede
+crear cualquier número de directorios bajo este directorio para ayudar a
+organizar y separar sus datos. Los mapas se cargarán en orden alfanumérico a
+menos que se especifique capas.
+
+Las sugerencias sobre la instalación y organización de mapas se encuentran en
+el wiki Github de Xastir en
+https://github.com/Xastir/Xastir/wiki/Xastir-Mapping-Overview.
+Los mapas en formato gráfico de píxeles necesitan en realidad una combinación
+de dos archivos, un archivo de datos con un mapa de píxeles gráfico (.xpm) (u
+otro formato si compiló con GraphicsMagick), y un archivo de calibración (.geo).
+El archivo .xpm es el formato gráfico estándar, disponible sin bibliotecas
+adicionales. Si desea ahorrar espacio de almacenamiento puede usar gzip para
+comprimir esos archivos ("gzip map.xpm" resultará en "map.xpm.gz"). Xastir
+detecta esto automáticamente durante la carga de mapas. Puede usar
+XView/Gimp/GraphicsMagick y otros programas para convertir imágenes gif, jpg y
+tif en este formato si no tiene soporte para muchos tipos de imágenes compilado
+(GraphicsMagick). Si tiene problemas con mapas en formato xpm, intente cargar
+y guardar los gráficos con Gimp primero, para convertir todos los nombres de
+color desconocidos en la representación binaria.
+
+El archivo .geo es un archivo de datos de texto que vinculará la imagen a una
+ubicación en el mundo. Aquí hay un ejemplo de un archivo .geo que cubrirá todo
+el mundo con el mapa world1.xpm:
+
+FILENAME   world1.xpm
 #          x          y        lon         lat
 TIEPOINT   0          0        -180        90
-TIEPOINT   640        320      180         -90
+TIEPOINT   639        319      180         -90
+IMAGESIZE  640        320
 
-Este es un archivo simple, con 4 componentes básicos.
-La primera línea especifica este archivo data .geo es usado,
-este archivo debe estar en el mismo directorio como el archivo de .geo.  
+Los archivos .geo pueden tener muchos elementos:
 
-La segunda línea muestra un comentario;
-cualquier línea con el carácter como un "#" será ignorado.  
-  
-Las últimas dos líneas son para conectar un pixel en la posición x,y  
-en la imagen a una posición lat y long en la mundo. Dos puntos unidos  
-son necesitado y debe estar cerca de la esquina izquierda superior 
-y la esquina derecha más abajo de la imagen.  
-  
-Usar archivo pixmap con xastir, use el selector de mapa y seleccione el archivo .geo
-para incluir la imagen en la vista del mapa actual.  
+FILENAME <filename>
+Esto especifica el nombre de archivo de una imagen de mapa a cargar desde el
+disco local.
 
-Por razones de velocidad, otras líneas de opciones pueden ser anexada
-en el archivo .geo.
-Aquí algunos ejemplos del formato modificado:
+URL <https://website>
+Esto especifica la URL de una imagen de mapa a cargar desde un sitio web o ftp.
+Solo GraphicsMagick.
 
-ARCHIVO         Agnes_Mountain.xpm.gz
-#
-#               X       Y       Lon             Lat
-#               ----    ----    -------------   -----------
-TIEPOINT        0       0       -121.00120491   48.37481943
-TIEPOINT        1337    1999    -120.87619806   48.24982052
-#
-#EDGES  BOTTOM          TOP             LEFT            RIGHT
-EDGES  48.24982052  48.37481943  -121.00120491  -120.87619806
+TIEPOINT <x-pixel> <y-pixel> <longitude> <latitude>
+Se requieren dos puntos de amarre, y más de 2 serán ignorados.
+Estas dos líneas son para conectar una posición de píxel x,y en la imagen a una
+posición de lat y long en la tierra. Los puntos deben estar lo más cerca posible
+de la esquina superior izquierda y la esquina inferior derecha de la imagen para
+la mejor precisión. La latitud/longitud se especifica en grados decimales.
 
-La línea EDGES especifica el min/max bordes del mapa. El mencionado
-mapa arriba es inclinado ligeramente, el cual es el porqué los números
-no corresponden a la esquina 'tiepoints' exactamente. Xastir usará esa
-información saltar el mapa si no encaja en la vista actual.
+IMAGESIZE <píxeles horizontalmente> <píxeles verticalmente>
+Esto especifica el tamaño de la imagen en píxeles. Si esto no está establecido,
+la imagen se cargará en cada redibujado de mapa, independientemente de si está
+en pantalla o no.
+IMAGESIZE es una OPCIÓN REQUERIDA si se especifica una URL. Para archivos
+locales, es un parámetro opcional (usamos GraphicsMagick para consultar el
+ tamaño de la imagen para archivos locales).
 
-Mapas geoTIFF son una combinación de dos archivos también:
-un archivo .tif y un .fgd. El archivo .tif es el actual data mapa.
-El archivo .fgd necesita solamente tener cuatro líneas como estas:
+DATUM <datum>
+Esta característica no está implementada.
+Tiempo de actividad
+PROJECTION <projection>
+Esta característica solo está parcialmente implementada, por defecto es
+"LatLon", otra posibilidad es "TM" para especificar que el mapa está en
+proyección Transverse Mercator.
+
+# <anything>
+Cualquier línea con el primer carácter de un '#' será ignorada.
+
+Mejoras de imagen específicas de GraphicsMagick:
+
+GAMMA
+ej: GAMMA 1.2    o    GAMMA 1.2,2.0,1.2
+El primero cambiará gamma general para esta imagen, el segundo aclarará
+más el verde que el rojo o azul.
+
+CONTRAST
+ej: CONTRAST 0    o    CONTRAST 1
+No parece hacer mucho, otros valores no hacen diferencia.
+
+NEGATE
+ej: NEGATE 0    o    NEGATE 1
+0 negará todos los colores, 1 solo los colores en escala de grises.
+
+EQUALIZE
+Sin argumento.
+
+NORMALIZE
+Sin argumento.
+
+LEVEL <black_point, mid_point, white_point>
+ej: LEVEL 0,1,65535
+Estos valores parecen ser los valores predeterminados.
+
+MODULATE <brightness, saturation, hue>
+ej: MODULATE 90,150,100
+Estos son porcentajes, 100,100,100 es el valor predeterminado.
+
+REFRESH <seconds>
+ej: REFRESH 900
+Esta etiqueta se utiliza para URLs dinámicas, como radar meteorológico, donde
+desea que Xastir redibujar automáticamente el mapa a un intervalo especificado.
+Al agregar esta etiqueta a radares meteorológicos .geos, puede ver el clima
+moverse a través de su pantalla. Xastir contiene solo un contador de intervalo,
+por lo que el intervalo REFRESH cargado más pequeño se aplica a todos los mapas
+seleccionados.
+
+TRANSPARENT
+Color a eliminar del fondo (hacerlo transparente). Use un número, 0=negro. Las
+imágenes asignadas a mapas utilizan el valor del mapa, por lo que blanco es
+generalmente 0xffffffff (32 bits de 1s). Los valores deben estar en
+hexadecimal, y deben ser precedidos por "0x". El valor se puede obtener
+utilizando nivel de depuración 16. El primer número de los cuatro números
+después de "Color allocated is" es el índice del mapa de colores.
+
+CROP <left top right bottom>
+Elimina bordes (los hace transparentes). Los valores están en píxeles con
+(0,0) en la esquina superior izquierda. Un buen valor para las imágenes de
+radar NWS de 620x620 es "CROP 35 20 616 600"
+
+Archivos .geo especiales/no estándar:
+
+WMSSERVER
+Permite el uso de Servicios de Mapas Web (WMS). Varios ejemplos de este tipo
+de fuente de mapas en línea se instalan automáticamente en el directorio de
+mapas, como "USTigermap.geo" y los mapas de radar meteorológico en el directorio
+"NWS".
+
+OSMSTATICMAP
+OSM_TILED_MAP
+Permite el uso de servidores OpenStreetMap que proporcionan una imagen estática
+única o pequeños mosaicos de mapas. Varios ejemplos cuyos nombres comienzan con
+"OSM_" se instalan en el directorio de mapas.
+
+
+Los mapas GeoTIFF son una variante del formato de imagen TIFF con etiquetas de
+referencia geográfica adicionales incrustadas. Los de los EE.UU. generalmente han
+venido con dos archivos: un .tif y un archivo .fgd. El archivo .tif es el datos
+del mapa real. El archivo .fgd es un archivo de metadatos que se conforma a un
+estándar federal, pero para los propósitos de Xastir solo necesita contener
+cuatro líneas como esta (pero puede contener muchas otras líneas):
 
 1.5.1.1   WEST BOUNDING COORDINATE:  -122.000000
 1.5.1.2   EAST BOUNDING COORDINATE:  -120.000000
 1.5.1.3   NORTH BOUNDING COORDINATE:  48.000000
 1.5.1.4   SOUTH BOUNDING COORDINATE:  47.000000
 
-Xastir usa esas cuatro líneas en su calculaciones para determinar los puntos
-de la esquina del mapa, y si o no el mapa vuelve al actual punto de vista
-(asi que el puede decidir si saltarlo). Si su data mapa es un mapa topo USGS,
-el archivo .fgd podría ser leídamente disponible a usted.
-Una forma anexada en Xastir es la abilidad hacer traslaciones datum desde
-NAD 1927 a WGS 84 datum, el cual hace el mapa topo USGS mucho más posicionalmente
-exacto sobre la pantalla en Xastir.
+Xastir usa solo esas cuatro líneas en sus cálculos para determinar los puntos
+de esquina de un mapa, para ver si el mapa se ajusta en la ventana gráfica
+actual (para decidir si puede omitirlo). Si sus datos de mapa son mapas
+topográficos del USGS, el archivo .fgd debería estar fácilmente disponible para
+usted. Si no es así, el script mapfgd.pl puede crearlo para usted. Si no tiene
+un archivo .fgd, el mapa se cargará bien, pero los bordes blancos no se
+recortarán y el tamaño y la rotación pueden estar un poco desactivados. Una
+característica añadida en Xastir es la capacidad de hacer traslaciones de datum
+de NAD 1927 a WGS 84 datum, lo que hace que los mapas topográficos del USGS
+sean mucho más precisos en la pantalla de Xastir.
 
-Mapas Condado WX  
-Todos los mapas Condado WX deben guardarse en el directorio de
-/usr/local/share/xastir/Counties.  Hay formatos diferentes para los mapas,
-pero de cualquier modo este directorio tendrá directorios (usted podrías
-necesitar crearlos) bajo este  para cada estado (2 abreviaciones de letras).
-
-               /usr/local/share/xastir/Counties
-                                         /CO/
-                                         /CO/COPARK.map
-                                         /CO/CODOUGLA.map
-                                         /CO/COJEFFER.map
-                                         /CO/COZ001.map
-                                         /CO/COZ002.map
-                                         /CO/COZ003.map
-                                         /NJ/
-                                         /NJ/NJOCEAN.map
-                                         /NJ/NJBERGEN.map
-                                         /NJ/NJMONMOU.map
-                                         /NJ/NJZ001.map
-                                         /NJ/NJZ002.map
-                                         /NJ/NJZ003.map
+Xastir puede usar mapas topográficos GeoTIFF del USGS directamente desde la
+unidad de CD. Monte el disco manualmente o use auto-mounter para hacerlo por
+usted, y asegúrese de tener un enlace simbólico creado en su directorio de
+mapas que apunte a donde montó su unidad de CD-ROM. ¡Eso es todo!
 
 
-Aqui estan dos lugares en el Internet donde usted puedes obtener esos mapas:
+Los mapas ESRI Shapefile también son una combinación de varios archivos, un
+archivo .shp, un archivo .dbf y un archivo .shx. Solo necesita seleccionar
+el archivo .shp para cargar el mapa, pero los otros(s) deben estar presentes
+para que el mapa se cargue correctamente.
+Además, a menos que su conjunto de shapefile coincida con los que Xastir ya
+tiene reglas de renderización, tendrá que construir un archivo "dbfawk" para
+que Xastir lo haga bonito.
 
-ftp://aprs.rutgers.edu/pub/hamradio/APRS/NWSCounties/
-http://home.att.net/~kg5qd1/Maps.html
 
-Como los mensajes NWS son recibidos, diferentes areas obtendrán un tintado
-hacia las áreas designadas.
-Ellas son coloreadas para especificar diferentes tipos de alertas. 
+Mapas de condados WX
 
-Los colores originales fueron:
+Todos los mapas de condados WX deben almacenarse en el
+/usr/local/share/xastir/Counties y Xastir solo soporta el estándar ESRI
+Shapefile para estos. La instalación se explica en
+https://github.com/Xastir/Xastir/wiki/Xastir-Mapping-Overview. Debe tener
+Shapelib compilado en.
 
-Cian para el asesor, amarillo para alerta del tiempo,
-rojo para advertencia, naranja para alerta cancelada, azul real para pruebas,
-y verde para niveles de indeterminadas alarmas.
+A medida que se reciben mensajes del NWS, diferentes áreas se teñirán para
+designar áreas de preocupación. Están codificadas por colores para especificar
+diferentes tipos de alertas. Los colores son: Cyan para aviso, amarillo para
+vigilancia, rojo para advertencia, naranja para alerta cancelada, azul real para
+pruebas, y verde para niveles de alerta indeterminados. La coloración se hace
+con un patrón de píxeles que muestra el tipo de alerta, si es posible
+determinarlo. Estos cambios se hicieron para que los mapas subyacentes aún
+puedan verse debajo de las áreas de alerta meteorológica, y para que el tipo
+de alerta pueda determinarse más fácilmente, ya que a veces es difícil hacer
+coincidir las alertas en pantalla y en el diálogo de alertas meteorológicas.
+La visualización de alertas meteorológicas se puede activar/desactivar a través
+del menú Mapas.
 
-Con la última versión de Xastir los colores pueden ser diferentes
-debido a un cambio mayor: 
-Las áreas que ahora son tintadas en lugar de relleno de color,
-y la dependencia en el tintado debajo los colores.
+HELP-INDEX>Menú de Estaciones
 
-Este cambio fue hecho asi que los mapas estando debajo de esto pueden
-mantenerse visible debajo en las áreas de alertas del tiempo. 
-Las alertas del tiempo podrían ser fijada en on/off vía el menú del mapa también.
+                             Menú de Estaciones
 
+Estas opciones le permitirán controlar los datos que se muestran alrededor de
+las estaciones en el mapa. También le permitirá rastrear y encontrar estaciones,
+y limpiar estaciones y pistas en la base de datos y del mapa.
+
+Encontrar Estación
+Vea el tema de ayuda "Localización de una Estación".
+
+Rastrear Estación
+Vea el tema de ayuda "Rastreo de una Estación"
+
+Obtener Pista de Findu
+Descarga datos históricos de pista de findu.com. Las barras deslizantes
+controlan el punto de inicio y la duración de los datos descargados. Por
+ejemplo, si deseaba ver la pista que ocurrió hace dos días, todo el día, podría
+establecer el primer deslizador a 48 horas (hora de inicio hace dos días) y el
+segundo deslizador a 24 horas para obtener exactamente un día de datos, desde
+el inicio hasta 24 horas después.
+
+
+Exportar todo
+Este submenú permite guardar datos para todas las estaciones en archivos [o
+bases de datos]
+
+    Exportar a archivo KML
+      Guarda todas las estaciones y sus pistas en un archivo de Lenguaje de
+      Marcado de Agujeros de Llave en ~/.xastir/tracklogs. El nombre de archivo
+      será la fecha y hora actual con extensión .kml, p. ej.
+      20080125-033045.kml. Los archivos KML también se pueden escribir de forma
+      regular utilizando Instantáneas KML en el menú de archivo.
+
+    Guardar en bases de datos abiertas [No implementado aún]
+      [La interfaz de almacenamiento a base de datos actualmente solo se
+      implementa a través de diálogos de interfaz de base de datos SQL
+      individuales]
+
+    Para guardar una instantánea png del mapa actual, use Archivo->Activa PNG Instantánea
+
+Filtrar Datos
+Este submenú permite el filtrado de los símbolos mostrados:
+
+  Seleccionar Ninguno
+    Determina si los símbolos deben dibujarse en el mapa. Las otras opciones
+    dependen de que esto esté habilitado.
+
+  Seleccionar Mío
+    Determina si su propia estación se muestra en el mapa.
+
+  Seleccionar vía TNC
+   Activación/desactivación global para mostrar datos recibidos a través de un
+   TNC, pero se puede reducir:
+
+   Seleccionar Directo
+     Esta opción solo muestra estaciones escuchadas directamente (no
+     digipeated).
+
+   Seleccionar vía Digi
+     Esta opción muestra estaciones escuchadas indirectamente a través de un
+     digipeater.
+
+  Seleccionar Red
+    Esta opción muestra estaciones con datos recibidos a través de Internet.
+
+  Incluir Datos Expirados
+    Hace que Xastir continúe mostrando los datos de la estación que normalmente
+    desaparecen cuando el símbolo se desvanece. El tiempo de expiración se puede
+    ajustar en el menú Archivo|Configurar|Predefinidos.
+
+
+  Seleccionar Estaciones
+    Activación/desactivación global para mostrar estaciones, pero se puede
+    reducir:
+
+    Seleccionar Estaciones Fijas
+      Esta opción muestra estaciones estacionarias.
+
+    Seleccionar Estaciones en Movimiento
+      Esta opción muestra estaciones con múltiples posiciones o velocidad
+      distinta de cero
+
+    Seleccionar Estaciones WX
+      Esta opción muestra Estaciones Meteorológicas.
+
+     Seleccionar Estaciones CWOP WX
+      Esta opción incluye la visualización de datos meteorológicos de
+      ciudadano (no radioaficionado). Actualmente, Xastir reconoce cualquier
+      estación que comience con las letras C hasta G, cuya segunda letra es "W",
+      y que tenga cuatro dígitos después como estaciones CWOP.
+
+  Seleccionar Objetos/Elementos
+    Activación/desactivación global para mostrar objetos/elementos, pero se
+    puede reducir:
+
+    Seleccionar Objetos/Elementos WX
+     Esta opción muestra Objetos y Elementos meteorológicos. Esto incluye
+     tormentas tropicales y estaciones meteorológicas remotas.
+
+    Seleccionar Objetos/Elementos de Indicador de Agua
+     Esta opción alterna la visualización de objetos de indicador de agua (/w).
+
+    Seleccionar Otros Objetos/Elementos
+     Esta opción habilita o deshabilita la visualización de objetos que no se
+     enumeran arriba.
+
+
+Filtrar Visualización
+Este submenú permite el filtrado de los datos mostrados:
+
+  Mostrar Indicativo
+  Determina si el indicativo se muestra.
+
+    Etiquetar Puntos de Pista
+    Esta opción incluye indicativos a lo largo de las pistas para ayudar a
+    identificar qué puntos pertenecen a qué estaciones.
+
+  Mostrar Símbolo
+  Determina si el símbolo se muestra a la izquierda del indicativo.
+
+    Girar Símbolo
+    Algunos símbolos cambiarán su orientación para mostrar la dirección en la
+    que se están moviendo.
+
+  Mostrar Pista
+  Cuando está habilitado, cualquier estación móvil dejará un rastro de línea
+  coloreada. Ahora mostramos tantas ubicaciones como tenemos en nuestra base de
+  datos (el antiguo límite era 100). Los segmentos de pista largos (más de 2
+  grados de latitud o 2 grados de largo), o segmentos con más de 45 minutos de
+  retardo entre los puntos no se mostrarán. Los puntos duplicados también se
+  eliminan de la pista (equipo de SAR que regresa a la base: el último segmento
+  puede no mostrarse debido a que el punto de partida aparece dos veces en la
+  lista de pistas).
+
+  Mostrar Curso
+  Cuando está habilitado, el texto verde aparecerá debajo del indicativo. Esto
+  mostrará el último curso conocido (en grados) en el que se estaba moviendo la
+  estación.
+
+  Mostrar Velocidad
+  Cuando está activado, el texto rojo aparecerá debajo del indicativo (o curso).
+  Esto mostrará la última velocidad conocida de la estación.
+
+    Mostrar Velocidad Corta
+    Esta opción elimina la visualización de las unidades de medida de velocidad.
+
+  Mostrar Altitud
+  Cuando está habilitado, el texto azul aparecerá arriba del indicativo. Esto
+  mostrará la última altitud conocida de la estación.
+
+
+  Mostrar Información Meteorológica
+  Activación/desactivación global para mostrar información meteorológica, pero
+  se puede reducir:
+
+    Mostrar Texto Meteorológico Cuando está habilitado, los datos meteorológicos
+    más recientes (temperatura, velocidad del viento/curso/ráfagas, humedad) se
+    muestran. Esto se puede ajustar con la siguiente opción:
+
+      Mostrar Solo Temperatura Muestra solo los datos de temperatura para la
+      estación.
+
+    Mostrar Barba de Viento Cuando está habilitado, se dibuja una barba de
+    viento que muestra la dirección y la velocidad del viento para todas las
+    estaciones mostradas que reportan esta información.
+
+
+  Mostrar Ambigüedad de Posición Cuando está habilitado, se sombrea el área en
+  la que la estación que utiliza ambigüedad de posición puede estar ubicada,
+  con la estación relevante en el centro.
+
+  Mostrar Potencia/Ganancia Cuando está activado, se mostrarán Círculos de
+  Potencia/Ganancia. Los círculos superpuestos indican que las estaciones
+  teóricamente están dentro del rango simplex entre sí. Esto solo es
+  aproximadamente preciso, especialmente en áreas de terreno variable.
+
+    Usar Potencia/Ganancia Predeterminada Habilita una configuración de
+    potencia/ganancia predeterminada como se especifica en la especificación
+    APRS(tm).
+
+    Mostrar Potencia/Ganancia Móvil Habilita círculos de potencia/ganancia para
+    estaciones móviles.
+
+
+  Mostrar Atributos DF Cuando está habilitado, se mostrarán todos los
+  círculos/líneas de DF en la pantalla.
+
+  Habilitar Predicción Muerta Cuando está habilitado, las posiciones de las
+  estaciones se estiman en función del curso y la velocidad pasados. La
+  velocidad de recálculo debería ser razonable, pero se puede ajustar en el
+  archivo de configuración.
+
+    Mostrar Arco Muestra un arco que se expande de la distancia de viaje máximo
+    esperada, la ubicación y el curso dados del curso y la velocidad pasados.
+    El arco se convierte lentamente en un círculo a medida que el informe de
+    posición envejece.
+
+    Mostrar Curso Muestra un curso esperado y una distancia recorrida por la
+    estación, asumiendo que el curso no ha cambiado.
+
+    Mostrar Símbolos Muestra una versión fantasmal del símbolo de las estaciones
+    en la posición esperada, asumiendo que la estación ha continuado a su curso
+    y velocidad actuales.
+
+
+  Mostrar Dist/Rumbo Cuando está habilitado, dos líneas de texto se mostrarán
+  en el lado izquierdo del icono de las estaciones. La línea superior contendrá
+  la distancia desde su estación a esta estación. La línea inferior contendrá el
+  curso desde su estación a esta estación.
+
+  Mostrar Edad del Último Informe Muestra el tiempo desde que se escuchó por
+  última vez la estación.
+
+Recargar Historial de Objetos/Elementos Esto recargará el archivo
+~/.xastir/config/objects.log utilizado para la persistencia de Objetos y
+Elementos. Esto es necesario si edita el archivo mientras Xastir se está
+ejecutando.
+
+Borrar Historial de Objetos/Elementos Esto borrará el archivo
+~/.xastir/config/objects.log utilizado para la persistencia de Objetos y
+Elementos. Se recomienda que seleccione y elimine manualmente todos los
+Objetos y Elementos que posee antes de hacer esto, de lo contrario pueden
+permanecer en las pantallas de otros usuarios de APRS(tm).
+
+Borrar Todos los Indicativos Tácticos Borra todos los indicativos tácticos
+asignados. Esto tendrá efecto en el próximo redibujado. Tenga en cuenta que
+esto NO borrará los indicativos tácticos en las pantallas de otras personas si
+los ha publicado a través de un mensaje a "TACTICAL" (vea el texto de ayuda
+para "Enviar Mensaje").
+
+Borrar Historial de Indicativo Táctico Esto elimina el archivo de historial
+de indicativo táctico, lo que significa que los indicativos tácticos asignados
+no permanecerán permanentes entre reinicios de Xastir. Tenga en cuenta que
+esto NO borrará los indicativos tácticos en las pantallas de otras personas si
+los ha publicado a través de un mensaje a "TACTICAL" (vea el texto de ayuda
+para "Enviar Mensaje".
+
+Borrar Todas las Pistas Esto borrará todos los datos de seguimiento de línea
+de la base de datos de estaciones y actualizará la pantalla. Esta opción es
+quizás útil si tiene poca memoria o simplemente desea una pantalla sin
+desorden. También puede borrar las pistas de estaciones individuales desde el
+diálogo Información de la Estación.
+
+Borrar Todas las Estaciones Esto borrará todos los datos de la base de datos
+de estaciones excepto el suyo. Esta opción es quizás útil si tiene poca
+memoria o simplemente desea desorden su pantalla.
+
+HELP-INDEX>Mensajes y el menú de Mensajes
+
+                  Mensajes y el menú de Mensajes
+
+Enviar Mensaje a y Abrir mensajes de grupo
+
+Estos son muy similares. "Enviar mensaje a" enviará sus mensajes a una
+estación y solo recibirá datos de esa estación. Los mensajes de grupo son más
+generales: puede recibir cualquier mensaje para el grupo y enviará sus mensajes
+a ese nombre de grupo. El código de mensajes de grupo no está completamente
+implementado aún y varios problemas aún deben resolverse. El archivo "groups"
+se busca en ~/.xastir/config. Aquí es donde se almacenan los grupos de los que
+es miembro. Como se dijo anteriormente, la funcionalidad de "grupos" puede que
+aún no esté completa.
+
+En algún momento en el futuro, el envío de boletines debería agregarse a este
+menú también. Aún no está codificado.
+
+Cada una de estas dos pantallas contiene un cuadro de mensaje, una línea de
+llamada, una línea de mensaje y varios botones. Primero debe ingresar la
+llamada del grupo o estación que desea contactar. Una vez hecho esto, cualquier
+nuevo mensaje que haya llegado de esa estación a usted se mostrará. Si la
+estación le está enviando información y no hay una ventana de mensaje abierta,
+se abrirá automáticamente una nueva ventana (hasta 10) con el indicativo de esa
+estación rellenado para usted. Ahora puede ingresar un mensaje en la línea de
+mensaje. El mensaje puede ser más largo que la línea de mensaje, y alcanzará
+un máximo de aproximadamente 250+ caracteres. Una vez que ingrese su mensaje,
+hacer clic en el botón "¡Enviar Ahora!" enviará su mensaje. El botón "¡Enviar
+Ahora!" se desactivará hasta que su mensaje sea completamente reconocido. Cualquier
+mensaje que reciba se ordenará por el número de línea y se colocará en la ventana
+de mensaje. Si está en modo de grupo, cada línea mostrará el indicativo desde
+donde se envió el mensaje seguido del mensaje en sí. Actualmente, los mensajes de
+grupo se ordenan por indicativo y luego por número de línea. Cuando haya
+terminado de enviar mensajes, hacer clic en el botón de salida cerrará la
+ventana. También hay otros botones disponibles: El botón "Nueva Llamada" le
+permitirá ver datos antiguos que una estación ha enviado. Escriba la llamada y
+haga clic en este botón; se mostrará información antigua. También puede usar
+este botón para cambiar la llamada de la estación con la que está hablando.
+Ingrese la nueva llamada y haga clic en el botón. El botón "Borrar Historial
+de Mensajes" borrará cualquier mensaje que se muestre en la ventana de mensaje.
+"Cancelar Mensajes Pendientes" cancelará todos los mensajes en la cola de
+transmisión que aún no han sido reconocidos por la estación remota. Después de
+cancelar los mensajes pendientes o recibir un paquete de reconocimiento de la
+estación remota, puede enviar nuevos mensajes a la estación remota. Xastir le
+permitirá escribir con anticipación, por lo que puede seguir escribiendo si no
+desea esperar los reconocimientos.
+
+Los mensajes en respuesta a los anteriores intentarán usar la ruta del mensaje
+recibido para evitar inundar el sistema con mensajes de difusión. Puede ajustar
+la ruta en el diálogo de envío de mensaje, o las rutas predeterminadas
+establecidas en el control de interfaz se usarán si deja esto en blanco. La
+ruta se puede establecer para cada mensaje enviado, pero una vez que se envía
+un mensaje, la ruta permanece fija para ese mensaje en particular.
+
+Cada mensaje saliente permanece resaltado hasta que sea reconocido por la
+estación remota. Si agota el tiempo o si cancela los mensajes pendientes, esos
+mensajes permanecerán resaltados a menos que borre el historial de mensajes.
+
+Para publicar indicativos TACTICAL a otras estaciones Xastir y APRS+SA, así
+como asignar esos indicativos tácticos localmente: Envíe un mensaje a
+"TACTICAL" con el cuerpo del mensaje que contenga líneas algo como:
+
+  callsign-1=TAC1;callsign-2=TAC2;callsign-3=TAC3
+
+Para eliminar estos indicativos tácticos más tarde de pantallas locales Y
+remotas, asegúrese de que el/los mensaje(s) original(es) que los asignan
+haya(n) agotado el tiempo o sido cancelado, luego envíe un mensaje como este
+y déjelo reintentar hasta que agote el tiempo (asigna indicativos tácticos en
+blanco a los indicativos originales, eliminando así la asignación):
+
+    callsign-1=;callsign-2=;callsign-3=
+
+Borrar todos los mensajes salientes
+Esto borrará todos los mensajes sin reconocer que ha enviado.
+
+Consulta General de Estaciones
+Esto envía un paquete ?APRS?, que debería hacer que todas las estaciones
+locales reporten su posición y/o estado. La mayoría del software ignora esta
+consulta, porque responder a ella causaría masivas inundaciones de datos.
+
+Consulta de Estaciones IGate
+Esto envía un paquete ?IGATE?, que debería hacer que todos los IGates locales
+respondan con sus capacidades.
+
+Consulta de Estaciones WX
+Esto envía un paquete ?WX?, que debería hacer que todas las estaciones
+meteorológicas locales reporten su posición y meteorología.
+
+Modificar Mensaje de Respuesta Automática
+Esto establecerá el mensaje que se envía como Respuesta Automática.
+
+Habilitar Mensaje de Respuesta Automática
+Esto activará una respuesta automática cuando se reciba un mensaje entrante.
+
+Modo de Reconocimiento de Satélite
+Este modo deshabilita el envío de mensajes de reconocimiento en respuesta a
+mensajes recibidos. Los mensajes aún se reconocen utilizando el sistema de
+respuesta-reconocimiento. Cuando opera sobre un satélite, está claro que su
+mensaje llegó, porque lo escuchará repetido. La estación receptora que envía un
+reconocimiento independiente solo agrega QRM.
+
+HELP-INDEX>Menú de Interfaces
+
+                         Menú de Interfaces
+
+Este menú contiene opciones relacionadas con la interfaz.
+
+Control de Interfaz
+Esta opción muestra una ventana donde puede activar y desactivar sus interfaces
+configuradas, así como agregar, eliminar o configurar interfaces. Vea el tema
+de ayuda "Configurar Interfaces".
+
+Opciones Desactivar Transmisión
+Estas opciones desactivan la transmisión de todo, la propia posición u objetos
+propios. Estas son opciones globales y afectan todas las interfaces. La mayoría
+de las interfaces también tienen una opción para desactivar la transmisión en
+esa interfaz específica en sus menús de configuración.
+
+Habilitar Puerto del Servidor
+Esto habilita/deshabilita sockets de escucha TCP y UDP en el puerto 2023. Puede
+conectar otros clientes APRS(tm) al puerto TCP para enviar/recibir datos
+APRS(tm). Una vez que se autentiquen, podrán enviar datos a Xastir. Sin
+autenticación, podrán recibir todos los datos de TNC e INET que Xastir recibe.
+Tenga en cuenta que CUALQUIER usuario con las credenciales adecuadas puede
+entrar en los puertos TCP o UDP si están habilitados. El único de estos dos
+puertos que actualmente puede enviar a RF es el puerto del Servidor UDP. El
+puerto TCP no puede.
+
+    "user WE7U-13 pass XXXX vers XASTIR 1.3.3"
+
+Conecte otro cliente APRS(tm) a ese puerto y debería autenticarse y poder
+enviar a cualquier servidor al que esté conectado Xastir, así como recibir
+paquetes de todos los puertos/servidores a los que está conectado Xastir.
+
+También debería tener un binario llamado "xastir_udp_client" que pueda enviar
+paquetes al puerto de escucha UDP. Invóquelo así:
+
+ xastir_udp_client localhost 2023 <callsign> <passcode> "APRS Packet Goes Here"
+
+Actualmente eso inyectará el paquete en las rutinas de decodificación de Xastir
+y lo enviará a cualquier cliente conectado a TCP. También lo igatearía a INET si
+tiene habilitado igateo. Enviará el paquete a los puertos de RF como paquetes
+de terceros solo si agrega la bandera "-to_rf" después del código de acceso así:
+
+ xastir_udp_client localhost 2023 <callsign> <passcode> -to_rf "APRS Packet"
+
+El cliente UDP es útil para generar e inyectar paquetes APRS desde scripts
+externos. También se puede usar para obtener el indicativo del servidor xastir
+remoto usando la bandera -identify:
+
+ xastir_udp_client localhost 2023 <callsign> <passcode> -identify
+
+Transmitir ahora
+Hace que todas las interfaces que tengan habilitada la transmisión (vea
+configure|interfaces) transmitan un paquete de posición. Se desactivará si está
+seleccionada la opción Desactivar Transmisión: TODOS.
+
+Si tiene GPSMan instalado, tiene estas opciones de menú adicionales mostradas:
+
+Obtener Pista GPS
+Descargue un conjunto de puntos de pista de un GPS adjunto.
+
+Obtener Rutas GPS
+Descargue un conjunto de rutas de un GPS adjunto.
+
+Obtener Puntos de Ruta GPS
+Descargue un conjunto de puntos de ruta de un GPS adjunto.
+
+Obtener Puntos de Ruta de Garmin RINO
+Agarre puntos de ruta de un Garmin RINO adjunto, cree Objetos APRS(tm) de
+cualquier punto de ruta que comience con "APRS".
+
+HELP-INDEX>Cuadro de información de la estación - Búsqueda de FCC y RAC
+
+                  Cuadro de información de la estación - Búsqueda de FCC y RAC
+
+Información de la Estación mostrará cualquier dato decodificado por Xastir.
+
+Puede asignar (solo localmente) indicativos tácticos a estaciones desde aquí,
+haciendo clic en el botón "Asignar Indicativo Táctico". Esto hará que la
+estación en la pantalla se muestre como el indicativo táctico en lugar de su
+indicativo. Asignar un indicativo táctico en blanco borra esta función, y
+también se puede borrar para todas las estaciones en el menú Estaciones. Esta
+función asigna indicativos tácticos solo a la estación Xastir local, pero vea
+abajo para publicarlos a otros.
+
+Para publicar indicativos tácticos por el aire a otras estaciones Xastir y
+APRS+SA (así como asignarlos localmente), vea la sección de ayuda "Enviar
+Mensaje".
+
+"Habilitar Actualizaciones Automáticas" hará que la ventana se actualice
+frecuentemente con la información más reciente.
+
+La información disponible puede incluir: Número de paquetes escuchados, el
+tiempo escuchado por última vez, el dispositivo desde el que llegó el paquete,
+comentarios de la estación, potencia/altura/ganancia de la estación,
+curso/distancia desde su estación, información meteorológica y posiciones
+actuales y anteriores.
+
+Para estaciones móviles, un registro de pista sigue con las entradas más
+recientes en la parte superior. Un '+' al frente indica que comienza una nueva
+pista en ese punto (si había un gran intervalo de tiempo o posición). Una
+estrella al final de una línea indica que esta estación podría ser escuchada
+directamente (sin digi) en esa posición específica. Las posiciones van seguidas
+del cuadrado de cuadrícula de Maidenhead de 6 dígitos en el que se ubicó la
+estación en ese punto.
+
+Para su propia estación, hay un campo "Echoed from", enumerando los últimos
+seis repetidores que lo escucharon directamente. Esto es útil para establecer
+rutas no genéricas.
+
+Actualmente, dos filas de cuatro botones aparecen en la ventana Información de
+la Estación. Algunas de las etiquetas en los botones cambian según el tipo de
+estación con la que esté tratando.
+
+Para objetos/elementos:
+
+Guardar    Modificar  En Blanco  Cerrar
+Pista      Objeto/
+           Elemento
+
+Versión    Consulta   Mensajes   Consulta
+de         de Rastreo No         de Estaciones
+Estación              Reconocidos Directas
+
+Para otras estaciones:
+
+Guardar    Enviar     Buscar     Cerrar
+Pista      Mensaje    Base de
+                      Datos FCC
+                      (RAC)
+
+Versión    Consulta   Mensajes   Consulta
+de         de Rastreo No         de Estaciones
+Estación              Reconocidos Directas
+
+"Consulta de Versión de Estación" cambia a "Borrar Pista" para estaciones
+móviles. El botón Borrar Pista borrará cualquier pista de seguimiento de línea
+para esta estación que actualmente esté almacenada o se muestre en el mapa.
+
+"Guardar Pista" guardará la pista de la estación en un archivo en el disco. El
+formato es similar al utilizado por receptores GPS, pero su especificación
+podría cambiar (mejorarse) en futuras versiones. Actualmente, no hay forma de
+leer esos datos de pista, pero está planeado para el futuro. El objetivo es
+también leer y mostrar registros de pista GPS de manera similar. Estos archivos
+de registro de pista se colocarán en el directorio ~/.xastir/tracklogs con un
+nombre igual al indicativo de la estación con ".trk" como extensión. "Guardar
+Pista" guardará simultáneamente la pista de la estación como un archivo de
+Lenguaje de Marcado de Agujeros de Llave (.kml) con un nombre de archivo igual
+al indicativo de la estación, la fecha y hora actual y .kml como extensión. Si
+se ha incluido soporte de archivos de forma, la pista de la estación también se
+guardará como un conjunto de cuatro archivos (.dbf,.prj,.shp,.shx). Los
+presionamientos posteriores de Guardar Pista para la misma estación escribirán
+líneas adicionales en el archivo .trk y crearán nuevos archivos .kml (y de
+forma) (cada uno que contiene todas las posiciones en la pista de la estación).
+
+"Modificar Objeto/Elemento" abrirá la ventana Modificar Objeto.
+
+"Enviar mensaje" abrirá la ventana de mensaje y le permitirá enviar un mensaje
+a esta estación. Rellenará el indicativo para usted.
+
+Si la base de datos de FCC (Comisión Federal de Comunicaciones de EE.UU.) o RAC
+(Radioaficionados de Canadá) está instalada y el indicativo parece ser un
+indicativo canadiense o de EE.UU., el botón "Buscar Base de Datos de FCC/RAC"
+se volverá activo, de lo contrario este botón estará inactivo. Los archivos de
+FCC y RAC deben colocarse en el directorio /usr/local/share/xastir/fcc, ¡y la
+mayúsculas/minúsculas es importante! Presionar este botón agrega el nombre y
+dirección de la estación al cuadro de Información de la Estación. Las
+instrucciones para instalar estas bases de datos se encuentran en la página
+"Helper Scripts" en el wiki,
+https://github.com/Xastir/Xastir/wiki/Helper-Scripts
+
+Xastir creará archivos de índice para cada archivo de base de datos al
+iniciar. Si un archivo de indicativo más nuevo se coloca allí mientras Xastir
+se está ejecutando, creará o reconstruirá el índice en la próxima búsqueda. Los
+prefijos especiales NO se manejan.
+
+HELP-INDEX>Crear un registro
+                              Crear un registro
+
+Xastir puede registrar datos de Internet o TNC para su posterior reproducción
+o para propósitos de depuración. ADVERTENCIA: El registro puede llenar su disco
+duro, así que tenga cuidado al usarlo, o haga preparativos para que los
+archivos de registro se roten automáticamente a través de cron. Se mostrará una
+indicación en la barra de estado cuando el registro esté habilitado.
+
+Todas estas opciones son accesibles a través del menú Archivo:
+
+Habilitar Registro de TNC
+Registra todos los datos de TNC recibidos y transmitidos. Estos registros se
+pueden reproducir usando la función "Abrir Archivo de Registro".
+
+Habilitar Registro de Red
+Registra todos los datos de Internet recibidos y transmitidos. Estos registros
+se pueden reproducir usando la función "Abrir Archivo de Registro". Si no
+tiene interfaces iniciadas pero aún desea registrar sus posits y objetos
+localmente, esta es la opción para habilitar para eso también.
+
+Habilitar Registro de IGate
+Registra todos los datos reenviados en ambas direcciones y reenvíos rechazados
+con razones de rechazo. Incluye mensajes NWS reenviados a RF.
+
+Habilitar Registro WX
+Registra todos los datos meteorológicos recibidos de su estación meteorológica.
+
+
+HELP-INDEX>Reproducción de un registro
+
+                              Reproducción de un registro
+
+Haga clic en "Archivo", luego "Abrir Archivo de Registro" y se mostrará una
+ventana de selector de archivos. Puede usarlo para explorar su disco duro y
+seleccionar cualquier archivo que contenga datos TNC sin procesar como los
+creados por las opciones de registro de TNC y Red. Su estación seguirá
+funcionando de la misma manera, recibiendo y transmitiendo. Si estaba registrando
+datos, el lugar típico para buscar esos archivos sería ~/.xastir/logs/
+
+NOTA: Esta función no lee los registros de pista de estación guardados.
+
+HELP-INDEX>Localización de una Estación
+
+                             Localización de una Estación
+
+Haga clic en "Estaciones", luego "Encontrar Estación". Se abrirá una ventana.
+Ahora puede ingresar una llamada o parte de una llamada. Por defecto, buscará
+una coincidencia exacta (llamada completa, no parcial) y no distingue mayúsculas
+de minúsculas. Si busca una coincidencia parcial, "Coincidir Exacto" no debe
+estar seleccionado.
+
+¡Para objetos que podrían contener letras minúsculas, debe marcar "Coincidir
+Mayúsculas"! Al contrario del nombre, sin "Coincidir Mayúsculas", el texto de
+búsqueda solo se convertirá a mayúsculas...
+
+Hacer clic en el botón "¡Localizar Ahora!" centrará la primera estación
+encontrada en el centro de su pantalla en el nivel de zoom actual.
+
+Hacer clic en "Búsqueda de FCC/RAC" buscará la información del usuario si la
+base de datos de FCC o RAC, de esas bases de datos están instaladas.
+
+Hacer clic en "Cancelar" cerrará la ventana.
+
+Este diálogo aparecerá si una estación envía un paquete "¡Emergencia!" Mic-e,
+para alentar a los usuarios a localizar y quizás ayudar a la estación listada.
+
+HELP-INDEX>Crear y usar marcadores de pantalla de mapa
+
+                  Crear y usar marcadores de pantalla de mapa
+
+Haga clic en "Mapas", luego "Marcadores de Pantalla de Mapa" y se abrirá una
+ventana. Si esta es la primera vez que lo usa, el cuadro no tendrá entradas en
+él. Para agregar un marcador a la lista: Coloque el mapa principal en el área
+y el nivel de zoom que desea utilizar. Ingrese un nombre único en el área
+"Nuevo Nombre", luego haga clic en agregar. Su entrada se agregará a la lista
+(en orden alfabético). Puede agregar tantos marcadores de pantalla de mapa como
+desee. Para usar uno de los marcadores, marque su nombre y haga clic en
+"¡Activar!". El mapa principal mostrará el área almacenada y el nivel de zoom.
+Puede eliminar un marcador de manera similar haciendo clic en el nombre del
+marcador y luego en el botón "Eliminar".
+
+"Mapas->Localizar Característica de Mapa" es otro método para saltar a una
+ubicación, si se conoce el nombre de la ubicación y tiene archivos GNIS
+instalados.
+
+HELP-INDEX>Rastreo de una Estación
+
+                        Rastreo de una Estación
+
+Haga clic en "Estaciones", luego "Rastrear Estación". Ingrese el indicativo a
+rastrear (todo o parte) y luego haga clic en el botón "¡Rastrear Ahora!".
+Cuando la estación se mueva, permanecerá visible en la ventana del mapa
+principal. Cuando la estación comience a acercarse al borde de la ventana del
+mapa, la ventana se re-centrará para que el objeto siempre sea visible. Para
+dejar de rastrear esta estación, haga clic en el botón "Borrar Rastreo".
+Mientras el rastreo está activo, se muestra una "Tr" en la barra de estado junto
+al nivel de zoom. Si la estación aún no está en el mapa, el rastreo comenzará
+tan pronto como aparezca.
+
+HELP-INDEX>Impresión
+
+                       Impresión de la Pantalla del Mapa
+
+Nota: La impresión no se ha configurado en Windows/Cygwin. Estas instrucciones
+son para sistemas operativos Unix y similares a Unix.
+
+Xastir puede imprimir el área de dibujo en blanco y negro o color. Lo hace
+primero descargando la imagen a un archivo XPixmap en el disco, luego
+utilizando herramientas externas para convertirla a postscript, escalarla,
+rotarla, previsualizarla e imprimirla. Debe tener su impresión del sistema
+configurada para manejar postscript (normalmente esto requiere Ghostscript y
+un filtro de impresión instalado, así como spoolers de impresión lp o lpr).
+También debe tener las siguientes herramientas instaladas para esta
+capacidad: herramientas de GraphicsMagick (específicamente "convert"),
+"Ghostscript", fuentes de Ghostscript y "gv". Una vez que todos estos
+paquetes estén instalados y funcionales, debería obtener una ventana "gv"
+que aparezca poco después de que le diga a Xastir que cree un archivo de
+impresión. Desde allí puede ver la imagen impresa, y si es aceptable, le
+dice a "gv" que la imprima. Tenga en cuenta que a veces se recomienda cambiar
+a un fondo blanco predeterminado para los mapas, dependiendo de qué mapas
+tenga visibles. Esto puede ahorrar bastante tinta.
+
+HELP-INDEX>Crear Instantáneas
+
+                     Crear Instantáneas Automáticas
+Xastir tiene la capacidad de crear snapshots automáticos de la pantalla del mapa
+en forma recurrente. El período de tiempo predeterminado es una vez cada cinco
+minutos. Si tiene "convert" de las herramientas GraphicsMagick instaladas,
+Xastir creará un archivo en formato XPM en ~/.xastir/tmp/, luego lo convertirá
+al archivo PNG ~/.xastir/tmp/snapshot.png. Este archivo es útil para
+incrustar en páginas web para mostrar una imagen "en vivo" de lo que hay en su
+pantalla de Xastir. Activa esta característica mediante el botón de alternancia
+"Archivo->Activa PNG Instantánea". La frecuencia es una vez cada cinco minutos (configurable
+desde el diálogo Configurar Cronómetro desde "Archivo->Configurar->Cronómetro"), o cada vez
+que el botón se alterna de apagado a encendido. Se crea un archivo .geo para que
+pueda usar el snapshot como mapa. También se escribe un archivo .kml para que
+pueda usar el snapshot como una superposición gráfica en terreno en
+aplicaciones capaces de leer kml. Ver kml_snapshot_to_web.sh y
+kml_snapshot_feed.kml en el directorio scripts para más información sobre cómo
+usar los archivos snapshot.png y snapshot.kml para producir una fuente kml
+usando los snapshots.
+
+                    Crear Snapshots KML Automáticos
+
+Xastir es capaz de escribir todas las estaciones actuales y pistas a un archivo
+kml en forma recurrente. Activa esta característica mediante el botón de
+alternancia "Archivo->Instantáneas KML". La frecuencia a la que se generan estos
+snapshots es la misma que la de los snapshots PNG, configurada desde
+"Archivo->Configurar->Cronómetro" estableciendo el intervalo de tiempo de snapshot.
+Cada snapshot se escribe a un archivo .kml en ~/.xastir/tracklogs, con un nombre
+de archivo basado en la fecha y hora del snapshot, ej. 20080206-000720.kml. Este
+comportamiento puede cambiar para que los snapshots KML se escriban a un único
+archivo como los snapshots PNG.
+
+
+HELP-INDEX>Scripts Incluidos
+
+                        Scripts Incluidos
+
+Xastir incluye varios scripts Perl y un script de shell que pueden ser útiles:
+
+get-fcc-rac.pl
+Este script de shell automatiza la recuperación e instalación de las bases de
+datos de callsign FCC y RAC. ¡Ten en cuenta que estas bases de datos son muy
+grandes!
+
+icontable.pl
+Este script genera un bitmap xpm de todos los símbolos primarios y secundarios
+de Xastir desde el archivo symbols.dat. Las superposiciones y especiales se
+ignoran. La salida es a STDOUT, por lo que una llamada típica sería
+"icontable.pl > symbols.xpm".
+
+inf2geo.pl
+Este script crea archivos .geo desde archivos .inf de UI-View. Para crear un
+map.geo desde un map.inf, el uso típico sería "inf2geo.pl map".
+
+kiss-off.pl
+Este script envía los comandos necesarios para apagar el modo KISS de un TNC.
+
+mapfgd.pl
+Este script crea archivos .fgd mínimos para imágenes GeoTIFF que carecen de
+ellos, basándose en información encontrada en el archivo GeoTIFF. Los archivos
+creados permiten a Xastir recortar los bordes blancos y rotar/escalar el mapa
+correctamente. El uso típico sería "mapfgd.pl mapdir" donde mapdir es el
+directorio que contiene las imágenes GeoTIFF.
+
+overlay.pl
+Este script crea archivos en formato .log desde archivos de superposición
+separados por comas. Ver los comentarios del script para información de uso
+completa.
+
+ozi2geo.pl
+Este script crea archivos .geo desde archivos .map de OziExplorer.
+
+permutations.pl
+Este script convierte entre diferentes formatos lat/lon. Ver los comentarios del
+script para más detalles.
+
+test_coord.pl
+Pruebas para el módulo Coordinate.pm Perl.
+
+track-get.pl
+Este script descarga el registro de pista de un objeto especificado desde un GPS
+Garmin. Requiere el módulo GPS::Garmin. Te pide un nombre de objeto e escribe
+el registro de pista al directorio ~/.xastir/logs.
+
+update_langfile.pl
+Este script está dirigido a desarrolladores. Reconstruye un archivo de idioma
+especificado para contener todas las cadenas de otro. Generalmente se usa para
+regenerar los archivos de idioma que no son en inglés cuando se han hecho
+cambios significativos al archivo en inglés. Cuando al archivo de idioma
+secundario le falta una cadena en el archivo principal, se inserta la cadena
+sin traducir. El uso típico sería "update_langfile.pl language-German.sys".
+El archivo de idioma principal está codificado pero fácilmente editable.
+
+waypoint-get.pl
+Este script similar descarga los waypoints desde un GPS Garmin y crea un
+registro en el directorio ~/.xastir/logs que contiene los waypoints como
+objetos. También requiere el módulo GPS::Garmin.
+
+db_gis_mysql.sql  db_gis_postgis.sql
+Estos crearán tablas para almacenar datos de estaciones en una base de datos
+mysql o postgresql/postgis. El soporte de la base de datos SQL Server es
+experimental. Ver la sección "OPTIONAL: Experimental. Add GIS database
+support" en INSTALL.md
 
 HELP-INDEX>Configurar Interfaces
 
-                           Configurar Interfaces  
-  
-Pulse el botón en Configurar luego en Interfaces  
-  
-Un diálogo de "Interfaces Instalados" debe aparecer. 
-Este diálogo le permitirás a usted Agregar, Anular, y modificar las Propiedades 
-en varios dispositivos que usted puedes querer usar con Xastir.  
-  
-Las opciones actuales son:  
-TNC vía el Puerto Serial
-TNC vía un Puerto Serial con (GPS más cable HSP)
-GPS vía un Puerto Serial
-Estación Meteorológica vía Puerto Serial
-Conexión a un Servidor en Internet
-TNC vía la Uilidades del AX.25
-GPS Enlazado vía el Servidor gpsd
-Estación Meteorológica Enlazada a una RED
-TNC vía un Puerto Serial con (GPS más AUX puerto)
-  
-Para agregar un dispositivo, pulse el botón de agregar. 
-Un diálogo "Elegir Tipo de Interfaz" aparecerá. 
-Pulse el botón en el tipo de dispositivo que le gustaría agregar. 
-Luego pulse el botón de Agregar en el diálogo "Elegir Tipo de Interfaz". 
-Las propiedades para ese dispositivo aparecerá. 
-
-Rellene la información pedida y pulse el botón en Aceptar, anular el dispositivo, 
-pulse el botón en el dispositivo usted deseas anular y entonces pulse el botón Anular.
-Para modificar las propiedades de un dispositivo, 
-pulse el botón en el dispositivo usted deseas modificar, 
-luego pulse sobre el botón de propiedades. 
-
-Las propiedades para ese dispositivo aparecerá.
-Cambie la información que usted quieres y pulsar el botón en Aceptar.
-
-HELP-INDEX>Configurando el Serial sobre un TNC
-
-                 Configurando el Serial sobre un TNC
-
-SERIAL TNC CONFIGURACION
-
-Pulse el botón "Configurar" luego en "Interfaces" después en "Agregar"
-después en "Serial TNC" luego "Agregar" y por último en "Puerto TNC"
-
-Si usted tienes un TNC y planea usarlo con XASTIR seleccione "Puerto TNC".
-El valor por defecto no, es seleccionado.
-
-Ahora entre en el puerto que el TNC está, es decir /dev/ttyS0 para com1
-
-Seleccione los valores del puerto que se acoplan a su TNCs velocidad del puerto.
-
-Entre en tres rutas de UNPROTO.
-
-Xastir asumirá los XX VIA la parte de la ruta de UNPROTO. Hay tres Rutas 
-permitidas para que su señal sea escuchada si las condiciones son mala.
-Si cualquiera de éstos es llenado en XASTIR ciclará a través de uno de ellos
-a cada intervalo de transmision.
-
-Si usted estás local, sólo un WIDE2-2 puede ser una buena opción.
-Si usted estás usando baja potencia y/o estás distante de un digi entonces
-WIDE1-1,WIDE2-2 puede trabajar mejor.
-
-O si usted conoces el indicativo de su digi más cercano que usted
-puedes usar XXXCALL,WIDE2-2.
-La mayoría de ustedes necesitarán sólo una ruta.
-
-Si usted estás en una área remota y su señal es difícil de conseguirla
-usted puedes necesitar más.
-
-Verifique con un grupo local y pregúntele que ruta 
-puede ser mejor para su área. Algunas areas
-usan el flujo de protocolos más eficientes, en tales caso usted podría usar
-WIDE3-3 o WIDE1-1,WIDE3-3.
-
-Los archivos de Inicio y Salida del TNC. Estos campos especifican a nombre
-de archivo qie es localizado en el directorio /usr/local/share/xastir/config.
-Cada archivo es un archivo de texto estandar conteniendo algunos comandos que
-usted le gustaria enviarle a su TNC a la vez que el dispositivo es activado
-(Archivo de Inicio - Startup file) o de deshabilitar (shut down).
-
-Pulsando el botón "Aceptar" guardarás sus cambios.
-Pulsando el botón en "Cancelar" guardará la configuracion actual.
-
-HELP-INDEX>Opciones del TNC
-
-                   Opciones del TNC
-
-Permitir Transmisión (on/off)
- Esto controla la transmisión de datos a través del TNC. Usted puedes querer
-Simplemente escuchar en RF o si usted no es un HAM y no debes transmitir. Con
-Esta opción (el cual está apagado por defecto) usted puedes controlar 
-transmisión de cualquier datos vía RF. 
-
-Bitácora (log) del TNC (on/off)
- Si está en 'ON', un archivo de log (Bitácora) se creará en el directorio logs. 
-El archivo se llamará tnc.log y se añadirá con toda la información oída vía RF.
-
-Transmitir Ahora!
- Este transmitirá su position/info de su estacion cuando usted pulses el botón 
-en esta selección. No transmitirá si la opción "Serial TNC" no está seleccionada
-(en la sección Configurar/Interfaces/Agregar/Serial TNC/Adregar/Puerto TNC)
-o si la opción arriba mencionada permitir transmisión está fijada en off.
-
-HELP-INDEX>Configurar TNC via Serial c/GPS en HSP cable o AUX puerto
-
-            Configurar TNC via Serial c/GPS en HSP cable o AUX puerto
-
-Esos tipos de interfaces híbridos implementan las opciones de ambos serial TNCs
-y GPSs. Por favor consulte la configuración de ayuda para ambos serial TNCs y
-serial GPSs para más detalles de información sobre la configuración
-de esos dispositivos.
-
-HELP-INDEX>Configurando el AX.25 TNC
-
-                 Configurando el AX.25 TNC
-
-AX.25 TNC CONFIGURACION    
-    
-Esta sección cubre agregando o modificando AX.25 TNC dispositivos.
-AX.25 dispositivos pueden sea cualquier dispositivo que use controladores AX.25
-en Linux.
-
-Éste es un controlador de nivel del núcleo (kernel),
-y el dispositivo como un Baycom o una tarjeta de sonido como módem 
-puede usarse como un TNC.
-Estos dispositivos deben ser configurado y correrlo
- antes de que Xastir pueda usarlos.    
-    
-Seleccionando Activar en Inicio, le dirá a Xastir que busque este dispositivo
-y fije las comunicaciones con él cuando el programa de su primer inicio.
-    
-Seleccionando Permite Transmitir, le dirá a Xastir que cualquier
-salida de datos de RF puede ser enviado a este dispositivo para la transmisión.
-    
-Escoja la operación correcta de IGate para este dispositivo.
-Usted puedes tener varios dispositivos TNC, y esta opción puede ser diferente 
-por cada dispositivo. Si usted no estás ejecutando un IGate 
-usted puedes dejar ésta opción predefinida de "Desactivar todo el tráfico".    
-    
-Entre el nombre del Dispositivo AX.25 
-que usted especificó en el archivo del axports para este dispositivo.
-    
-Entre en tres rutas de UNPROTO. Xastir asumirá el XX VIA parte de la ruta
-del UNPROTO. Hay tres rutas permitidas para que su señal sea escuchada
-si las condiciones son mala.
-
-Si cualquiera de ésas son llenada en XASTIR ciclará a través de uno de ellos 
-en cada momento de la transmisión. Si usted es local, sólo un
-WIDE2-2 puede ser una buena opción.
-
-Si usted estás usando baja potencia y/o estás distante de un digi
-entonces WIDE1-1,WIDE2-2 pueden trabajar mejor.
-O si usted sabes el indicativo de su digi más cercano
-a usted puedes usar XXXCALL,WIDE2-2. La mayoría de ustedes necesitarán sólo una ruta.
-
-Si usted estás en una área remota y su señal es difícil de conseguir usted puedes 
-necesitar más. Verifique con un grupo local y pregúntele qué 
-ruta puede ser mejor para su área. Algunas areas
-usan el flujo de protocolos más eficientes, en tales caso usted podría usar
-WIDE3-3 o WIDE1-1,WIDE3-3.
-
-    
-NOTA: Para usar dispositivos AX.25 con Xastir usted necesitarás ejecutar el programa como "raíz" ("root").
-
-Si usted quieres ejecutar Xastir como otro usuario usted necesitarás
-fijar el suid en ON  en el archivo de programa de xastir.
-El orden siguiente como raíz debe fijar esto para usted. chmod a+s /usr/local/bin/xastir.
-
-como con cualquier programa que este corriendo de esta forma, por favor note que
-esto puede ser considerado como una seguridad de riesgo, como el programa no ha sido
-probado para explotar. Uselo en este modo en un multi-usuarios en su propio riesgo!
-
-HELP-INDEX>Cómo uso yo mi GPS con Xastir?  
-  
-                             Usando UN GPS con Xastir  
-  
-Para usar una unidad de GPS con Xastir usted tienes tres opciones,
-un GPS Conectado a una red o a un serial GPS,
-o a un serial GPS con un TNC y cable HSP.
-
-                            GPS conectado a una red:   
-  
-La ventaja de usar un GPS conectado a una red
-es que usted puedes compartir el GPS con otros programas.   
-Xastir usa un programa llamado gpsd para hacer una connexión a una red.   
-  
-Este programa entrega datos de GPS normales en un sócalo de conexión de redes.
-Algunas versiones también permiten corrección de GPS vía un servidor de Internet.   
-  
-Una vez que usted tengas bajado e Instalado el gpsd en su máquina
-(u otra máquina), usted puedes fijar el Xastir
-para conectar a él creando una interfaz.   
-  
-Pulse el botón en "Configurar" y después en "Interfaces".
-Cuando el diálogo de Interfaces aparezca Pulse el botón de "Agregar".   
-Un nuevo diálogo aparecerá con los tipos de Interfaces,
-Elegir en "Enlazado GPS (via el gpsd)", y luego pulse el botón en Agregar.
-
-Hay 4 opciones a elegir.
-Primero entre el nombre del servidor del programa gpsd que está ejecutando.   
-Si está en el mismo computador que Xastir entonces  entre localhost.   
-  
-Luego entre en el puerto que usted puso el programa gpsd para escuchar.
-Si usted seleccionas "Activar en Inicio", Xastir tratará de conectar
-al programa gpsd tan pronto se inicia y tan pronto usted hagas click
-en el botón "Aceptar". La última opción, si seleccionado,
-intentará hacer la reconexión al gpsd si un fallo fué encontrado.  
-  
-Serial GPS: Un serial GPS es cualquier unidad de GPS normal 
-que conecte al puerto serial y transmita datos en el NMEA normal. 
-Permitir a Xastir a usar este tipo de GPS pulse el botón
-de "Configurar" luego en "Interfaces". Cuando el diálogo
-de Interfaces aparezca pulse el botón de "Agregar".
-
-Un diálogo con los tipos de Interfaces aparecerá,
-Pulse sobre el "Serial GPS" y después en el botón Agregar.   
-  
-               Unas pocas opciones para fijar.
-               
-Primero entre el puerto serial en donde el dispositivo
-está conectado (como "/dev/ttyS1 (COM2)"). 
-Próximo si usted seleccionas "Activar en Inicio",
-Xastir intentará inicializar el "serial GPS" cuando él se
-inicie y cuando usted pulses el botón "Aceptar".
-Las próximas opciones pondrán la velocidad del puerto serial y modo.   
-  
-Para la mayoría de las unidades de GPS los valores predefinidos están bien.
-Pero Chequee usted el manual del GPS sólo en caso de dudas.
-
-HSP TNC/GPS: 
-Mire en "Cómo uso yo mi TNC con Xastir?"  
-
-
-HELP-INDEX>Configurando el Puerto/GPS
-
-              Configurando el Puerto/GPS
-
-Pulse el botón en "Configurar" luego en "Interfaces" luego en "Agregar" 
-elija "Serial GPS" luego "Agregar" después ajuste los parámetros del Puerto/GPS.
-
-Para usar una posición "Serial GPS" en el puerto serial,
-pulse el botón en Posición Serial GPS.
-Este puerto puede especificarse en la Posición "Sólo el puerto de GPS".
-Usted puedes usar un dispositivo serial como /dev/ttyS1 (COM2).
-
-Si usted tienes un cable de HSP que le permitas compartir el Serial TNC con una 
-unidad GPS usted puedes seleccionar "Serial TNC c/GPS más (Cable HSP).
-Éste es un cable especial y el mío no trabaja en todas las combinaciones
-de computadores/GPS/TNC.
-
-Ahora usted puedes escoger un GPS muestreo y TNC relación, Recuerde usarlo con 
-precaución aqui, que sean amigables por sus estaciones cercanas.
-
-¿Activar el uso de los datos de GPS seleccione el "Uso Posición GPS?" opción.
-Con esta selección hecha la unidad de GPS pondrá al día su posición.
-Si esto no se selecciona la posición actual vendrá desde la locación 
-en configuración información de la Estación.
-
-Cuando active los datos de GPS también pondrás al día 
-la posición en configuración de información de la Estación.
-
-Cuando use el GPS sus paquetes cambian, usted obtendrás una estación móvil con 
-curso y velocidad aún cuando la suya no esté moviendose (yo puedo cambiar esto 
-después a una opción).
-
-El tiempo del GPS le permitirá seleccionar proporciones de la relación
-de muestra  para el GPS y sobre pasar el tiempo del paquete normal 
-por transmitir su estación.
-
-Si usted estás estacionado entonces use 10 minutos.
-Si usted estás haciendo algún especial/rastreo etc..
-use la selección que encajarán mejor los datos que usted necesitas.
-Por favor no haga sobre transmisión, si usted no lo necesitas hacer. 
-
-
-Pulsando el botón "Aceptar" guardarás sus cambios.
-Pulsando el botón en "Cancelar" guardarás las configuraciones actuales.
-
-HELP-INDEX>Cómo uso yo mi TNC con Xastir?  
-  
-                Usando UN TNC con Xastir  
-  
-Para usar un TNC con Xastir usted tienes tres opciones,
-un "serial TNC" o un "Serial TNC c/GPS más (cable HSP)"
-o un TNC Conectado a una red "AX.25 TNC".
-
-AX.25 o un TNC en una red:
-Este tipo de tnc le permitirá compartir el TNC con otros programas.
-Al usarlo usted debes tener la librería AX.25 , y el
-HamRadio soporte instalado en el núcleo (kernel) de su Linux OS.
-
-Ellos son un poco más difíciles de configurar para usarlo 
-pero hay muy buenas opciones y ventajas en su uso. 
-
-Usando el soporte del "AX.25 TNC", usted tienes varios
-dispositivos que usted puedes usar con Xastir.
-Algunos de ellos son serial TNC que usan AX.25,
-tarjetas de sonidos como TNC's, Baycom, etc.  
-  
-SERIAL TNC: SERIAL TNC con (GPS más cable HSP):
-
-HELP-INDEX>Configurando la conexión de Internet
-
-             Configurando la conexión de Internet
-
-La conexion a los Servicios de Internet le permite a usted enviar
-y recibir datos desde y hacia todo el mundo.
-
-Para configurar el Internet usted necesitarás conocer un host y un número de 
-puerto. El host predefinido es www.aprs.net y el puerto es 10151. Usted puedes 
-escoger otros pero este debe trabajar. Una Palabra de paso válida le permitirá
-a su estación transmitir por el Internet.
-
-Permitirá a su estación salir de una I-Gate y conseguir retransmitir vía RF.
-Para conseguir un código de paso usted necesitarás contactar con Frank, 
-email fgiannan@earthlink.net, Enviarle su nombre, Indicativo, etc.
-
-Una vez él verifique su estado como un HAM él puede enviarle su código. 
-Usted puedes mantenerse recibiendo y transmitiendo datos vía el 
-Internet aunque usted no tengas un passcode. Pero sin el código de paso sus 
-datos no serán directamente retransmitido vía RF.
-Cualquiera que esté conectado al Internet directamente conseguirá su mensaje.
-
-Host1 y Host2 son servidores opcionales que serán contactado si el servidor 
-primario está fuera. Cada servidor será intentado dos veces, siguiendo al 
-próximo si la conexión fracasa.
-
-Si usted quieres que XASTIR reconecte después de una conexión perdida
-en el net entonces seleccione la opción "Reconecte en fracaso de la RED?"
-en la que por defecto está en ON.
-
-Las últimas opciones son para preparar su estación para ser un IGate. Esto 
-permite a su estación con su código de paso simplemente actuar como una puerta 
-(gateway), pero en lugar de otra banda sus datos atravesarán el Internet.
-Esta opción no debe ser tomada ligeramente.
-
-Primero usted debes coordinar con otros 
-en su área para que usted puedas agregar verdadera información que puede estar 
-perdiendo. Usted también debes avisar a Steve sobre esto. Esta versión puede 
-enviar información recibida desde su TNC hacia el Internet y transmitirá 
-cualquier mensaje procedente de Internet a través de su estación via RF.
-
-Enviará sólo datos vía RF si usted tienes el opción seleccionada de transmisión 
-de mensajes. Sólo estaciones que usted has oído (vía RF) en las últimas horas 
-tendrán mensajes enviados a ellos en ésta vía.
-
-Note también usted es responsable por los datos transmitidos
-por su estación asi que tenga cuidado con esta 
-opción (otros pueden enviarle mensajes que usted no quieres transmitir).
-
-Si usted quieres ver que su I-Gate esta haciendo encienda la opción Log I-Gate 
-de transacciones. esto construirá un archivo de igate.log en su "logs" los 
-directorios  mostrarán todos los datos pasados de RF local hacia la red con 
-línea que tiene "IGATE-RF->NET": y conteniendo todo los datos.
-
-También mostrará todo el tráfico entrante desde la red con "NET->RF-IGATE:".
-Note aquí usted no verás la completa salida de paquetes, como su estación y ruta son 
-asumida. Solamente mostrará el data como un mensaje de tercera persona.
-
-
-Pulsando el botón "Aceptar" guardarás sus cambios.
-Pulsando el botón en "Cancelar" guardarás los cambios actuales.
-
-
-APRS[tm] es una Marca de fábrica de Bob Bruninga, 
-su página está en "http://web.usna.navy.mil/~bruninga/aprs.html"
-
-
-HELP-INDEX>Opciones de RED
-
-                   Opciones de RED
-
-Permitir Transmisión (on/off)
-Esto controla la transmisión de datos a través del Internet.
-El valor por defecto es apagado.
-Con esto en (off) apagado ningún dato será enviado al Internet.
-
-Bitácora de Internet (on/off)
- Si esto está en 'ON', un archivo log se creará en el directorio logs. El archivo
-se llamará net.log y se añadirá con toda la información oída vía el Internet.
-
-Transmitir Ahora!
- Esto transmitirá su position/info de la estación cuando usted pulses el 
-botón en esta selección. No transmitirá si la opción está apagada en Permitir 
-transmisión.
-
-HELP-INDEX>Configurando una Estación Meteorológica sobre un Puerto Serial.
-
-Configurando una Estación Meteorológica sobre un Puerto Serial.
-
-Configurar el puerto serial para su estación Meteorológica. A los valores 
-comunes de /dev/ttyS0 (COM1) o /dev/ttyS1 (COM2) pueden ser usado.
-
-Seleccionado "Activar en Inicio" le dirás a Xastir buscar este dispositivo y
-fijar comunicanciones con el cuando el programa se inicie primero.
-
-Ahora fije el bps bajo el puerto de configuración, y los parámetros bajo el
-puerto estilo. El seteo del puerto estilo 8N1, es usado para 8 bitios de datos,
-No paridad y 1 bitio de parada (stop bit). 7E1 es usado para 7 bitios de datos,
-even paridad y 1 bitio de parada. 7O1 es usado para 7 bitios de datos, odd paridad
-y 1 bitio de parada. Esos parámetros deben de machar con su estación Meteorológica.
-El tipo de opción de data le perimitirá sobrepasar que tipo de serial data el progrma
-verá. La forma de auto-detección primero buscará datos del tiempo en un modo binario
-como lo usa el Radio Shack WX-200. Si no dato binario es encontrado,
-Xastir buscará un tipo ASCII de estación Meteorológica (como la Peet Bros.)
-
-HELP-INDEX>Configurando una Estación Meteorlógica en la RED
-
-Configurando una Estación Meteorlógica en la RED
-
-Xastir puede usar servicios de dato de una estación Meteorológica
-tales como la wx200d. La wx200d le permitirás varias conexiones de redes,
-asi compartiendo el informe del tiempo con varios programas o computadores.
-
-Entre el nombre del host (o la dirección numérica IP) y el número del puerto
-de la estación Meteorológica servidora que usted quieres contactar.
-
-Seleccionado "Activar en Inicio" le dirás a Xastir buscar este dispositivo y
-fijar comunicanciones con el cuando el programa se inicie primero.
-
-Seleccionado "Reconectar en fallo de la RED" le dirá a Xastir tratar de reconectar cuando
-el data conexión haya fracasado.
-Como antes el tipo de data sobrepasará el auto-detección.
-
-HELP-INDEX>Diálogo info estación - búsqueda FCC y RAC  
-  
-                  Diálogo info estación - búsqueda FCC y RAC  
-  
-Info estación desplegará cualquier dato descifrado por Xastir.
-Actualmente dos o tres botones aparecen aquí además del botón Cerrar.
-
-Los botones de Anular Rastro anularán cualquier línea de rastro para esa estación 
-que es actualmente guardada o en el despliegue de mapa.
-
-Envíe mensaje abrirá la ventana de mensaje y le permitirá enviar a mensje a esta estación.
-El llenará en el indicativo por usted. 
-
-Si el banco de datos de FCC se instala,
-un botón de Búsqueda en el Banco de datos FCC aparecerá en este Diálogo.
-Si el RAC (RadioAficionados de Canadá) banco de datos se instala, 
-un botón de búsqueda RAC Banco de datos aparecerá para indicativo 
-que empiezan con una "V".  
-
-El archivo FCC y  RAC deben colocarse en el directorio
-/usr/local/share/xastir/fcc, y el caso es importante!  
-  
-Usted puedes usar este botón para agregar los nombres de estaciones
-y diríjase al Diálogo de Estación Info. 
-
-Para usar la búsqueda de FCC bajelo de aqui:
-ftp://ftp.fcc.gov/pub/XFS_AlphaTest/amateur/appl.zip
-
- o el Nuevo banco de datos en:
-ftp://ftp.fcc.gov/pub/Bureaus/Wireless/Databases/uls/complete/l_amat.zip  
-  
-(El único archivo necesitado forma este 40Meg zip es el archivo EN.dat)  
-  
-* * * * NOTA para usar el NUEVO archivo base de datos debe ordenarse primero!!! * * * *
-
-¡Asegúrese que usted tienes espacio en el disco suficiente 
-para esto como el archivo es GRANDE!  
-
-Para ordenar el archivo: sort +4 -t \ | EN.dat >EN.dat.ordenado  
-rm EN.dat  
-mv EN.dat.ordenado EN.dat  
-  
-Para usar la búsqueda de RAC bájelo de: ftp://ftp.rac.ca/pub/cdncaldb.zip  
-Xastir creará archivos índice por cada archivo del banco de datos en el inicio.  
-  
-Si un archivo de indicativo es eliminado mientras Xastir está corriendo,
-creará o reconstruirá el índice en la próxima búsqueda. No se manejan prefijos especiales.
-
-HELP-INDEX>Opciones de Despliegue
-
-                        Opciones de Despliegue
-
-Estas opciones le permitirán desplegar datos sobre la estación alrededor del 
-ícono de las estaciones en el mapa.
-
-Indicativo (on/off)
- Cuando esté en 'ON', todo los indicativos de las estaciones se desplegarán.  
-Si este esta en 'OFF' los indicativos no se desplegarán sobre el mapa.
-
-Para viejas estaciones el símbolo es dibujado
-como fantasma y en su orientación estandar.
-
-Corespondiendo al arrastre que son subrayado más que sólido y todo el data
-excepto el indicativo desaparece de la pantalla.
-
-Callsign (on/off)
-Determines if the callsign is displayed on the right side of the symbol.
-
-Altura (on/off)
- Cuando esté en 'ON', una línea azul de datos aparecerá  sobre el indicativo.  
-Este desplegará la última altitud conocida de la estación.
-
-Curso (on/off)
- Cuando esté en 'ON', una línea verde de dato aparecerá debajo del indicativo. 
-Esto desplegará el último curso conocido (en grados) de la estación que está en 
-movimiento.
-
-Velocidad (on/off)
- Cuando esté en 'ON', una línea roja aparecerá debajo del indicativo (o curso). 
-Esto despliegará la última velocidad conocida de la estación que está en 
-movimiento.
-
-Dist/curso (on/off)
- Cuando esté en 'ON', se desplegarán dos líneas de información en el lado 
-izquierdo del ícono de la estación. La línea de arriba tendrá la distancia 
-de su estación hacia esta estación. La línea de abajo tendrá el curso desde su 
-estación hacia esta estación. 
-
-Rastros de estaciones (on/off)
- Cuando esté en 'ON', cualquier estación en movimiento arrastrará una línea 
-coloreada con las últimas 100+ localizaciones. Cuando la estación se pone vieja 
-el ícono es opaco la línea de rastro se volverá intermitente en lugar de la 
-línea contínua.
-
-
-Estación Potencia/Ganancia (on/off)
- Cuando esté en 'ON', se desplegarán Círculos de Poder/Ganancia.
- Sobrepasando los círculos indicado que las estaciones están teóricamente
- con simple rango uno del otro.
- Esto es aproximandaemnte exacto, especialmente in áreas de terreno variable.
- 
-Rastreo Estación
- Traerá una caja abierta similar a la opción localizar estación. Usted puedes 
-entrar  todos o parte del indicativo. Al seleccionar "Rastrear Ahora!" El 
-despliegue saltará a la posición de la estación (si es encuentrada). Cuando 
-nuevos datos para esa estación son encuentrados el despliegará el rastro a lo largo 
-de esa estación.
-
- El botón "Borrar Rastro" limpiará todo el rastro.
-
- El botón de "Cancelar" terminará sin cambios realizados.
-
-Informe del Tiempo (on/off)
-Cuando esté en 'ON', los últimos datos del tiempo 
-(velocidad/curso/ráfaga,Humedad,temperatura,viento) 
- son desplegados.
-
-Símbolos (on/off)
-Determina si los símbolos podrían ser dibujado en el mapa.
-
-Rotar Símbolos (on/off)
-Si 'ON', algunos símbolos deberían cambiar su orientación y mostrar la
-dirección en la cual una estación móvil se está moviendo.
-
-HELP-INDEX>Mensajes
-
-                        Mensajes
-
-Enviar mensaje a y Mensajes De grupo abierto
-Éstos son muy similares. El "Enviar mensaje a" enviará sus mensajes a una 
-estación y recibirá sólo forma de datos de la estación. Los mensajes de grupo 
-son más en general usted puedes recibir cualquier mensaje para el grupo y usted 
-enviarás sus mensajes a ese nombre de grupo. Los mensajes de grupo no pueden 
-trabajar mejor por el momento hay varios problemas que necesitan ser 
-solucionado. Sin embargo, volviendo atrás al
-uso de estas pantallas. 
-
-Cada una de estas pantallas contienen una caja de mensaje, una línea de 
-llamada, una línea de mensaje, y varios botones. Usted debes primero entrar  la 
-llamada del grupo o estación que usted quieres avisar. Una vez que eso se hace 
-cualquier nuevo mensaje que ha entrado de esa estación hacia usted serás 
-desplegado. Si la estación está enviándole información y ninguna ventana de 
-mensaje está abierta él abrirá automáticamente a una nueva ventana (hasta 10) 
-con esos indicativos de estaciones para usted. Usted puedes ahora entrar un 
-mensaje en la línea de mensaje. El mensaje puede ser más largo que la línea de 
-mensaje, y la máxima salida es aproximadamente 250+ carácteres. Una vez su 
-mensaje es entrado, pulsando el botón "Enviar Ahora!" mandará su mensaje.
-
-El botón "Enviar Ahora!" se pondrá opaco hasta que su mensaje sea completamente Reconocido.
-Cualquier mensaje que usted recibas será ordenado por la línea # y será puesto 
-en la ventana de mensaje. Si usted estás en un modo de grupo cada línea 
-desplegará el indicativo de donde el mensaje se envió seguido por el propio 
-mensaje. Los mensajes de grupos actuales son ordenados por llamada y después   
-la línea #. Cuando usted hayas enviado el mensaje pulsando el botón de "Cerrar" 
-cerrará la ventana.
-
-Dos otros botones son también disponible. El botón "Nuevo Indicativo" 
-le permitirá mirar datos viejos que una estación ha enviado.
-Teclee el indicativo y pulse en este botón, cualquier 
-información vieja será desplegada.
-Usted también puedes usar este botón para cambiar el indicativo de la estación
-con la que usted estás hablando.
-Entre el nuevo indicativo y pulse el botón. El botón de "Borrar Mensajes"
-limpiará cualquier mensaje desplegado en la ventana de mensajes.
-
-
-Borrar todos los mensajes salientes
- Esto limpiará todo los mensajes no-conocidos que usted has enviado.
-
-Auto Contestación de Msj
-Esto encenderá una contestación automática
-cuando un mensaje entrante se recibe.
-
-Fijar Mensaje en  contestación Automática
- Esto fijará un mensaje que se enviará en ausencia automáticamente.
-
-HELP-INDEX>Limpiando el despliegue de línea de rastros
-
-            Limpiando el despliegue de línea de rastros
-
-Pulse el botón en "Archivo" y después "Borrar Todo rastro". Esto limpiará 
-todo el dato de la línea de rastreo del banco de datos de la estación y 
-actualiza la pantalla.
-
-HELP-INDEX>Limpiando el despliegue de estaciones
-
-             Limpiando el despliegue de estaciones
-
-Pulse el botón en "Archivo" y luego el botón "Borrar Toda las Estaciones". Esto 
-limpiará todo los datos del banco de datos de las estaciones excepto la suya.
-
-HELP-INDEX>Reenviando un log (Bitácora) 
-
-                     Reenviando una Bitácora
-
-Pulse el botón en "Archivo" y después en "Abrir Bitácora"
-una ventana de selección de archivo se desplegará.
-
-Usted puedes usarlo hojear su unidad de disco duro y seleccionar cualquier archivo
-que contenga un TNC datos raw  como aquéllos creados por el TNC y opciones de red.
-
-Su estación todavía funcionará de la misma manera, recibiendo y transmitiendo.
-Y debe haber una palabra de advertencia aquí, si su dato contiene una sessión 
-de mensaje y usted tienes su estación lista para transmitir, responderá al 
-archivo como si el dato fué recibido sobre el TNC o Internet. 
-
-HELP-INDEX>Localizando una Estación
-
-                  Localizando una Estación
-
-Pulse el botón sobre "Visualizador" luego en, "Localizar Estación"
-o sobre el botón de "Desplegar" luego en "Estación Rastreo" una ventana se abrirá.
-Usted puedes ahora entrar una estación o parte de una estación. Por 
-defecto buscará un macheo exacto (llamada completa, no parcial) y no es caso 
-sensible. Si usted estás buscando un macheo parcial, "Macheo Exacto" podría no 
-ser seleccionado.
-
-Realmente usted puedes usar esto para localizar una estación o un objeto. Qué es
-donde nosotros venimos a la opción "Macheo Sensible". Yo he notado que algunos 
-objetos están en caso mixto o minúscula. Con "Macheo Sensible" seleccionado, 
-el localizador buscará mayúscula y minúscula cuando usted la entró. Si
-"Macheo Sensible" no se selecciona, el localizador asumirá cualquier caso que usted 
-teclees es mayúscula y investigará en eso. Pulsando el botón "Localizar Ahora!"
-centrará la primera estación encontrada en el centro de su pantalla
-al nivel del enfoque actual. Pulsando el botón "Cancelar" cerrará la ventana.
-
-HELP-INDEX>Creando y usando Salto a Localizaciones  
-  
-                     Creando y usando Salto a Localizaciones  
-  
-Pulse el botón "Visualizador", luego en "Saltar a la posición" una ventana aparecerá.
-Si ésta es la primera vez usted has usado este diálogo no tendrás ninguna entrada en él.
-Agregar una posición en la lista de posición vaya al área del mapa principal 
-y enfoque el nivel que usted quieres usar.
-
-Entre un único nombre en el área "Nombre de Nueva localización",
-luego pulse el botón agregar.
-Su entrada se agregará a la lista (en orden alfabético).
-Usted puedes agregar tantas locación de mapas que usted quieras de esta manera.
-
-Para usar uno de la posición pulsar el botón en el nombre de la posición 
-y pulsar el botón  "IR!", el mapa principal entonces mostrará esa posición. 
-
-Usted puedes anular una posición similarmente pulsando el botón 
-sobre el nombre de la posición y luego el botón "Anular".
-
-HELP-INDEX>Rastreando una Estación  
-  
-Rastreando una Estación  
-  
-Pulse sobre el botón de "Desplegar" luego en "Rastreo Estación".
-Entre en el indicativo para rastrear (todos o parte) luego pulse el botón "Rastrear Ahora!".
-Como la estación lo mueve será centrado en la ventana del mapa principal.
-Dejar de rastrear esta estación pulsar el botón  "Anular Rastro".
-
-HELP-INDEX>Tráfico de mensajes
-  
-    Tráfico de todos los mensajes
-    
-Pulse sobre la opción de "Tráfico de Mensajes"
-luego un diálogo se abrirá e iniciará el Monitoreo
-de todas las estaciones alrededor del mundo, en chat o enviando
-mensaje de prueba etc.
-  
-HELP-INDEX>Imprimiendo
-  
-              Imprimiendo la Pantalla del Mapa  
-  
-Xastir puede imprimir el área de dibujo en cualquier blanco y negro o color.  Hace  
-esto primero descargando la imagen a un archivo XPixmap en disco, entonces usando una  
-herramienta externa para convertirlo al posdata, balancearlo, rotarlo, prevista, entonces la impresión  
-.  Usted debe tener su sistema que configure la impresión para manejar posdata (normalmente  
-esto requiere Ghostscript y un filtro de impresión instalados, así como lp o lpr  
-imprime spoolers). Usted también debe tener las herramientas siguientes instaladas para esta  
-capacidad:  Herramientas de ImageMagick (específicamente "convertido"), "Ghostscript",  
-Conjuntos de caracteres de Ghostscript, y "gv". Una vez todos esos paquetes son instalando y  
-funcional, usted debe una "gv" ventana sobre salte brevemente después que usted le diga a  
-Xastir crear un archivo de impresión.  De allí usted puede ver la imagen impresa, y  
-si aceptable, diga a "gv" imprimirlo.  Note que algunas veces cambiando a un blanco  
-el fondo predefinido para los mapas se recomienda, dependiendo de qué mapas usted tienen  
-visualizable.  Esto puede ahorrar le grandemente la tinta.  
-  
-HELP-INDEX>Creando Captura Instantánea Automáticamente
-
-             Creando Captura Instantánea Automáticamente
-  
-Xastir tiene la capacidad para crear captura instantánea automáticamente en pantalla del mapa  
-recurriendo al algo básico.  Este periodo de tiempo es actualmente fijado por cinco  
-minutos.  Asumiendo que usted tiene "convertir" de la herramienta de ImageMagick  
-instalado, Xastir creará un archivo de formato XPM en /var/tmp, entonces lo converte,  
-al archivo de PNG /var/tmp/xastir_snap.png. Este archivo es útil para ponerlo  
-en páginas web para mostrar una imagen viva de lo que está en su pantalla de Xastir.  Habilite  
-este rasgo vía el "Archivo->Activar PNG Instantánea".  
-  
-
-HELP-INDEX>Tabla de Símbolo
-
-Eso son los símbolos que usted puedes selecionar para su estación bajo la
-"Información de la Estación" menú de configuración.
-
-La lista actual puede ser encontrada en el APRS Referencia en el cual usted
-puedes obtenerlo desde http://www.tapr.org/
-
-                   Tabla de símbolo
-
-Símbolo Grupo/                          Grupo/
-
-!       Triángulo w/!                   Triángulo w/!
-"       Lluvia Nube                     Lluvia Nube
-#       Digi                            DIGI         
-$       Símbolo  telefónico             $ Símbolo
-%       DX                              DX 
-&       GATE-HF                         GATE
-'       Avión pequeño                   Avión Caído
-(       Nube                            nube
-)       TBD                           
-*       NIEVE Hojuela                   NIEVE Hojuela  
-+       Cruz roja                     
-,       Inverso  L
--       w/omni casa                  
-.       X pequeña
-/       Punto rojo                       
-0       0 en una caja                    Círculo
-1       1 en una caja
-2       2 en una caja
-3       3 en una caja
-4       4 en una caja
-5       5 en una caja
-6       6 en una caja
-7       7 en una caja
-8       8 en una caja
-9       9 en un GAS de la caja
-:       Bombero                         ?
-;       Tienda                          tienda
-<       motocicleta                     Banderín
-=       Máquina de tren                  
->       Automóvil                       automóvil 
-?       Antena POS                      ? en una caja
-@       HURRICAN/TORMENTA               HURRICAN/TORMENTA 
-A       Primero auxilio                 Caja
-B       BBS                             Blowing Nieve 
-C       Canoa                         
-D       D en un círculo                 
-E       E en un circulo                 Pila de Humo
-F       F en un círculo                 
-G       Reja Antena Cuadrada            ?
-H       Hotel/Cama                     
-I       TCP/IP                          ?
-J       J en un círculo                 descarga
-K       Escuela                  
-L       Casa Iluminada                  Casa Iluminada
-M       Mac                           
-N       NTS                             ?
-O       Globo                       
-P       Carro  de  Patrulla             Rx
-Q       Circle con Círculos             Círculo con Círculos
-R       RV                              Restaurante
-S       Transbordador                   Satélite
-T       Tormenta (cloud/bolt)           Tormenta (cloud/bolt)
-U       Autobús escolar                 Sol
-V       VOR TAC                         VOR TAC Símbolo
-W       Servicio  del Tiempo Nacional   NWS-Digi
-X       Helicóptero
-Y       Velero                     
-Z       Windows
-[       corredor                        WC
-\       DF Triángulo
-]       Packet Mail Box
-^       Avión grande                    Avión Grande
-_       Estación Meteorológica          WS-Digi
-`       Plato de satélite              
-a       Ambulancia
-b       Bicicleta                       vuela nube
-c       antena de DX                     
-d       depto de bombero.               Antena de DX
-e       Caballo                         Aguanieve nube 
-f       Camión de bombero               FC Nube
-g       planeador                       Banderín (2)
-h       Hospital                        HAM
-i       Isla                            Isla
-j       Jeep                            Jeep
-k       Camión                          Camión 
-l       Punto pequeño                   Punto pequeño
-m       MIC                             Milla Poste
-n       N                               Triángulo Pequeño
-o       EOC                             Punto en Círculos 
-p       Cachorro                        Punto en Círculos 
-q       GS Antena                       Antena de GS
-r       Antena Torre                    Antena Torre
-s       Bote                            Barco
-t       TS                              ?
-u       18 Rueda de Camión
-v       Carro de mudanzas               Punto en Círculos 
-w       H20                             Diluvio
-x       X Windows                       Punto Rojo
-y       Casa w/Yagi                     Casa w/yagi 
-z                                       X Windows
-{       NIEBLA                          NIEBLA
-|       Línea Negra                     Línea negra
-}       TCP                             TCP
-~       Velero                          Velero
+                           Configurar Interfaces
+
+Haga clic en Interfaces, luego en Control de interfaz.
+
+Debería aparecer un cuadro de "Interfaces instaladas". Este cuadro le permitirá
+agregar, eliminar y modificar las propiedades de varios dispositivos que pueda
+querer usar con Xastir.
+
+Los tipos de interfaz soportados son:
+Serial TNC
+Serial TNC con GPS en cable HSP
+Serial GPS
+Serial WX
+Internet Server
+AX.25 TNC
+Networked GPS (vía gpsd)
+Networked WX
+Serial TNC con GPS en puerto AUX
+Serial KISS TNC
+Networked Database (No Implementada Aún)
+Networked AGWPE
+Serial Multi-Port KISS TNC
+SQL Databases (Experimental)
+
+Para agregar un dispositivo, haga clic en el botón Agregar. Aparecerá un cuadro
+"Choose Interface Type". Haga clic en el tipo de dispositivo que desee agregar.
+Luego haga clic en el botón Agregar en el cuadro "Choose Interface Type". Las
+propiedades de ese dispositivo aparecerán. Completa la información solicitada y
+haga clic en Aceptar.
+
+Para eliminar el dispositivo, haga clic en el dispositivo que desee eliminar y
+luego haga clic en el botón Eliminar.
+
+Para modificar las propiedades de un dispositivo, haga clic en el dispositivo que
+desee modificar, luego haga clic en el botón Propiedades. Las propiedades de ese
+dispositivo aparecerán. Cambie la información que quiera y haga clic en Aceptar.
+
+Hay ayuda más específica disponible bajo los temas de ayuda de cada tipo de
+interfaz.
+
+Las SQL Databases solo aparecerán como una opción si tiene soporte de MySQL o
+Postgis compilado.
+
+HELP-INDEX>Configurar Dispositivos Serial TNC
+
+                          Configurar Dispositivos Serial TNC
+
+Esta sección cubre la adición o modificación de TNCs en Serie o TNCs en Serie
+con un GPS en un cable HSP.
+
+Si tiene un cable HSP, que le permite compartir el puerto TNC con una unidad
+GPS, puede elegir un TNC con GPS (HSP Cable). Este es un cable especial y puede
+que no funcione en todas las combinaciones de computadoras/GPS/TNC. Si usa este
+dispositivo el TNC y el GPS deben estar configurados con los mismos parámetros
+de comunicación. Generalmente 4800 bps, 8 bits de datos, sin paridad y 1 bit de
+parada.
+
+Opciones del Puerto TNC:
+Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
+y configure las comunicaciones con él cuando el programa primero se inicia.
+
+Seleccionar "Allow Transmitting" le dirá a Xastir que cualquier dato de RF
+saliente puede ser enviado a este dispositivo para difusión.
+
+Seleccionar "Add Delay" le dirá a xastir que inserte un retraso de un segundo
+entre emitir el comando para entrar en modo "Converse" y los datos reales a
+enviar. Esta opción existe únicamente para tratar con el TNC Kantronics KAM,
+que a menudo fallará al entrar en modo converse si recibe datos inmediatamente
+después del comando converse. Si tiene un KAM, marque esta casilla; si no, déjela
+sin marcar.
+
+El Puerto TNC es el dispositivo Unix al que está conectado el TNC (o TNC y GPS).
+Normalmente puede usar /dev/ttyS0 (com1), /dev/ttyS1 (com2), etc.
+
+El comentario le permitirá establecer un nombre amigable o comentario para el
+puerto.
+
+Ahora establece la velocidad en baudios bajo la configuración del puerto y los
+parámetros bajo el estilo del puerto. La configuración del Estilo del Puerto
+8N1 se usa para 8 bits de datos, Sin paridad y 1 bit de parada. 7E1 se usa para
+7 bits de datos, paridad par y 1 bit de parada. 7O1 se usa para 7 bits de datos,
+paridad impar, y 1 bit de parada. Estos parámetros deben coincidir con su TNC
+y GPS.
+
+Elija la operación de IGate correcta para este dispositivo. Puede tener varios
+dispositivos TNC, y esta opción puede ser diferente para cada dispositivo. Si no
+está ejecutando un IGate déjelo en la opción predeterminada de "Disable".
+
+Ingrese hasta tres rutas UNPROTO. Xastir asumirá la parte XX VIA de la ruta
+UNPROTO. Se permiten tres rutas para que su señal se escuche si las condiciones
+son malas. XASTIR ciclará a través de cada una que esté llena, una por cada vez
+que se transmite. Si está local a un digi, simplemente WIDE2-2 puede ser una
+buena opción. Si usa baja potencia y/o está lejos de un digi entonces WIDE1-1,
+WIDE2-2 puede funcionar mejor. O si conoce el call de su digi más cercano puede
+usar XXXCALL, WIDE2-2. La mayoría de los usuarios solo necesitará una ruta. Si
+está en un área remota y su señal es difícil de sacar puede necesitar más.
+Consulte con un grupo local y pregunte qué ruta puede ser mejor para su área.
+Si no se ingresan rutas por defecto será WIDE2-2.
+
+Si está usando IGate a RF, puede ingresar una ruta específica a usar para
+los paquetes que envía a RF. Si deja esto en blanco, se utilizarán las rutas
+UNPROTO anteriores. Si las rutas UNPROTO están en blanco, se usará WIDE2-2.
+
+Archivos de Inicio y Apagado de TNC. Estos campos especifican un nombre de
+archivo que se ubica en el directorio /usr/local/share/xastir/config. Cada
+archivo es un archivo de texto estándar que contiene cualquier comando que
+quiera enviar a su TNC en el momento en que se activa el dispositivo (archivo
+de inicio) o se apaga.
+
+HELP-INDEX>Configurar Serial TNC con GPS en Cable HSP o Puerto AUX
+
+                Configurar Serial TNC con GPS en Cable HSP o Puerto AUX
+
+Estos tipos de interfaz híbridos implementan las opciones tanto de TNCs en
+Serie como de GPSs en Serie. Por favor consulta la ayuda de configuración tanto
+para Serial TNCs como para Serial Gpsd para más información sobre la
+configuración de estos dispositivos.
+
+"¿Enviar Control-E para obtener Datos de GPS?"
+
+Esta casilla de verificación controla si Xastir envía un Control-E al TNC cada
+vez que necesita datos de GPS.
+
+Algunos TNCs que soportan un GPS en un puerto auxiliar requieren que Xastir
+envíe un Control-E al TNC para obtener los datos de GPS cada vez que se
+necesita. Dispositivos en esta clase incluyen el Kantronics KPC-3+.
+
+Algunos dispositivos, como radios APRS Kenwood (D700, etc.) NO requieren
+esto, y de hecho el Control-E interfiere con el funcionamiento correcto de
+estos dispositivos.
+
+Debido a que Control-E era requerido por los TNCs más comunes que tenían un
+puerto auxiliar para GPS en el momento en que se escribió este tipo de interfaz,
+este es el comportamiento predeterminado de Xastir. Si tiene una radio Kenwood
+que está usando de esta forma, debe DESELECCIONAR la casilla de verificación
+"¿Enviar Control-E para obtener Datos de GPS?" en el diálogo de configuración
+para este tipo de interfaz.
+
+HELP-INDEX>Configurar Serial KISS TNC
+
+                     Configurar Serial KISS TNC
+
+Esta sección cubre la adición o modificación de TNCs en Serie KISS. El modo KISS
+puede hacerse por la mayoría de TNCs estándar también, y elimina la necesidad de
+configurar las opciones especialmente en los archivos de inicio, a costa de un
+uso ligeramente mayor del procesador. Y por supuesto esto permite el uso de TNCs
+puramente KISS, como el descrito en el número de noviembre de 2000 de QST, sin un
+programa separado o módulo del kernel.
+
+Opciones
+Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
+y configure las comunicaciones con él cuando el programa primero se inicia.
+
+Seleccionar "Allow Transmitting" le dirá a Xastir que cualquier dato de RF
+saliente puede ser enviado a este dispositivo para difusión.
+
+Seleccionar "Digipeat?" le dirá a Xastir que repita el tráfico de digipeater.
+Lo hará si el primer call de digipeater no utilizado en la ruta coincide con su
+call o un call listado en su archivo de configuración de Xastir (línea
+"RELAY_DIGIPEAT_CALLS", por defecto es "WIDE1-1"). Esta opción solo se
+recomienda para estaciones base en regiones donde hay pocos otros digipeaters de
+relleno en el área. Consulte con un grupo local sobre la mejor configuración
+para su región. Puede editar manualmente el archivo de configuración de Xastir
+cuando Xastir no está en ejecución para cambiar esta cadena para que coincida
+con tus recomendaciones locales. En EE.UU., "WIDE1-1" es la configuración
+recomendada.
+
+El Puerto TNC es el dispositivo serial Unix al que está conectado el TNC.
+Normalmente puede usar /dev/ttyS0 (com1), /dev/ttyS1 (com2), etc.
+
+El comentario le permitirá establecer un nombre amigable o comentario para el
+puerto.
+
+Ahora establece la velocidad en baudios bajo la configuración del puerto.
+
+Elija la operación de IGate correcta para este dispositivo. Puede tener varios
+dispositivos TNC, y esta opción puede ser diferente para cada dispositivo. Si no
+está ejecutando un IGate déjelo en la opción predeterminada de "Disable".
+
+Ingrese hasta tres rutas UNPROTO. Xastir asumirá la parte XX VIA de la ruta
+UNPROTO. Se permiten tres rutas para que su señal se escuche si las condiciones
+son malas. Xastir ciclará a través de cada una que esté llena, una por cada vez
+que se transmite. Si está local a un digi, simplemente WIDE2-2 puede ser una
+buena opción. Si usa baja potencia y/o está lejos de un digi entonces WIDE1-1,
+WIDE2-2 puede funcionar mejor. O si conoce el call de su digi más cercano puede
+usar XXXCALL,WIDE2-2. La mayoría de los usuarios solo necesitará una ruta. Si
+está en un área remota y su señal es difícil de sacar puede necesitar más.
+Consulte con un grupo local y pregunte qué ruta puede ser mejor para su área.
+Si no se ingresan rutas por defecto será WIDE2-2.
+
+Si está usando IGate a RF, puede ingresar una ruta específica a usar para
+los paquetes que envía a RF. Si deja esto en blanco, se utilizarán las rutas
+UNPROTO anteriores. Si las rutas UNPROTO están en blanco, se usará WIDE2-2.
+
+A continuación configura los parámetros KISS: TXdelay es el tiempo (en unidades
+de 10ms) necesario entre el cierre de la radio y cuando está lista para enviar
+datos. La persistencia y el slottime son los parámetros de acceso al canal: El
+Slottime es qué tan a menudo se ejecuta el algoritmo de acceso al canal, y
+generalmente debe establecerse en 10. La persistencia es qué tan agresivamente
+su estación intenta tomar el canal cuando está libre, y debería idealmente
+establecerse en 255 dividido por el número de estaciones en el canal. El full
+duplex permite que la transmisión comience mientras hay paquetes siendo
+recibidos en el canal; esto debería deshabilitarse en la mayoría de los casos
+(establecer en "0").
+
+HELP-INDEX>Configurar Dispositivos AX.25 TNC
+
+                        Configurar Dispositivos AX.25 TNC
+
+Esta sección cubre la adición o modificación de dispositivos AX.25 TNC. Los
+dispositivos AX.25 pueden ser cualquier dispositivo que use los controladores
+Linux AX.25. Este es un controlador a nivel del kernel, y dispositivos como
+un Baycom o un módem de sonido pueden usarse como TNC. Estos dispositivos
+deben estar configurados y en funcionamiento antes de que Xastir pueda usarlos.
+
+Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
+y configure las comunicaciones con él cuando el programa primero se inicia.
+
+Seleccionar "Allow Transmitting" le dirá a Xastir que cualquier dato de RF
+saliente puede ser enviado a este dispositivo para difusión.
+
+Seleccionar "RELAY Digipeat?" le dirá a Xastir que repita el tráfico de
+digipeater. Lo hará si el primer call de digipeater no utilizado en la ruta
+coincide con su call o un call listado en su archivo de configuración de Xastir
+(línea "RELAY_DIGIPEAT_CALLS", por defecto es "WIDE1-1"). Esta opción solo se
+recomienda para estaciones base en regiones donde hay pocos otros digipeaters de
+relleno en el área. Consulte con un grupo local sobre la mejor configuración
+para su región. Esto solo es necesario si no está usando ningún otro software
+que realice esta función, como aprsdigi o DIGI_NED. Puede editar manualmente el
+archivo de configuración de Xastir cuando Xastir no está en ejecución para
+cambiar esta cadena para que coincida con tus recomendaciones locales. En
+EE.UU., "WIDE1-1" es la configuración recomendada.
+
+Ingrese el nombre del Dispositivo AX.25 que especificó en el archivo axports
+para este dispositivo.
+
+El comentario le permitirá establecer un nombre amigable o comentario para el
+puerto.
+
+Elija la operación de IGate correcta para este dispositivo. Puede tener varios
+dispositivos TNC y esta opción puede ser diferente para cada dispositivo. Si no
+está ejecutando un IGate déjelo en la opción predeterminada de "Disable".
+
+Ingrese en hasta tres rutas UNPROTO. Xastir asumirá la parte XX VIA de la ruta
+UNPROTO. Se permiten tres rutas para que su señal se escuche si las condiciones
+son malas. Xastir ciclará a través de cada una que esté llena, una por cada vez
+que se transmite. Si está local a un digi, simplemente WIDE2-2 puede ser una
+buena opción. Si usa baja potencia y/o está lejos de un digi entonces WIDE1-1,
+WIDE2-2 puede funcionar mejor. O si conoce el call de su digi más cercano puede
+usar XXXCALL,WIDE2-2. La mayoría de los usuarios solo necesitará una ruta. Si
+está en un área remota y su señal es difícil de sacar puede necesitar más.
+Consulte con un grupo local y pregunte qué ruta puede ser mejor para su área.
+Si no se ingresan rutas por defecto será WIDE2-2.
+
+Si está usando IGate a RF, puede ingresar una ruta específica a usar para
+los paquetes que envía a RF. Si deja esto en blanco, se utilizarán las rutas
+UNPROTO anteriores. Si las rutas UNPROTO están en blanco, se usará WIDE2-2.
+
+NOTA: Para usar dispositivos AX.25 con Xastir necesitará ejecutar el programa
+como "root". Si quiere ejecutar Xastir como otro usuario puede querer
+establecer el bit suid en el archivo del programa Xastir. Por favor ver el
+archivo INSTALL para más información; el Xastir actual deja caer los privilegios
+adicionales pero no ha sido auditado para exploits. ¡Use de esta forma en un
+entorno multiusuario bajo su propio riesgo!
+
+HELP-INDEX>Configurar Dispositivos Serial GPS
+
+                       Configurar Dispositivos Serial GPS
+
+Establece el dispositivo de puerto serial para su unidad GPS. Puede usar
+valores comunes de /dev/ttyS0 (COM1) o /dev/ttyS1 (COM2).
+
+El comentario le permitirá establecer un nombre amigable o comentario para el
+puerto.
+
+Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
+y configure las comunicaciones con él cuando el programa primero se inicia.
+
+Seleccionar "Set system clock from GPS data" le dirá a Xastir que intente
+establecer el reloj del sistema a la señal de tiempo altamente preciso del
+receptor GPS. Esto requiere privilegios de root en la mayoría de los sistemas.
+
+Ahora establece la velocidad en baudios bajo la configuración del puerto y los
+parámetros bajo el estilo del puerto. La configuración del Estilo del Puerto
+8N1 se usa para 8 bits de datos, Sin paridad y 1 bit de parada. 7E1 se usa para
+7 bits de datos, paridad par y 1 bit de parada. 7O1 se usa para 7 bits de datos,
+paridad impar, y 1 bit de parada. Estos parámetros deben coincidir con su GPS.
+La mayoría de unidades GPS usarán 4800 bps y 8,n,1.
+
+HELP-INDEX>Configurar Dispositivos GPS en Red
+
+                    Configurar Dispositivos GPS en Red
+Si necesita compartir los datos de GPS con diferentes programas o máquinas,
+esta opción es la mejor. Xastir trabajará con gpsd que le permitirá varias
+conexiones para compartir sus datos de GPS.
+
+Establece el nombre de host (o dirección IP) y el número de puerto para el
+host gpsd en su red.
+
+El comentario le permitirá establecer un nombre amigable o comentario para el
+puerto.
+
+Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
+y configure las comunicaciones con él cuando el programa primero se inicia.
+
+Seleccionar "Reconnect on failure" le dirá a Xastir que intente reconectar
+cuando el flujo de datos ha fallado.
+
+Seleccionar "Set system clock from GPS data" le dirá a Xastir que intente
+establecer el reloj del sistema a la señal de tiempo altamente preciso del
+receptor GPS. Esto requiere privilegios de root en la mayoría de los sistemas.
+
+HELP-INDEX>Configurar el Servidor de Internet
+
+                         Configurar el Servidor de Internet
+
+Los Servidores de Internet le permiten enviar y recibir datos para todo el
+mundo.
+
+Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
+y configure las comunicaciones con él cuando el programa primero se inicia.
+
+Seleccionar "Allow Transmitting" le dirá a Xastir que cualquier dato saliente
+de Internet puede ser enviado a este dispositivo.
+
+Ingrese el nombre de host (o dirección IP) y el número de puerto del Servidor
+de Internet que desea contactar.
+
+Ingrese un código de acceso válido para validar su conexión; esto le permitirá
+que sus datos se transmitan a través de un IGate. Si no tiene un código de
+acceso, use el programa "callpass" incluido para generar uno. Tenga en cuenta que
+los códigos de acceso dependen de los callsigns. Desde el directorio src,
+"make callpass" debería crear el ejecutable si no está ya compilado.
+
+Ingrese cualquier parámetro de filtro. Esto causa que se envíe un mensaje
+especial al servidor solicitando que los datos se filtren de una manera
+determinada. El formato exacto de este campo está completamente especificado;
+por favor consulte APRSSIG para más información.
+
+El comentario le permitirá establecer un nombre amigable o comentario para el
+puerto.
+
+Seleccionar "Reconnect on failure" le dirá a Xastir que intente reconectar
+cuando el flujo de datos ha fallado.
+
+HELP-INDEX>Configurar una Estación Serial WX
+
+                     Configurar una Estación Serial WX
+
+Establece el dispositivo de puerto serial para su unidad WX. Puede usar
+valores comunes de /dev/ttyS0 (COM1) o /dev/ttyS1 (COM2).
+
+El comentario le permitirá establecer un nombre amigable o comentario para el
+puerto.
+
+Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
+y configure las comunicaciones con él cuando el programa primero se inicia.
+
+Ahora establece la velocidad en baudios bajo la configuración del puerto y los
+parámetros bajo el estilo del puerto. La configuración del Estilo del Puerto
+8N1 se usa para 8 bits de datos, Sin paridad y 1 bit de parada. 7E1 se usa para
+7 bits de datos, paridad par y 1 bit de parada. 7O1 se usa para 7 bits de datos,
+paridad impar, y 1 bit de parada. Estos parámetros deben coincidir con su unidad
+WX. La opción Tipo de Datos le permitirá anular qué tipo de datos seriales el
+programa buscará. La característica de detección automática primero buscará datos
+climáticos en un tipo binario como el que usa Weather Station WX-200 de Radio
+Shack. Si no se encuentra datos binarios en el flujo, Xastir buscará un tipo
+ASCII de estación WX (como Peet Bros.).
+
+Ahora establece el factor de corrección de la lluvia. Xastir requiere que el
+medidor de lluvia reporte en incrementos de .01 pulgadas. Si la unidad reporta
+en incrementos de .1 pulgadas o .1 milímetros, debe especificarse una corrección
+para obtener mediciones precisas.
+
+HELP-INDEX>Configurar una Estación WX en Red
+
+                   Configurar una Estación WX en Red
+Xastir puede usar servidores de datos WX tales como wx200d. wx200d permitirá
+varias conexiones de red, por lo tanto compartiendo los datos climáticos con
+varios programas u ordenadores.
+
+Ingrese el nombre de host (o dirección IP) y el número de puerto del servidor de
+datos WX que desea contactar.
+
+El comentario le permitirá establecer un nombre amigable o comentario para el
+puerto.
+
+Seleccionar "Activate on start up" le dirá a Xastir que busque este dispositivo
+y configure las comunicaciones con él cuando el programa primero se inicia.
+
+Seleccionar "Reconnect on failure" le dirá a Xastir que intente reconectar
+cuando el flujo de datos ha fallado.
+
+Como antes, el Tipo de Datos anulará la detección automática.
+
+Ahora establece el factor de corrección de la lluvia. Xastir requiere que el
+medidor de lluvia reporte en incrementos de .01 pulgadas. Si la unidad reporta
+en incrementos de .1 pulgadas o .1 milímetros, debe especificarse una corrección
+para obtener mediciones precisas.
+
+HELP-INDEX>Configurar una Conexión AGWPE
+
+                   Configurar una Conexión AGWPE
+
+Xastir puede usar una interfaz de red AGWPE que se ejecuta en una caja Windows
+como una interfaz TNC. También puede usar la seguridad de inicio de sesión/
+contraseña que tiene AGWPE integrada, pero debe configurar la cuenta en la
+aplicación AGWPE con su callsign como nombre de usuario, todo en letras
+mayúsculas. Por ejemplo: "AB7CD".
+
+Las otras opciones se describen en las secciones para Serial TNC e interfaces
+de Red.
+
+HELP-INDEX>Configurar una Conexión de Base de Datos SQL
+
+                Configurar una Conexión de Base de Datos SQL
+                         [Experimental]
+
+Xastir puede experimentalmente almacenar y recuperar datos de estaciones desde
+una base de datos MySQL o una base de datos Postgresql + Postgis. Ver la
+sección "OPTIONAL: Experimental. Add GIS database support." en el archivo
+INSTALL para más información. Los datos de estaciones y objetos se almacenan
+como datos espaciales, y pueden recuperarse desde otras aplicaciones GIS; por
+ejemplo, Xastir puede escribir ubicaciones de estaciones en una base de datos
+Postgis desde las cuales también pueden verse usando QGIS. Las conexiones SQL
+database también permiten la persistencia de datos entre sesiones de Xastir.
+Todos los aspectos del soporte de base de datos espacial, incluyendo estructuras
+de base de datos, son actualmente experimentales y pueden cambiar en cualquier
+momento. Puede configurar múltiples conexiones SQL database, pero solo debería
+tener una activa a la vez.
+
+Antes de crear una conexión de base de datos en Xastir, necesitará crear una
+base de datos para conectar, crear un conjunto apropiado de tablas
+(ver los scripts db_gis_xxxxx.sql en el directorio scripts), y agregar un
+usuario con una contraseña y derechos para acceder a la base de datos. Para
+bases de datos postgis también puede necesitar configurar apropiadamente el
+usuario en pg_hba.conf
+
+Las opciones de configuración en el diálogo SQL database incluyen:
+Base de datos: MySQL (lat/long) para bases de datos MySQL muy antiguas,
+          Postgis para postgresql + postgis, y
+          MySQL (Spatial) para bases de datos MySQL actuales.
+Con tablas para: Actualmente solo el esquema simple de Xastir - una tabla
+          muy básica que contiene información mínima sobre estaciones.
+Host: Dirección IP o nombre de host para el servidor de base de datos; el
+          predeterminado es localhost.
+Port: El predeterminado es 3306 para MySQL y 5432 para Postgresql. La base de
+          datos puede estar en un servidor remoto, pero el puerto apropiado
+          necesitará estar abierto en cualquier firewall.
+Username: Puede ser único para su base de datos; ej. xastir_user
+Password: Único para su base de datos.
+Schema name: El nombre de su base de datos. ej. xastir
+MySQL Socket: revisa my.cnf, o mysql --help | grep socket
+          Deja en blanco para bases de datos postgis.
+Reconnect on Net Failure: [Aún no implementado]
+Los valores predeterminados de MySQL y los valores predeterminados de Postgis
+proporcionados por los botones pueden o pueden no ser correctos para su base de
+datos.
+
+Tres opciones controlan el comportamiento de la interfaz SQL Database:
+Activate on Startup: Intenta conectar a esta base de datos y comienza a
+almacenar datos de estaciones escuchadas tan pronto como Xastir se inicia (si
+store incoming data también está seleccionado).
+
+Store incoming data: Almacena cada reporte de estación (incluyendo objetos e
+items) como un registro en la base de datos. Todas las estaciones escuchadas en
+todas las interfaces serán almacenadas en la base de datos - si está conectado
+a fuentes de internet y deja xastir ejecutándose esto fácilmente puede ser un
+millón de registros por día.
+
+Load data on startup: Recupera todos los datos de estaciones desde la base de
+datos cuando reinicia Xastir. Actualmente la única forma de recuperar datos
+persistentes desde una base de datos. Intentará conectar a la base de datos y
+recuperar datos independiente de la configuración de activate on startup o
+store incoming data. Debido a errores de redondeo y conversión, las estaciones
+no móviles pueden moverse ligeramente.
+
+El cuadro "Most Recent Error" puede o puede no contener un mensaje de error para
+ayudar a identificar problemas de conexión. Cuando Xastir falla en conectar a
+una base de datos, la interfaz mostrará ERROR en la lista de interfaces, y el
+error más reciente puede mostrarse aquí. Ejecutar xastir desde la consola y
+observar los mensajes de error allí, o ejecutar xastir desde la consola con
+xastir -v1 puede ayudar a identificar la causa de los problemas de conexión, como
+puede la examinación de los registros de error de la base de datos.
+
+Solo serás capaz de configurar una interfaz SQL Database si has compilado Xastir
+con soporte para ese DBMS (--with-mysql o --with-postgis).
+
+HELP-INDEX>Tabla de Símbolos
+
+Estos son los símbolos que puede seleccionar para su estación bajo el menú de
+configuración "Configurar la estación". La lista actual se puede encontrar en
+https://github.com/hessu/aprs-symbols.
+
+
+                             Tabla de Símbolos
+
+Símbolo     Grupo /                       Grupo \
+
+!          Triángulo con !                Triángulo con !
+"          Nube de lluvia                 Nube de lluvia
+#          Digi                           DIGI
+$          Símbolo de Teléfono            Símbolo $
+%          DX                             DX
+&          GATE-HF                        GATE
+'          Avión pequeño                  Avión estrellado
+(          Nube                           Nube
+)          TBD
+*          Copo de NIEVE                  Copo de NIEVE
++          Cruz Roja
+,          Reverse L
+-          Casa con omni
+.          Pequeña x
+/          Punto Rojo
+0          0 en una caja                  Círculo
+1          1 en una caja
+2          2 en una caja
+3          3 en una caja
+4          4 en una caja
+5          5 en una caja
+6          6 en una caja
+7          7 en una caja
+8          8 en una caja
+9          9 en una caja                  GAS
+:          Fuego                          ?
+;          Tienda                         Tienda
+<          Motocicleta                    Banderita
+=          Locomotora
+>          Coche                          Coche
+?          Antena POS                     ? en una caja
+@          HURACÁN/TORMENTA               HURACÁN/TORMENTA
+A          Primeros auxilios              Caja
+B          BBS                            Nieve soplada
+C          Canoa
+D          D en un círculo
+E          E en un círculo                Chimenea
+F          F en un círculo
+G          Antena de cuadrícula           ?
+H          Hotel/Cama
+I          TCP/IP                        ?
+J          J en un círculo                Rayo
+K          Escuela
+L          Faro                           Faro
+M          Mac
+N          NTS                           ?
+O          Globo
+P          Auto de policía                Rx
+Q          Círculo con Círculos adentro  Círculo con Círculos adentro
+R          RV                             Restaurante
+S          Transbordador                  Satélite
+T          Tormenta eléctrica (nube/rayo) Tormenta eléctrica (nube/rayo)
+U          Autobús escolar                Sol
+V          VOR TAC                        Símbolo VOR TAC
+W          Servicio Nacional de Meteorología NWS-Digi
+X          Helicóptero
+Y          Velero
+Z          Windows
+[          Corredor                       WC
+\          Triángulo DF
+]          Buzón de correo de paquetes
+^          Avión grande                   Avión grande
+_          Estación meteorológica         WS-Digi
+`          Plato satélite
+a          Ambulancia
+b          Bicicleta                      Nube soplada
+c          Antena DX
+d          Camión de bomberos             Antena DX
+e          Caballo                        Nube de aguanieve
+f          Camión de bomberos             Nube FC
+g          Planeador                      Banderita (2)
+h          Hospital                       HAM
+i          Isla                           Isla
+j          Jeep                           Jeep
+k          Camión                         Camión
+l          Punto pequeño                  Punto Pequeño
+m          MIC                            Mojón de milla
+n          N                              Triángulo pequeño
+o          EOC                            Punto con Círculos adentro
+p          Cachorro                       Punto con Círculos adentro
+q          Antena GS                      Antena GS
+r          Torre de antena                Torre de antena
+s          Barco                          Barco
+t          TS                             ?
+u          Camión de 18 ruedas
+v          Furgoneta                      Punto con Círculos adentro
+w          H2O                            Inundación
+x          Windows X                      Punto Rojo
+y          Casa con Yagi                  Casa con yagi
+z                                         Windows X
+{          NIEBLA                         NIEBLA
+|          Línea negra                    Línea negra
+}          TCP                            TCP
+~          Velero                         Velero
+


### PR DESCRIPTION
## Summary

This PR improves the Spanish localization in `config/language-Spanish.sys`, and the help file in `help/help-Spanish.dat`.

It fixes previously untranslated UI strings, spelling mistakes, missing or incorrect diacritics, unnatural wording, and several overly literal translations.

It completely overhauls the spanish help file.

## What changed

- Translated many strings that were still left in English.
- Fixed multiple typos and malformed words.
- Restored missing accent marks and corrected incorrect ones, including `ambigüa` -> `ambigua`.
- Replaced awkward or unnatural terms with more idiomatic Spanish.
- Fixed several false cognates and literal translations that did not match normal UI usage.
- Improved consistency across menus, dialogs, weather labels, and log/record terminology.
- Completed translation of the spanish help file
- Normalized help file to formal spanish since this variant is more consistent across regions

## Examples

- `bitácora` -> `registro`
- `Wind Chill` -> `Sensación térmica`
- `Heat Index` -> `Índice de calor`
- `Alta/Baja Temperat.` -> `Temp. máx./mín.`
- `Macheo Sensible` -> `Distinguir mayús./minús.`

## Notes

Technical acronyms and domain-specific labels were kept unchanged where translating them would reduce clarity. 

The change of "bitácora" to "registro" may be controversial but "registro" is more widely used. I even consulted the dictionary (https://dle.rae.es/bit%C3%A1cora) and learned that it comes from french "bitacle" (habitacle) and it refers to the box used to hold the compass. It does not refer to the log itself (*cuaderno de bitácora*), with cuaderno meaning notebook. The chosen word, registro, is the correct one (https://dle.rae.es/registro, meaning 11: "Book, used as an index, where news or data is logged". (/pedantic)

This PR was made with AI assistance.

to be merged after #369 

closes #372 