### PR TITLE
map_OSM: replace per-pixel X11 calls with XImage bulk transfer

### DIFF
--- a/src/map_OSM.c
+++ b/src/map_OSM.c
@@ -719,15 +719,20 @@ static void draw_image(
 
 
 /**********************************************************
- * draw_OSM_image() - copy map image to display
+ * render_OSM_image_pixels() - internal helper: write one decoded image's
+ * pixels into a caller-supplied XImage buffer (no ownership, no XPutImage).
+ * Called by both draw_OSM_image() (single image) and draw_OSM_tiles()
+ * (shared buffer for all tiles) so that the X server round-trips for
+ * XGetImage and XPutImage happen exactly once per redraw, not once per tile.
  **********************************************************/
-static void draw_OSM_image(
+static void render_OSM_image_pixels(
   Widget w,
   Image *image,
   ExceptionInfo *except_ptr,
   tiepoint *tpNW,
   tiepoint *tpSE,
-  int osm_zl)
+  int osm_zl,
+  XImage *ximg)    // XImage to write into; may be NULL (fallback to X11 calls)
 {
   int l;
   XColor my_colors[256];
@@ -745,6 +750,7 @@ static void draw_OSM_image(
   long scr_x,  scr_y;             // screen pixel plot positions
   long scr_xp, scr_yp;            // previous screen plot positions
   int  scr_dx, scr_dy;            // increments in screen plot positions
+  unsigned long fill_pixel = 0;   // pixel value accumulated before writing
 
   //if (debug_level & 512)
   //    fprintf(stderr,"Color depth is %i \n", (int)image->depth);
@@ -930,17 +936,8 @@ static void draw_OSM_image(
     HandlePendingEvents(app_context);
     if (interrupt_drawing_now)
     {
-      // Update to screen
-      (void)XCopyArea(XtDisplay(da),
-                      pixmap,
-                      XtWindow(da),
-                      gc,
-                      0,
-                      0,
-                      (unsigned int)screen_width,
-                      (unsigned int)screen_height,
-                      0,
-                      0);
+      // Caller owns ximg; we just return without flushing —
+      // draw_OSM_image() or draw_OSM_tiles() will handle cleanup.
       return;
     }
 
@@ -997,7 +994,7 @@ static void draw_OSM_image(
               {
                 continue;
               }
-              XSetForeground(XtDisplay(w), gc, my_colors[(int)index_pack[l]].pixel);
+              fill_pixel = my_colors[(int)index_pack[l]].pixel;
             }
             else
             {
@@ -1032,12 +1029,31 @@ static void draw_OSM_image(
                               my_colors[0].green * raster_map_intensity,
                               my_colors[0].blue * raster_map_intensity,
                               &my_colors[0].pixel);
-              XSetForeground(XtDisplay(w), gc, my_colors[0].pixel);
+              fill_pixel = my_colors[0].pixel;
             }
-            // write the pixel from the map image to the
-            // screen. Stretch to a rectangle as needed
-            // specified by scr_dx and scr_dy.
-            (void)XFillRectangle (XtDisplay (w),pixmap,gc,scr_x,scr_y,scr_dx,scr_dy);
+            // Write pixel(s) to the screen. Use XImage bulk transfer when
+            // available to avoid per-pixel X11 round-trips (major bottleneck
+            // on Raspberry Pi and slow/remote displays).
+            if (ximg)
+            {
+              int ix, iy;
+              for (iy = (int)scr_y; iy < (int)scr_y + scr_dy && iy < screen_height; iy++)
+              {
+                for (ix = (int)scr_x; ix < (int)scr_x + scr_dx && ix < screen_width; ix++)
+                {
+                  if (ix >= 0 && iy >= 0)
+                  {
+                    XPutPixel(ximg, ix, iy, fill_pixel);
+                  }
+                }
+              }
+            }
+            else
+            {
+              // Fallback: per-pixel X11 calls (slow but always available)
+              XSetForeground(XtDisplay(w), gc, fill_pixel);
+              (void)XFillRectangle(XtDisplay(w), pixmap, gc, scr_x, scr_y, scr_dx, scr_dy);
+            }
           } // check map boundaries in y direction
         }  // don't do a screen pixel twice (in the same row)
       } // loop over map pixel columns
@@ -1049,6 +1065,50 @@ static void draw_OSM_image(
       (void)map_done; // map_done is never used, but this takes away the compile warning.
     } // don't do a screen row twice.
   } // loop over map pixel rows
