### PR TITLE
Fix signpost decode when altitude precedes signpost text (issue #259)

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -7634,53 +7634,56 @@ int extract_omnidf(char *info, char *phgd)
 
 
 /*
- *  Extract signpost data from APRS info field: "{123}", an APRS data extension
+ *  Extract signpost data from APRS info field: "{123}"
  *  Format can be {1}, {12}, or {123}.  Letters or digits are ok.
+ *  Scans the entire string so altitude (/A=xxxxxx) or other comment
+ *  data may precede the signpost text without causing a parse failure.
  */
 int extract_signpost(char *info, char *signpost)
 {
-  int i,found,len,done;
+  int i, ofs, found, len, end;
 
-  //0123456
-  //{1}
-  //{12}
-  //{121}
+  found = 0;
+  len   = (int)strlen(info);
 
-  found=0;
-  len = (int)strlen(info);
-  if ( (len > 2)
-       && (info[0] == '{')
-       && ( (info[2] == '}' ) || (info[3] == '}' ) || (info[4] == '}' ) ) )
+  /* Scan for '{' followed by 1-3 chars and a closing '}' */
+  for (ofs = 0; !found && ofs < len - 2; ofs++)
   {
-
-    i = 1;
-    done = 0;
-    while (!done)                   // Snag up to three digits
+    if (info[ofs] == '{')
     {
-      if (info[i] == '}')         // We're done
+      if (   (ofs + 2 < len && info[ofs + 2] == '}')
+          || (ofs + 3 < len && info[ofs + 3] == '}')
+          || (ofs + 4 < len && info[ofs + 4] == '}') )
       {
-        found = i;              // found = position of '}' character
-        done++;
-      }
-      else
-      {
-        signpost[i-1] = info[i];
-      }
-
-      i++;
-
-      if ( (i > 4) && !done)      // Something is wrong, we should be done by now
-      {
-        done++;
-        signpost[0] = '\0';
-        return(0);
+        found = 1;
       }
     }
-    substr(signpost,info+1,found-1);
-    found++;
-    for (i=0; i<=len-found; i++)    // delete omnidf from data extension field
+  }
+
+  if (found)
+  {
+    ofs--;                    /* back up: loop incremented one past the match */
+
+    /* find closing '}' (1-3 chars after '{') */
+    end = ofs + 2;
+    while (end < len && info[end] != '}')
     {
-      info[i] = info[i+found];
+      end++;
+    }
+
+    if (end >= len || (end - ofs - 1) < 1 || (end - ofs - 1) > 3)
+    {
+      signpost[0] = '\0';
+      return(0);
+    }
+
+    substr(signpost, info + ofs + 1, end - ofs - 1);
+
+    /* delete "{xxx}" from the info buffer */
+    int match_len = end - ofs + 1;   /* length including '{' and '}' */
+    for (i = ofs; i <= len - match_len; i++)
+    {
+      info[i] = info[i + match_len];
     }
     return(1);
   }
@@ -8256,15 +8259,6 @@ void process_data_extension(DataRow *p_station, char *data, int UNUSED(type) )
       }
     }
 
-    if (extract_signpost(data, temp2))
-    {
-      //fprintf(stderr,"extracted signpost data\n");
-      xastir_snprintf(p_station->signpost,
-                      sizeof(p_station->signpost),
-                      "%s",
-                      temp2);
-    }
-
     if (extract_probability_min(data, temp3, sizeof(temp3)))
     {
       if (strncasecmp(temp3, "0.0", sizeof(temp3)) == 0)
@@ -8330,6 +8324,26 @@ void process_info_field(DataRow *p_station, char *info, int UNUSED(type) )
     xastir_snprintf(p_station->altitude, sizeof(p_station->altitude), "%.2f",atof(temp_data)*0.3048);
     //fprintf(stderr,"%.2f\n",atof(temp_data)*0.3048);
   }
+
+  /* Signpost text ({xxx}) is a comment field item, not a data extension.
+   * It is only valid for the signpost symbol (\m) and must be parsed here
+   * so that altitude (/A=xxxxxx), which may precede it in the comment,
+   * has already been stripped by extract_altitude() above.
+   * Area-object corridor strings ({xxx} for symbol \l) are handled
+   * separately in process_data_extension() via extract_area(). */
+  if (   p_station->aprs_symbol.aprs_type   == '\\'
+      && p_station->aprs_symbol.aprs_symbol == 'm')
+  {
+    char temp_signpost[3+1];
+    if (extract_signpost(info, temp_signpost))
+    {
+      xastir_snprintf(p_station->signpost,
+                      sizeof(p_station->signpost),
+                      "%s",
+                      temp_signpost);
+    }
+  }
+
   // do other things...
 }
 

