### PR TITLE
mgrs_utils: fix strlen/sizeof misuse for utmZone buffer

### DIFF
--- a/src/mgrs_utils.c
+++ b/src/mgrs_utils.c
@@ -69,7 +69,7 @@
                     allign more cleanly with UTM strings.
    space_string_len length of the space_string char[]
 */
-void convert_xastir_to_MGRS_str_components(char *utmZone, int UNUSED(utmZone_len),
+void convert_xastir_to_MGRS_str_components(char *utmZone, int utmZone_len,
     char *EastingL, int EastingL_len,
     char *NorthingL, int NorthingL_len,
     unsigned int *int_utmEasting, unsigned int *int_utmNorthing,
@@ -97,8 +97,8 @@ void convert_xastir_to_MGRS_str_components(char *utmZone, int UNUSED(utmZone_len
                 &utmNorthing,
                 &utmEasting,
                 utmZone,
-                sizeof(utmZone) );
-  utmZone[9] = '\0';
+                utmZone_len );
+  utmZone[utmZone_len-1] = '\0';
 
   // Restore it
   coordinate_system = coordinate_system_save;
@@ -329,7 +329,7 @@ void convert_xastir_to_MGRS_str(char *str, int str_len, long x, long y, int nice
   char EastingL[3] = "  ";
   char NorthingL[3] = "  ";
   char utmZone[10];
-  convert_xastir_to_MGRS_str_components(utmZone, strlen(utmZone),
+  convert_xastir_to_MGRS_str_components(utmZone, sizeof(utmZone),
                                         EastingL, sizeof(EastingL),
                                         NorthingL, sizeof(NorthingL),
                                         &intEasting, &intNorthing,


### PR DESCRIPTION
Fixes two related bugs in `mgrs_utils.c` that were flagged by GCC `-Wuninitialized` and reported in #376.

### Problem 1 — `strlen()` on an uninitialized buffer (undefined behaviour)

`convert_xastir_to_MGRS_str()` declared `utmZone` as a local `char[10]` without initialization, then immediately called `strlen(utmZone)` to obtain the buffer length to pass to `convert_xastir_to_MGRS_str_components()`:

```c
char utmZone[10];                                      // uninitialized
convert_xastir_to_MGRS_str_components(utmZone, strlen(utmZone), ...);
```

If none of the 10 bytes happen to be `'\0'`, `strlen()` reads past the end of the stack buffer — undefined behaviour.

### Problem 2 — `sizeof` of a pointer inside the callee

`convert_xastir_to_MGRS_str_components()` received `utmZone_len` as a parameter (previously annotated `UNUSED`) but then used `sizeof(utmZone)` when forwarding the buffer to `ll_to_utm_ups()`. Because `utmZone` is a `char *` (pointer) inside the function, `sizeof(utmZone)` evaluates to the **pointer size** (8 on 64-bit), not the intended buffer size of 10. The passed-in length was silently ignored.

### Fix

- Replace `strlen(utmZone)` with `sizeof(utmZone)` at the call site so the correct buffer size (10) is always passed.
- Remove the `UNUSED()` annotation from `utmZone_len` and use it inside the function instead of `sizeof(utmZone)`, so the caller-supplied length is actually honoured and the terminating NUL is written at the correct position.

Closes #376