+}  // end render_OSM_image_pixels()
+
+
+/**********************************************************
+ * draw_OSM_image() - copy a single decoded image to the display.
+ * Allocates an XImage seeded from the current pixmap (so areas outside the
+ * image bounds are preserved), writes pixels via render_OSM_image_pixels(),
+ * then flushes the whole buffer with a single XPutImage.
+ **********************************************************/
+static void draw_OSM_image(
+  Widget w,
+  Image *image,
+  ExceptionInfo *except_ptr,
+  tiepoint *tpNW,
+  tiepoint *tpSE,
+  int osm_zl)
+{
+  // Seed XImage from current pixmap so missing-tile areas show the
+  // previously-rendered content (e.g. lower-zoom fallback tiles).
+  XImage *ximg = XGetImage(XtDisplay(w), pixmap, 0, 0,
+                            (unsigned)screen_width, (unsigned)screen_height,
+                            AllPlanes, ZPixmap);
+  if (!ximg)
+  {
+    // Fallback: zeroed buffer (better than nothing)
+    ximg = XCreateImage(XtDisplay(w),
+                        DefaultVisualOfScreen(XtScreen(w)),
+                        DefaultDepthOfScreen(XtScreen(w)), ZPixmap, 0, NULL,
+                        (unsigned)screen_width, (unsigned)screen_height, 32, 0);
+    if (ximg)
+    {
+      ximg->data = calloc(ximg->bytes_per_line * screen_height, 1);
+      if (!ximg->data) { XDestroyImage(ximg); ximg = NULL; }
+    }
+  }
+
+  render_OSM_image_pixels(w, image, except_ptr, tpNW, tpSE, osm_zl, ximg);
+
+  if (ximg)
+  {
+    XPutImage(XtDisplay(w), pixmap, gc, ximg, 0, 0, 0, 0,
+              (unsigned)screen_width, (unsigned)screen_height);
+    XDestroyImage(ximg);
+  }
 }  // end draw_OSM_image()
 
 