--- a/tests/db_tests.at
+++ b/tests/db_tests.at
@@ -188,3 +188,65 @@ AT_KEYWORDS([db extract_speed_course])
 AT_CHECK(["$abs_top_builddir/tests/test_db" extract_speed_course_course_001], [0], [PASS: extract_speed_course with course=001 (minimum valid)
 ])
 AT_CLEANUP
+
+AT_BANNER([extract_signpost() Function Tests])
+
+AT_SETUP([extract_signpost: 1-char text])
+AT_KEYWORDS([db extract_signpost])
+AT_CHECK(["$abs_top_builddir/tests/test_db" extract_signpost_1char], [0], [PASS: extract_signpost with 1-char text
+])
+AT_CLEANUP
+
+AT_SETUP([extract_signpost: 2-char text])
+AT_KEYWORDS([db extract_signpost])
+AT_CHECK(["$abs_top_builddir/tests/test_db" extract_signpost_2char], [0], [PASS: extract_signpost with 2-char text
+])
+AT_CLEANUP
+
+AT_SETUP([extract_signpost: 3-char text])
+AT_KEYWORDS([db extract_signpost])
+AT_CHECK(["$abs_top_builddir/tests/test_db" extract_signpost_3char], [0], [PASS: extract_signpost with 3-char text
+])
+AT_CLEANUP
+
+AT_SETUP([extract_signpost: numeric text])
+AT_KEYWORDS([db extract_signpost])
+AT_CHECK(["$abs_top_builddir/tests/test_db" extract_signpost_digits], [0], [PASS: extract_signpost with numeric text
+])
+AT_CLEANUP
+
+AT_SETUP([extract_signpost: altitude precedes signpost (issue #259 regression)])
+AT_KEYWORDS([db extract_signpost])
+AT_CHECK(["$abs_top_builddir/tests/test_db" extract_signpost_after_altitude_string], [0], [PASS: extract_signpost with altitude prefix (issue #259 regression)
+])
+AT_CLEANUP
+
+AT_SETUP([extract_signpost: signpost not at start of string])
+AT_KEYWORDS([db extract_signpost])
+AT_CHECK(["$abs_top_builddir/tests/test_db" extract_signpost_not_at_start], [0], [PASS: extract_signpost with signpost not at start
+])
+AT_CLEANUP
+
+AT_SETUP([extract_signpost: empty string])
+AT_KEYWORDS([db extract_signpost])
+AT_CHECK(["$abs_top_builddir/tests/test_db" extract_signpost_empty_string], [0], [PASS: extract_signpost with empty string
+])
+AT_CLEANUP
+
+AT_SETUP([extract_signpost: no signpost token])
+AT_KEYWORDS([db extract_signpost])
+AT_CHECK(["$abs_top_builddir/tests/test_db" extract_signpost_no_signpost], [0], [PASS: extract_signpost with no signpost token
+])
+AT_CLEANUP
+
+AT_SETUP([extract_signpost: token too long (4 chars)])
+AT_KEYWORDS([db extract_signpost])
+AT_CHECK(["$abs_top_builddir/tests/test_db" extract_signpost_too_long], [0], [PASS: extract_signpost with too-long token (4 chars)
+])
+AT_CLEANUP
+
+AT_SETUP([extract_signpost: missing closing brace])
+AT_KEYWORDS([db extract_signpost])
+AT_CHECK(["$abs_top_builddir/tests/test_db" extract_signpost_no_close_brace], [0], [PASS: extract_signpost with missing closing brace
+])
+AT_CLEANUP

--- a/tests/db_tests.at
+++ b/tests/db_tests.at
@@ -215,9 +215,9 @@ AT_CHECK(["$abs_top_builddir/tests/test_db" extract_signpost_digits], [0], [PASS
 ])
 AT_CLEANUP
 
-AT_SETUP([extract_signpost: altitude precedes signpost (issue #259 regression)])
+AT_SETUP([extract_signpost: altitude precedes signpost (issue 259 regression)])
 AT_KEYWORDS([db extract_signpost])
-AT_CHECK(["$abs_top_builddir/tests/test_db" extract_signpost_after_altitude_string], [0], [PASS: extract_signpost with altitude prefix (issue #259 regression)
+AT_CHECK(["$abs_top_builddir/tests/test_db" extract_signpost_after_altitude_string], [0], [PASS: extract_signpost with altitude prefix (issue 259 regression)
 ])
 AT_CLEANUP
 

--- a/tests/test_db.c
+++ b/tests/test_db.c
@@ -562,7 +562,7 @@ int test_extract_signpost_after_altitude_string(void)
     TEST_ASSERT_STR_EQ("XY", signpost, "Signpost text should be extracted");
     TEST_ASSERT_STR_EQ("/A=000100", info, "Only signpost token should be removed");
 
-    TEST_PASS("extract_signpost with altitude prefix (issue #259 regression)");
+    TEST_PASS("extract_signpost with altitude prefix (issue 259 regression)");
 }
 
 int test_extract_signpost_not_at_start(void)

--- a/tests/test_db.c
+++ b/tests/test_db.c
@@ -37,6 +37,7 @@
 /* Forward declarations of functions under test */
 void pad_callsign(char *callsignout, char *callsignin);
 int extract_speed_course(char *info, char *speed, char *course);
+int extract_signpost(char *info, char *signpost);
 
 /* Local implementation of substr helper function */
 static void substr(char *dest, char *src, int size)
@@ -483,6 +484,161 @@ int test_extract_speed_course_course_001(void)
     TEST_PASS("extract_speed_course with course=001 (minimum valid)");
 }
 
+/* Test cases for extract_signpost() */
+
+int test_extract_signpost_1char(void)
+{
+    char info[100] = "{A}";
+    char signpost[10];
+    int result;
+
+    result = extract_signpost(info, signpost);
+
+    TEST_ASSERT(result == 1, "Should return 1 for 1-char signpost");
+    TEST_ASSERT_STR_EQ("A", signpost, "1-char signpost should be extracted");
+    TEST_ASSERT_STR_EQ("", info, "Signpost token should be removed from info");
+
+    TEST_PASS("extract_signpost with 1-char text");
+}
+
+int test_extract_signpost_2char(void)
+{
+    char info[100] = "{AB}";
+    char signpost[10];
+    int result;
+
+    result = extract_signpost(info, signpost);
+
+    TEST_ASSERT(result == 1, "Should return 1 for 2-char signpost");
+    TEST_ASSERT_STR_EQ("AB", signpost, "2-char signpost should be extracted");
+    TEST_ASSERT_STR_EQ("", info, "Signpost token should be removed from info");
+
+    TEST_PASS("extract_signpost with 2-char text");
+}
+
+int test_extract_signpost_3char(void)
+{
+    char info[100] = "{ABC}";
+    char signpost[10];
+    int result;
+
+    result = extract_signpost(info, signpost);
+
+    TEST_ASSERT(result == 1, "Should return 1 for 3-char signpost");
+    TEST_ASSERT_STR_EQ("ABC", signpost, "3-char signpost should be extracted");
+    TEST_ASSERT_STR_EQ("", info, "Signpost token should be removed from info");
+
+    TEST_PASS("extract_signpost with 3-char text");
+}
+
+int test_extract_signpost_digits(void)
+{
+    char info[100] = "{123}";
+    char signpost[10];
+    int result;
+
+    result = extract_signpost(info, signpost);
+
+    TEST_ASSERT(result == 1, "Should return 1 for numeric signpost");
+    TEST_ASSERT_STR_EQ("123", signpost, "Numeric signpost should be extracted");
+    TEST_ASSERT_STR_EQ("", info, "Signpost token should be removed from info");
+
+    TEST_PASS("extract_signpost with numeric text");
+}
+
+/* This is the regression test for issue #259: altitude precedes signpost text */
+int test_extract_signpost_after_altitude_string(void)
+{
+    /* After extract_altitude() strips /A=000100, the remaining comment is "{XY}".
+     * But we also verify the new implementation handles the full string directly,
+     * i.e. {xxx} does not have to be at position 0. */
+    char info[100] = "/A=000100{XY}";
+    char signpost[10];
+    int result;
+
+    result = extract_signpost(info, signpost);
+
+    TEST_ASSERT(result == 1, "Should find signpost even when altitude precedes it");
+    TEST_ASSERT_STR_EQ("XY", signpost, "Signpost text should be extracted");
+    TEST_ASSERT_STR_EQ("/A=000100", info, "Only signpost token should be removed");
+
+    TEST_PASS("extract_signpost with altitude prefix (issue #259 regression)");
+}
+
+int test_extract_signpost_not_at_start(void)
+{
+    char info[100] = "some comment {Z}";
+    char signpost[10];
+    int result;
+
+    result = extract_signpost(info, signpost);
+
+    TEST_ASSERT(result == 1, "Should find signpost not at start of string");
+    TEST_ASSERT_STR_EQ("Z", signpost, "Signpost text should be extracted");
+    TEST_ASSERT_STR_EQ("some comment ", info, "Prefix should remain, token removed");
+
+    TEST_PASS("extract_signpost with signpost not at start");
+}
+
+int test_extract_signpost_empty_string(void)
+{
+    char info[100] = "";
+    char signpost[10];
+    int result;
+
+    result = extract_signpost(info, signpost);
+
+    TEST_ASSERT(result == 0, "Should return 0 for empty string");
+    TEST_ASSERT_STR_EQ("", signpost, "Signpost should be empty");
+    TEST_ASSERT_STR_EQ("", info, "Info should be unchanged");
+
+    TEST_PASS("extract_signpost with empty string");
+}
+
+int test_extract_signpost_no_signpost(void)
+{
+    char info[100] = "just a plain comment";
+    char signpost[10];
+    int result;
+
+    result = extract_signpost(info, signpost);
+
+    TEST_ASSERT(result == 0, "Should return 0 when no signpost present");
+    TEST_ASSERT_STR_EQ("", signpost, "Signpost should be empty");
+    TEST_ASSERT_STR_EQ("just a plain comment", info, "Info should be unchanged");
+
+    TEST_PASS("extract_signpost with no signpost token");
+}
+
+int test_extract_signpost_too_long(void)
+{
+    char info[100] = "{ABCD}";
+    char signpost[10];
+    int result;
+
+    result = extract_signpost(info, signpost);
+
+    TEST_ASSERT(result == 0, "Should return 0 for 4-char signpost (max is 3)");
+    TEST_ASSERT_STR_EQ("", signpost, "Signpost should be empty");
+
+    TEST_PASS("extract_signpost with too-long token (4 chars)");
+}
+
+int test_extract_signpost_no_close_brace(void)
+{
+    char info[100] = "{ABC";
+    char signpost[10];
+    int result;
+
+    result = extract_signpost(info, signpost);
+
+    TEST_ASSERT(result == 0, "Should return 0 when closing brace is missing");
+    TEST_ASSERT_STR_EQ("", signpost, "Signpost should be empty");
+    TEST_ASSERT_STR_EQ("{ABC", info, "Info should be unchanged");
+
+    TEST_PASS("extract_signpost with missing closing brace");
+}
+
 /* Test runner */
 typedef struct {
     const char *name;
@@ -524,6 +680,17 @@ int main(int argc, char *argv[])
         {"extract_speed_course_partial_match", test_extract_speed_course_partial_match},
         {"extract_speed_course_long_string", test_extract_speed_course_long_string},
         {"extract_speed_course_course_001", test_extract_speed_course_course_001},
+        /* extract_signpost tests */
+        {"extract_signpost_1char", test_extract_signpost_1char},
+        {"extract_signpost_2char", test_extract_signpost_2char},
+        {"extract_signpost_3char", test_extract_signpost_3char},
+        {"extract_signpost_digits", test_extract_signpost_digits},
+        {"extract_signpost_after_altitude_string", test_extract_signpost_after_altitude_string},
+        {"extract_signpost_not_at_start", test_extract_signpost_not_at_start},
+        {"extract_signpost_empty_string", test_extract_signpost_empty_string},
+        {"extract_signpost_no_signpost", test_extract_signpost_no_signpost},
+        {"extract_signpost_too_long", test_extract_signpost_too_long},
+        {"extract_signpost_no_close_brace", test_extract_signpost_no_close_brace},
         {NULL, NULL}
     };
 


### PR DESCRIPTION
## Problem

When a signpost object includes an altitude (`/A=xxxxxx`), Xastir fails to decode the signpost text (`{xxx}`). The `{xxx}` ends up stored in the comment field instead of `p_station->signpost`, so the signpost text is not displayed on the map and the Modify Object dialog shows it in the wrong place/format.

Root causes:

1. `extract_signpost()` only matched `{xxx}` at position 0 of the buffer, so `/A=xxxxxx{xxx}` was never matched.
2. `extract_signpost()` was called from `process_data_extension()`, **before** `extract_altitude()` in `process_info_field()` had a chance to strip the altitude string. Per the APRS spec, signpost text is a **comment field** item, not an APRS data extension.

## Fix (src/db.c)

**1. Rewrite `extract_signpost()`** to scan the entire string for `{xxx}` at any offset, similar to `extract_altitude()`. This makes the parser robust against other comment-field data preceding the signpost text.

**2. Remove the `extract_signpost()` call from `process_data_extension()`.**  Signpost text is not a data extension.

**3. Add the `extract_signpost()` call to `process_info_field()`**, guarded by the signpost symbol check (`aprs_type == '\\'` && `aprs_symbol == 'm'`). It runs *after* `extract_altitude()` has already stripped `/A=xxxxxx`, so packets with altitude + signpost text now decode correctly.

Area-object corridor strings (`{xxx}` for symbol `\l`) are handled by `extract_area()` in `process_data_extension()` and are unaffected.

## Reproduction (from issue)

1. Create a signpost object with a non-zero altitude and 1–3-char signpost text.
2. Observe the first transmitted packet — e.g. `...symbol\m/A=000100{ABC}`.
3. Right-click → Modify Object.
4. **Before**: signpost text field is empty; `{ABC}` appears verbatim in the comment field.
5. **After**: signpost text field shows `ABC`; map renders the signpost label correctly.

Fixes #259.