@@ -1082,12 +1142,9 @@ void draw_OSM_tiles (Widget w,
   int interrupted = 0;
 
   ExceptionInfo exception;
-  Image *canvas = NULL;
   Image *tile = NULL;
-  ImageInfo *canvas_info = NULL;
   ImageInfo *tile_info = NULL;
   unsigned int row, col;
-  unsigned int offset_x, offset_y;
   char tmpString[MAX_TMPSTRING];
 
   char temp_file_path[MAX_VALUE];
@@ -1274,52 +1331,6 @@ void draw_OSM_tiles (Widget w,
     /*
      * Create a canvas upon which the tiles will be composited.
     */
-    canvas_info=CloneImageInfo((ImageInfo *)NULL);
-
-    // Set canvas dimensions in pixels
-    xastir_snprintf(tmpString, sizeof(tmpString), "%lix%li",
-                    ((tiles.endx + 1) - tiles.startx) * 256,
-                    ((tiles.endy + 1) - tiles.starty) * 256);
-    (void)CloneString(&canvas_info->size, tmpString);
-
-    /*
-     * A file name based on a color creates an image filled
-     * with that color. The matte color will be treated as
-     * transparent when the completed OSM map gets copied to the X
-     * display.
-     */
-    xastir_snprintf(canvas_info->filename, sizeof(canvas_info->filename),
-                    "%s", MATTE_COLOR_STRING);
-    canvas = ReadImage(canvas_info, &exception);
-    if (exception.severity != UndefinedException)
-    {
-      CatchException(&exception);
-      fprintf(stderr, "Could not allocate canvas to hold tiles.\n");
-
-      if (canvas_info != NULL)
-      {
-        DestroyImageInfo(canvas_info);
-      }
-      return;
-    }
-    // Make sure that the canvas is an image type that uses the
-    // opacity channel for compositing.
-    SetImageType(canvas, PaletteMatteType);
-
-    // Fill the image with an opaque color. Ultimately pixels that
-    // are this color will be skipped when the image is written to
-    // the screen.
-    canvas->background_color.red = MATTE_RED;
-    canvas->background_color.green = MATTE_GREEN;
-    canvas->background_color.blue = MATTE_BLUE;
-    canvas->background_color.opacity = MATTE_OPACITY;
-#if defined(HAVE_GRAPHICSMAGICK)
-    SetImage(canvas, MATTE_OPACITY);
-#else
-    SetImageBackgroundColor(canvas);
-    SetImageOpacity(canvas, MATTE_OPACITY);
-#endif
-
     xastir_snprintf(map_it, sizeof(map_it), "%s",
                     langcode ("BBARSTA049")); // Reading tiles...
     statusline(map_it,0);
@@ -1327,81 +1338,97 @@ void draw_OSM_tiles (Widget w,
 
     tile_info = CloneImageInfo((ImageInfo *)NULL);
 
-    // Read the tile and composite them onto the canvas
-    for (col = tiles.starty, offset_y = 0;
-         col <= tiles.endy;
-         col++, offset_y += 256)
+    // Allocate a single shared XImage for all tiles.
+    // Seeded from the current pixmap so that areas without a tile (missing or
+    // not-yet-downloaded) preserve the previously-rendered content, e.g.
+    // lower-zoom fallback tiles — the same behaviour as the original canvas.
+    // Each tile's pixels are written into this buffer with render_OSM_image_pixels()
+    // and the whole screen is flushed to the pixmap in one XPutImage at the end.
+    XImage *shared_ximg = XGetImage(XtDisplay(w), pixmap, 0, 0,
+                                    (unsigned)screen_width, (unsigned)screen_height,
+                                    AllPlanes, ZPixmap);
+    if (!shared_ximg)
     {
-      for (row = tiles.startx, offset_x = 0;
-           row <= tiles.endx;
-           row++, offset_x += 256)
+      shared_ximg = XCreateImage(XtDisplay(w),
+                                 DefaultVisualOfScreen(XtScreen(w)),
+                                 DefaultDepthOfScreen(XtScreen(w)),
+                                 ZPixmap, 0, NULL,
+                                 (unsigned)screen_width,
+                                 (unsigned)screen_height, 32, 0);
+      if (shared_ximg)
       {
-
-        xastir_snprintf(tmpString, sizeof(tmpString),
-                        "%s/%d/%d/%d.%s", tileRootDir, osm_zl, row, col,
-                        tileExt[0] != '\0' ? tileExt : "png");
-        strncpy(tile_info->filename, tmpString, MaxTextExtent);
-
-        tile = ReadImage(tile_info,&exception);
-
-        if (exception.severity != UndefinedException)
-        {
-          //fprintf(stderr,"Exception severity:%d\n", exception.severity);
-          if (exception.severity==FileOpenError)
-          {
-            //fprintf(stderr, "%s NOT available\n", tile_info->filename);
-#if !defined(HAVE_GRAPHICSMAGICK)
-            ClearMagickException(&exception);
-#endif
-          }
-          else
-          {
-            xastir_snprintf(tmpString, sizeof(tmpString), "%s/%d/%d/%d.%s",
-                            tileRootDir, osm_zl, row, col,
-                            tileExt[0] != '\0' ? tileExt : "png");
-            if (debug_level & 512)
-            {
-              fprintf(stderr, "%s NOT removed.\n", tmpString);
-            }
-            else
-            {
-              fprintf(stderr, "Removing %s\n", tmpString);
-              unlink(tmpString);
-            }
-            CatchException(&exception);
-          }
-          // clear exception so next iteration doesn't fail
-          GetExceptionInfo(&exception);
-
-          // replace the missing tile with a place holder
-          //(void)strcpy(tile_info->filename, "xc:red");
-          //tile = ReadImage(tile_info, &exception);
-        }
-        if (tile)
-        {
-          (void)CompositeImage(canvas, OverCompositeOp,
-                               tile, offset_x, offset_y);
-          DestroyImage(tile);
-        }
+        shared_ximg->data = calloc(shared_ximg->bytes_per_line * screen_height, 1);
+        if (!shared_ximg->data) { XDestroyImage(shared_ximg); shared_ximg = NULL; }
       }
     }
 
-    // Set the matte color for use in transparentency testing
-    canvas->matte_color.red = MATTE_RED;
-    canvas->matte_color.green = MATTE_GREEN;
-    canvas->matte_color.blue = MATTE_BLUE;
+    tile_info = CloneImageInfo((ImageInfo *)NULL);
 
-    if (debug_level & 512)
+    // Decode and render each tile directly into the shared XImage.
+    // One XGetImage + N render passes + one XPutImage = fast.
+    for (col = tiles.starty; col <= tiles.endy; col++)
     {
-#if defined(HAVE_GRAPHICSMAGICK)
-      DescribeImage(canvas, stderr, 0);
-#else
-      IdentifyImage(canvas, stderr, 0);
-#endif
-      WriteImages(canvas_info, canvas, "/tmp/xastirOSMTiledMap.png", &exception);
-    }
+      for (row = tiles.startx; row <= tiles.endx; row++)
+      {
+          tiepoint tpTileNW, tpTileSE;
 
-    draw_OSM_image(w, canvas, &exception, &NWcorner, &SEcorner, osm_zl);
+          // Per-tile tiepoints: OSM pixel coordinates of this tile
+          tpTileNW.img_x = 0;
+          tpTileNW.img_y = 0;
+          tpTileNW.x_long = row * 256;
+          tpTileNW.y_lat  = col * 256;
+          tpTileSE.img_x  = 255;
+          tpTileSE.img_y  = 255;
+          tpTileSE.x_long = (row + 1) * 256;
+          tpTileSE.y_lat  = (col + 1) * 256;
+
+          xastir_snprintf(tmpString, sizeof(tmpString),
+                          "%s/%d/%lu/%lu.%s", tileRootDir, osm_zl, row, col,
+                          tileExt[0] != '\0' ? tileExt : "png");
+          strncpy(tile_info->filename, tmpString, MaxTextExtent);
+
+          tile = ReadImage(tile_info, &exception);
+
+          if (exception.severity != UndefinedException)
+          {
+            if (exception.severity == FileOpenError)
+            {
+#if !defined(HAVE_GRAPHICSMAGICK)
+              ClearMagickException(&exception);
+#endif
+            }
+            else
+            {
+              if (debug_level & 512)
+              {
+                fprintf(stderr, "%s NOT removed.\n", tmpString);
+              }
+              else
+              {
+                fprintf(stderr, "Removing %s\n", tmpString);
+                unlink(tmpString);
+              }
+              CatchException(&exception);
+            }
+            GetExceptionInfo(&exception);
+          }
+
+          if (tile)
+          {
+            render_OSM_image_pixels(w, tile, &exception, &tpTileNW, &tpTileSE, osm_zl,
+                                    shared_ximg);
+            DestroyImage(tile);
+          }
+        }
+      }
+
+    // Flush all tiles to the pixmap in one bulk X11 transfer
+    if (shared_ximg)
+    {
+      XPutImage(XtDisplay(w), pixmap, gc, shared_ximg, 0, 0, 0, 0,
+                (unsigned)screen_width, (unsigned)screen_height);
+      XDestroyImage(shared_ximg);
+    }
 
     // Display the OpenStreetMap attribution
     // Just reuse the tile structure rather than creating another.
@@ -1442,14 +1469,6 @@ void draw_OSM_tiles (Widget w,
   if (tile_info != NULL)
   {
     DestroyImageInfo(tile_info);
-  }
-  if (canvas_info != NULL)
-  {
-    DestroyImageInfo(canvas_info);
-  }
-  if (canvas != NULL)
-  {
-    DestroyImage(canvas);
   }
   DestroyExceptionInfo(&exception);
   return;

--- a/src/map_OSM.c
+++ b/src/map_OSM.c
@@ -1383,7 +1383,7 @@ void draw_OSM_tiles (Widget w,
           tpTileSE.y_lat  = (col + 1) * 256;
 
           xastir_snprintf(tmpString, sizeof(tmpString),
-                          "%s/%d/%lu/%lu.%s", tileRootDir, osm_zl, row, col,
+                          "%s/%d/%u/%u.%s", tileRootDir, osm_zl, row, col,
                           tileExt[0] != '\0' ? tileExt : "png");
           strncpy(tile_info->filename, tmpString, MaxTextExtent);
 
@@ -1801,9 +1801,8 @@ void draw_OSM_map (Widget w,
   DestroyImage(image);
 
   // Display the OpenStreetMap attribution
-  xastir_snprintf(OSMtmp, sizeof(OSMtmp),
+  xastir_snprintf(image_info->filename, MaxTextExtent,
                   "%s/CC_OpenStreetMap.png", get_data_base_dir("maps"));
-  strncpy(image_info->filename, OSMtmp, MaxTextExtent);
 
   image = ReadImage(image_info,&exception);
   if (exception.severity != UndefinedException)


### PR DESCRIPTION
draw_OSM_image() was calling XSetForeground() + XFillRectangle() for every individual pixel. On a 1920x1080 display with OSM tiles this amounts to ~2 million X11 round-trips per redraw, which is extremely slow on Raspberry Pi 2 hardware and noticeably slow (~2s) even on modern PCs.

Changes:
- Allocate a client-side XImage (screen-sized) before the pixel loop
- Write pixels into the XImage buffer using XPutPixel()
- Flush the entire buffer to the pixmap with a single XPutImage() call
- On allocation failure, fall back to the original XSetForeground path

Additionally, eliminate the intermediate ImageMagick canvas in draw_OSM_tiles(). Previously each tile was decoded with ReadImage() then composited onto a large in-memory canvas via CompositeImage(), and only then passed to draw_OSM_image(). This wasted memory and CPU proportional to the number of visible tiles.

Now each tile is decoded and rendered directly into the shared XImage using per-tile tiepoints, completely removing the canvas allocation, SetImage(), SetImageOpacity(), and N x CompositeImage() calls.

Tested on x86-64. Subjective improvement from ~2s redraw to near- instant on cached tiles. Expected to be significantly faster on Raspberry Pi 2 where the original bottleneck was most severe.

This PR was made with AI Assistance.

closes #374 