### PR TITLE
Add global UTF-8 traffic toggle for APRS messages

### DIFF
--- a/config/language-Dutch.sys
+++ b/config/language-Dutch.sys
@@ -430,6 +430,7 @@ WPUPCFD030|Zet positie duplicaat controle uit||
 WPUPCFD031|Laad voor gedefinierde objecten uit bestand||
 WPUPCFD032|My trails in one color||
 WPUPCFD033|ALTNET:||
+WPUPCFD034|Verkeer als UTF-8 interpreteren|U|
 #
 # PopUp "Configure - Timing"
 WPUPCFTM01|Configureer tijdsinstelling|||

--- a/config/language-English.sys
+++ b/config/language-English.sys
@@ -422,6 +422,7 @@ WPUPCFD030|Disable Posit Dupe-Checks||
 WPUPCFD031|Load predefined objects from file||
 WPUPCFD032|My trails in one color||
 WPUPCFD033|ALTNET:||
+WPUPCFD034|Parse traffic as UTF-8|U|
 #
 # PopUp "Configure - Timing"
 WPUPCFTM01|Configure Timing||

--- a/config/language-French.sys
+++ b/config/language-French.sys
@@ -423,6 +423,7 @@ WPUPCFD030|Désactiver identif. de duplic. posit.||
 WPUPCFD031|Charger des objets prédéfinis à partir d'un fichier||
 WPUPCFD032|Mon parcour en une seule couleur||
 WPUPCFD033|ALTNET:||
+WPUPCFD034|Analyser le trafic en UTF-8|U|
 #
 # PopUp "Configure - Timing"
 WPUPCFTM01|Configurer temporisation||

--- a/config/language-German.sys
+++ b/config/language-German.sys
@@ -427,6 +427,7 @@ WPUPCFD030|Position Dubletten-Prüfung aus||
 WPUPCFD031|Vordefinierte Objekte aus Datei laden||
 WPUPCFD032|Meine Spuren in einer Farbe||
 WPUPCFD033|ALTNET:||
+WPUPCFD034|Verkehr als UTF-8 interpretieren|U|
 #
 # PopUp "Zeitverhalten"
 WPUPCFTM01|Einstellung des Zeitverhaltens|||

--- a/config/language-Italian.sys
+++ b/config/language-Italian.sys
@@ -418,6 +418,7 @@ WPUPCFD030|Disattiva Posit Dupe-Checks||
 WPUPCFD031|Load predefined objects from file||
 WPUPCFD032|My trails in one color||
 WPUPCFD033|ALTNET:||
+WPUPCFD034|Interpreta il traffico come UTF-8|U|
 #
 # PopUp "Configure - Timing"
 WPUPCFTM01|Configura Temporizzazioni||

--- a/config/language-Portuguese.sys
+++ b/config/language-Portuguese.sys
@@ -419,6 +419,7 @@ WPUPCFD030|Desactivar dupe-checks de  posit||
 WPUPCFD031|Load predefined objects from file||
 WPUPCFD032|My trails in one color||
 WPUPCFD033|ALTNET:||
+WPUPCFD034|Interpretar trafego como UTF-8|U|
 #
 # PopUp "Configurar - momento certo"
 WPUPCFTM01|Configurar momento certo|||

--- a/config/language-Spanish.sys
+++ b/config/language-Spanish.sys
@@ -417,6 +417,7 @@ WPUPCFD030|Desactivar comprobación de duplicados de posición||
 WPUPCFD031|Cargar objetos predefinidos desde archivo||
 WPUPCFD032|Mis rastros en un color||
 WPUPCFD033|ALTNET:||
+WPUPCFD034|Interpretar tráfico como UTF-8|U|
 #
 # Menu "Configurar - Cronómetro"
 WPUPCFTM01|Configurar Cronómetro||

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,6 +23,7 @@ XASTIR_SRC = \
     db_gui.c db_gui.h \
     dbfawk.c dbfawk.h \
     dlm.c dlm.h \
+    encoding.c encoding.h \
     dr_utils.c dr_utils.h \
     draw_symbols.c draw_symbols.h \
     fcc_data.c fcc_data.h \

--- a/src/db.c
+++ b/src/db.c
@@ -68,12 +68,14 @@
 #include "interface.h"
 #include "maps.h"
 #include "wx.h"
+#include "lang.h"
 #include "igate.h"
 #include "list_gui.h"
 #include "objects.h"
 #include "objects_gui.h"
 #include "track_gui.h"
 #include "xa_config.h"
+#include "lang.h"
 #include "x_spider.h"
 #include "db_gis.h"
 #include "db_gui.h"
@@ -216,6 +218,51 @@ void db_init(void)
 
 
 ///////////////////////////////////  Utilities  ////////////////////////////////////////////////////
+
+/*
+ * Local UTF-8 -> Latin-1 conversion helper used by db.c paths.
+ * Kept local so unit tests that link db.c without lang.c still build.
+ */
+static void db_utf8_to_latin1_inplace(char *buf)
+{
+  unsigned char *in  = (unsigned char *)buf;
+  unsigned char *out = (unsigned char *)buf;
+
+  while (*in)
+  {
+    if (*in < 0x80)
+    {
+      *out++ = *in++;
+    }
+    else if ((*in & 0xE0) == 0xC0 && (in[1] & 0xC0) == 0x80)
+    {
+      unsigned int cp = (unsigned int)((*in & 0x1F) << 6) | (in[1] & 0x3F);
+      *out++ = (cp <= 0xFF) ? (unsigned char)cp : (unsigned char)'?';
+      in += 2;
+    }
+    else if ((*in & 0xF0) == 0xE0
+             && (in[1] & 0xC0) == 0x80
+             && (in[2] & 0xC0) == 0x80)
+    {
+      *out++ = '?';
+      in += 3;
+    }
+    else if ((*in & 0xF8) == 0xF0
+             && (in[1] & 0xC0) == 0x80
+             && (in[2] & 0xC0) == 0x80
+             && (in[3] & 0xC0) == 0x80)
+    {
+      *out++ = '?';
+      in += 4;
+    }
+    else
+    {
+      *out++ = *in++;
+    }
+  }
+
+  *out = '\0';
+}
 
 
 
@@ -1281,6 +1328,7 @@ time_t msg_data_add(char *call_sign, char *from_call, char *data,
                     char *seq, char type, char from, long *record_out)
 {
   Message m_fill;
+  char normalized_data[MAX_MESSAGE_LENGTH+1];
   long record;
   char time_data[MAX_TIME];
   int do_msg_update = 0;
@@ -1334,6 +1382,19 @@ time_t msg_data_add(char *call_sign, char *from_call, char *data,
   (void)remove_trailing_spaces(m_fill.seq);
   (void)remove_leading_spaces(m_fill.seq);
 
+  if (data != NULL)
+  {
+    substr(normalized_data, data, MAX_MESSAGE_LENGTH);
+    if (traffic_utf8_enabled)
+    {
+      db_utf8_to_latin1_inplace(normalized_data);
+    }
+  }
+  else
+  {
+    normalized_data[0] = '\0';
+  }
+
   // If the sequence number is blank, then it may have been a query,
   // directed query, or group message.  Assume it is a new message in
   // each case and add it.
@@ -1366,7 +1427,7 @@ time_t msg_data_add(char *call_sign, char *from_call, char *data,
     // send message window and update the sec_heard field.  The
     // remote station must have restarted and is re-using the
     // sequence numbers.  What a pain!
-    if (strcmp(m_fill.message_line,data) != 0)
+    if (strcmp(m_fill.message_line, normalized_data) != 0)
     {
       m_fill.sec_heard = sec_now();
       last_ack_sent = (time_t)0;
@@ -1449,7 +1510,7 @@ time_t msg_data_add(char *call_sign, char *from_call, char *data,
   (void)remove_trailing_asterisk(m_fill.from_call_sign);
 
   // Update the message field
-  substr(m_fill.message_line,data,MAX_MESSAGE_LENGTH);
+  substr(m_fill.message_line, normalized_data, MAX_MESSAGE_LENGTH);
 
   substr(m_fill.seq,seq,MAX_MESSAGE_ORDER);
   (void)remove_trailing_spaces(m_fill.seq);
@@ -1887,7 +1948,19 @@ void update_messages(int force)
                   interval_str[0] = '\0';
                 }
 
-                xastir_snprintf(temp2, sizeof(temp2),
+                {
+                  char display_message[MAX_MESSAGE_LENGTH+1];
+
+                  xastir_snprintf(display_message,
+                                  sizeof(display_message),
+                                  "%s",
+                                  msg_data[msg_index[j]].message_line);
+                  if (traffic_utf8_enabled)
+                  {
+                    db_utf8_to_latin1_inplace(display_message);
+                  }
+
+                  xastir_snprintf(temp2, sizeof(temp2),
                                 "%s %-9s%s>%s%s\n",
                                 // Debug code.  Trying to find sorting error
                                 //"%ld  %s  %-9s>%s\n",
@@ -1896,7 +1969,8 @@ void update_messages(int force)
                                 msg_data[msg_index[j]].from_call_sign,
                                 interval_str,
                                 prefix,
-                                msg_data[msg_index[j]].message_line);
+                                display_message);
+                }
 
                 //fprintf(stderr,"message: %s\n", msg_data[msg_index[j]].message_line);
                 //fprintf(stderr,"update_messages: %s|%s", temp1, temp2);
@@ -13542,6 +13616,117 @@ int tactical_data_add(char *call, char *message, char UNUSED(from) )
 //
 //  Messages, Bulletins and Announcements         [APRS Reference, chapter 14]
 //
+
+
+/*
+ * Returns 1 if the message text is a valid APRS ACK packet per the
+ * APRS 1.0.1 spec (ch 14) and the Reply-Ack protocol addendum.
+ *
+ * A valid ACK has the form: ack<msgnum>[}<reply_msgnum>]
+ *   - Starts with lowercase "ack" (case-sensitive per spec)
+ *   - Followed by 1-5 alphanumeric characters (the message number)
+ *   - Optionally followed by "}" and 0-5 alphanumeric chars (Reply-Ack)
+ *   - Nothing else
+ *
+ * This strict check prevents legitimate messages that begin with "ack"
+ * (e.g. "acknowledged", "ack I received your message") from being
+ * misidentified as ACK packets and silently discarded.
+ *
+ * Note: the 'message' argument here is the text field AFTER the
+ * leading ack/rej sequence-number suffix (e.g. "{NNNNN") has already
+ * been stripped by decode_message().
+ */
+int is_aprs_ack_packet(const char *message)
+{
+  int i;
+  int msg_num_len;
+
+  if (message == NULL)
+    return 0;
+
+  /* Must start with lowercase "ack" */
+  if (strncmp(message, "ack", 3) != 0)
+    return 0;
+
+  /* Scan 1-5 alphanumeric chars for the message number */
+  i = 3;
+  msg_num_len = 0;
+  while (message[i] != '\0' && message[i] != '}' && msg_num_len < 5)
+  {
+    if (!isalnum((unsigned char)message[i]))
+      return 0;
+    i++;
+    msg_num_len++;
+  }
+
+  /* Must have at least 1 char in message number */
+  if (msg_num_len == 0)
+    return 0;
+
+  /* If there is a '}', handle the Reply-Ack portion */
+  if (message[i] == '}')
+  {
+    int reply_len = 0;
+    i++; /* skip '}' */
+    while (message[i] != '\0' && reply_len < 5)
+    {
+      if (!isalnum((unsigned char)message[i]))
+        return 0;
+      i++;
+      reply_len++;
+    }
+  }
+
+  /* Valid ACK only if we consumed the entire string */
+  return (message[i] == '\0') ? 1 : 0;
+}
+
+
+/*
+ * Returns 1 if the message text is a valid APRS REJ packet per the
+ * APRS 1.0.1 spec (ch 14).
+ *
+ * A valid REJ has the form: rej<msgnum>
+ *   - Starts with lowercase "rej" (case-sensitive per spec)
+ *   - Followed by 1-5 alphanumeric characters (the message number)
+ *   - Nothing else
+ *
+ * This strict check prevents legitimate messages beginning with "rej"
+ * (e.g. "rejected", "reject incoming call") from being misidentified
+ * as REJ packets.
+ */
+int is_aprs_rej_packet(const char *message)
+{
+  int i;
+  int msg_num_len;
+
+  if (message == NULL)
+    return 0;
+
+  /* Must start with lowercase "rej" */
+  if (strncmp(message, "rej", 3) != 0)
+    return 0;
+
+  /* Scan 1-5 alphanumeric chars for the message number */
+  i = 3;
+  msg_num_len = 0;
+  while (message[i] != '\0' && msg_num_len < 5)
+  {
+    if (!isalnum((unsigned char)message[i]))
+      return 0;
+    i++;
+    msg_num_len++;
+  }
+
+  /* Must have at least 1 char in message number */
+  if (msg_num_len == 0)
+    return 0;
+
+  /* Valid REJ only if we consumed the entire string */
+  return (message[i] == '\0') ? 1 : 0;
+}
+
+
 //
 // Returns 1 if successful
 //         0 if not successful
@@ -13758,7 +13943,7 @@ int decode_message(char *call,char *path,char *message,char from,int port,int th
   }
   len = (int)strlen(message);
   //--------------------------------------------------------------------------
-  if (!done && len > 3 && strncmp(message,"ack",3) == 0)                // ACK
+  if (!done && is_aprs_ack_packet(message))                              // ACK
   {
 
     // Received an ACK packet.  Note that these can carry the
@@ -13850,7 +14035,7 @@ int decode_message(char *call,char *path,char *message,char from,int port,int th
     fprintf(stderr,"2\n");
   }
   //--------------------------------------------------------------------------
-  if (!done && len > 3 && strncmp(message,"rej",3) == 0)                // REJ
+  if (!done && is_aprs_rej_packet(message))                              // REJ
   {
 
     substr(msg_id,message+3,5);

--- a/src/db.c
+++ b/src/db.c
@@ -13619,70 +13619,6 @@ int tactical_data_add(char *call, char *message, char UNUSED(from) )
 
 
 /*
- * Returns 1 if the message text is a valid APRS ACK packet per the
- * APRS 1.0.1 spec (ch 14) and the Reply-Ack protocol addendum.
- *
- * A valid ACK has the form: ack<msgnum>[}<reply_msgnum>]
- *   - Starts with lowercase "ack" (case-sensitive per spec)
- *   - Followed by 1-5 alphanumeric characters (the message number)
- *   - Optionally followed by "}" and 0-5 alphanumeric chars (Reply-Ack)
- *   - Nothing else
- *
- * This strict check prevents legitimate messages that begin with "ack"
- * (e.g. "acknowledged", "ack I received your message") from being
- * misidentified as ACK packets and silently discarded.
- *
- * Note: the 'message' argument here is the text field AFTER the
- * leading ack/rej sequence-number suffix (e.g. "{NNNNN") has already
- * been stripped by decode_message().
- */
-int is_aprs_ack_packet(const char *message)
-{
-  int i;
-  int msg_num_len;
-
-  if (message == NULL)
-    return 0;
-
-  /* Must start with lowercase "ack" */
-  if (strncmp(message, "ack", 3) != 0)
-    return 0;
-
-  /* Scan 1-5 alphanumeric chars for the message number */
-  i = 3;
-  msg_num_len = 0;
-  while (message[i] != '\0' && message[i] != '}' && msg_num_len < 5)
-  {
-    if (!isalnum((unsigned char)message[i]))
-      return 0;
-    i++;
-    msg_num_len++;
-  }
-
-  /* Must have at least 1 char in message number */
-  if (msg_num_len == 0)
-    return 0;
-
-  /* If there is a '}', handle the Reply-Ack portion */
-  if (message[i] == '}')
-  {
-    int reply_len = 0;
-    i++; /* skip '}' */
-    while (message[i] != '\0' && reply_len < 5)
-    {
-      if (!isalnum((unsigned char)message[i]))
-        return 0;
-      i++;
-      reply_len++;
-    }
-  }
-
-  /* Valid ACK only if we consumed the entire string */
-  return (message[i] == '\0') ? 1 : 0;
-}
-
-
-/*
  * Returns 1 if the message text is a valid APRS REJ packet per the
  * APRS 1.0.1 spec (ch 14).
  *
@@ -13943,7 +13879,7 @@ int decode_message(char *call,char *path,char *message,char from,int port,int th
   }
   len = (int)strlen(message);
   //--------------------------------------------------------------------------
-  if (!done && is_aprs_ack_packet(message))                              // ACK
+  if (!done && strncmp(message,"ack",3)==0)                              // ACK
   {
 
     // Received an ACK packet.  Note that these can carry the

--- a/src/db.c
+++ b/src/db.c
@@ -68,14 +68,12 @@
 #include "interface.h"
 #include "maps.h"
 #include "wx.h"
-#include "lang.h"
 #include "igate.h"
 #include "list_gui.h"
 #include "objects.h"
 #include "objects_gui.h"
 #include "track_gui.h"
 #include "xa_config.h"
-#include "lang.h"
 #include "x_spider.h"
 #include "db_gis.h"
 #include "db_gui.h"
@@ -1427,7 +1425,7 @@ time_t msg_data_add(char *call_sign, char *from_call, char *data,
     // send message window and update the sec_heard field.  The
     // remote station must have restarted and is re-using the
     // sequence numbers.  What a pain!
-    if (strcmp(m_fill.message_line, normalized_data) != 0)
+    if (strcmp(m_fill.message_line,normalized_data) != 0)
     {
       m_fill.sec_heard = sec_now();
       last_ack_sent = (time_t)0;
@@ -1510,7 +1508,7 @@ time_t msg_data_add(char *call_sign, char *from_call, char *data,
   (void)remove_trailing_asterisk(m_fill.from_call_sign);
 
   // Update the message field
-  substr(m_fill.message_line, normalized_data, MAX_MESSAGE_LENGTH);
+  substr(m_fill.message_line,normalized_data,MAX_MESSAGE_LENGTH);
 
   substr(m_fill.seq,seq,MAX_MESSAGE_ORDER);
   (void)remove_trailing_spaces(m_fill.seq);
@@ -13616,8 +13614,6 @@ int tactical_data_add(char *call, char *message, char UNUSED(from) )
 //
 //  Messages, Bulletins and Announcements         [APRS Reference, chapter 14]
 //
-
-
 //
 // Returns 1 if successful
 //         0 if not successful
@@ -13834,7 +13830,7 @@ int decode_message(char *call,char *path,char *message,char from,int port,int th
   }
   len = (int)strlen(message);
   //--------------------------------------------------------------------------
-  if (!done && strncmp(message,"ack",3)==0)                              // ACK
+  if (!done && len > 3 && strncmp(message,"ack",3) == 0)                // ACK
   {
 
     // Received an ACK packet.  Note that these can carry the
@@ -13926,7 +13922,7 @@ int decode_message(char *call,char *path,char *message,char from,int port,int th
     fprintf(stderr,"2\n");
   }
   //--------------------------------------------------------------------------
-  if (!done && strncmp(message,"rej",3)==0)                              // REJ
+  if (!done && len > 3 && strncmp(message,"rej",3) == 0)                // REJ
   {
 
     substr(msg_id,message+3,5);

--- a/src/db.c
+++ b/src/db.c
@@ -13618,51 +13618,6 @@ int tactical_data_add(char *call, char *message, char UNUSED(from) )
 //
 
 
-/*
- * Returns 1 if the message text is a valid APRS REJ packet per the
- * APRS 1.0.1 spec (ch 14).
- *
- * A valid REJ has the form: rej<msgnum>
- *   - Starts with lowercase "rej" (case-sensitive per spec)
- *   - Followed by 1-5 alphanumeric characters (the message number)
- *   - Nothing else
- *
- * This strict check prevents legitimate messages beginning with "rej"
- * (e.g. "rejected", "reject incoming call") from being misidentified
- * as REJ packets.
- */
-int is_aprs_rej_packet(const char *message)
-{
-  int i;
-  int msg_num_len;
-
-  if (message == NULL)
-    return 0;
-
-  /* Must start with lowercase "rej" */
-  if (strncmp(message, "rej", 3) != 0)
-    return 0;
-
-  /* Scan 1-5 alphanumeric chars for the message number */
-  i = 3;
-  msg_num_len = 0;
-  while (message[i] != '\0' && msg_num_len < 5)
-  {
-    if (!isalnum((unsigned char)message[i]))
-      return 0;
-    i++;
-    msg_num_len++;
-  }
-
-  /* Must have at least 1 char in message number */
-  if (msg_num_len == 0)
-    return 0;
-
-  /* Valid REJ only if we consumed the entire string */
-  return (message[i] == '\0') ? 1 : 0;
-}
-
-
 //
 // Returns 1 if successful
 //         0 if not successful
@@ -13971,7 +13926,7 @@ int decode_message(char *call,char *path,char *message,char from,int port,int th
     fprintf(stderr,"2\n");
   }
   //--------------------------------------------------------------------------
-  if (!done && is_aprs_rej_packet(message))                              // REJ
+  if (!done && strncmp(message,"rej",3)==0)                              // REJ
   {
 
     substr(msg_id,message+3,5);

--- a/src/db.c
+++ b/src/db.c
@@ -75,6 +75,7 @@
 #include "track_gui.h"
 #include "xa_config.h"
 #include "x_spider.h"
+#include "encoding.h"
 #include "db_gis.h"
 #include "db_gui.h"
 #include "db_funcs.h"
@@ -216,51 +217,6 @@ void db_init(void)
 
 
 ///////////////////////////////////  Utilities  ////////////////////////////////////////////////////
-
-/*
- * Local UTF-8 -> Latin-1 conversion helper used by db.c paths.
- * Kept local so unit tests that link db.c without lang.c still build.
- */
-static void db_utf8_to_latin1_inplace(char *buf)
-{
-  unsigned char *in  = (unsigned char *)buf;
-  unsigned char *out = (unsigned char *)buf;
-
-  while (*in)
-  {
-    if (*in < 0x80)
-    {
-      *out++ = *in++;
-    }
-    else if ((*in & 0xE0) == 0xC0 && (in[1] & 0xC0) == 0x80)
-    {
-      unsigned int cp = (unsigned int)((*in & 0x1F) << 6) | (in[1] & 0x3F);
-      *out++ = (cp <= 0xFF) ? (unsigned char)cp : (unsigned char)'?';
-      in += 2;
-    }
-    else if ((*in & 0xF0) == 0xE0
-             && (in[1] & 0xC0) == 0x80
-             && (in[2] & 0xC0) == 0x80)
-    {
-      *out++ = '?';
-      in += 3;
-    }
-    else if ((*in & 0xF8) == 0xF0
-             && (in[1] & 0xC0) == 0x80
-             && (in[2] & 0xC0) == 0x80
-             && (in[3] & 0xC0) == 0x80)
-    {
-      *out++ = '?';
-      in += 4;
-    }
-    else
-    {
-      *out++ = *in++;
-    }
-  }
-
-  *out = '\0';
-}
 
 
 
@@ -1385,7 +1341,7 @@ time_t msg_data_add(char *call_sign, char *from_call, char *data,
     substr(normalized_data, data, MAX_MESSAGE_LENGTH);
     if (traffic_utf8_enabled)
     {
-      db_utf8_to_latin1_inplace(normalized_data);
+      utf8_to_latin1_inplace(normalized_data);
     }
   }
   else
@@ -1955,7 +1911,7 @@ void update_messages(int force)
                                   msg_data[msg_index[j]].message_line);
                   if (traffic_utf8_enabled)
                   {
-                    db_utf8_to_latin1_inplace(display_message);
+                    utf8_to_latin1_inplace(display_message);
                   }
 
                   xastir_snprintf(temp2, sizeof(temp2),

--- a/src/db_funcs.h
+++ b/src/db_funcs.h
@@ -58,7 +58,6 @@ extern void check_message_remove(time_t curr_sec);
 void mscan_file(char msg_type, void (*function)(Message *fill));
 extern void mdisplay_file(char msg_type);
 extern void pad_callsign(char *callsignout, char *callsignin);
-extern int  is_aprs_rej_packet(const char *message);
 extern void clear_sort_file(char *filename);
 extern long sort_input_database(char *filename, char *fill, int size);
 int is_altnet(DataRow *p_station);

--- a/src/db_funcs.h
+++ b/src/db_funcs.h
@@ -58,6 +58,7 @@ extern void check_message_remove(time_t curr_sec);
 void mscan_file(char msg_type, void (*function)(Message *fill));
 extern void mdisplay_file(char msg_type);
 extern void pad_callsign(char *callsignout, char *callsignin);
+extern int  is_aprs_rej_packet(const char *message);
 extern void clear_sort_file(char *filename);
 extern long sort_input_database(char *filename, char *fill, int size);
 int is_altnet(DataRow *p_station);

--- a/src/encoding.c
+++ b/src/encoding.c
@@ -1,0 +1,132 @@
+/*
+ *
+ * XASTIR, Amateur Station Tracking and Information Reporting
+ * Copyright (C) 1999,2000  Frank Giannandrea
+ * Copyright (C) 2000-2026 The Xastir Group
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * Look at the README for more information on the program.
+ */
+
+#ifdef HAVE_CONFIG_H
+  #include "config.h"
+#endif  // HAVE_CONFIG_H
+
+#include <stddef.h>
+
+#include "encoding.h"
+
+// Must be last include file
+#include "leak_detection.h"
+
+
+/*
+ * Convert a UTF-8 encoded string to ISO-8859-1 in-place.
+ * Characters in the range U+0080..U+00FF are preserved as their single-byte
+ * Latin-1 equivalents.  Any codepoint above U+00FF (not representable in
+ * Latin-1) is replaced with '?'.  Invalid UTF-8 byte sequences are passed
+ * through as-is so that legacy ISO-8859-1 files that were never re-encoded
+ * continue to work unchanged.
+ *
+ * Because every multi-byte UTF-8 sequence is longer than its decoded form,
+ * the output is always <= the input length, making in-place conversion safe.
+ */
+void utf8_to_latin1_inplace(char *buf)
+{
+  unsigned char *in  = (unsigned char *)buf;
+  unsigned char *out = (unsigned char *)buf;
+
+  while (*in)
+  {
+    if (*in < 0x80)
+    {
+      /* Plain ASCII byte — copy as-is */
+      *out++ = *in++;
+    }
+    else if ((*in & 0xE0) == 0xC0 && (in[1] & 0xC0) == 0x80)
+    {
+      /* 2-byte sequence: U+0080 .. U+07FF */
+      unsigned int cp = (unsigned int)((*in & 0x1F) << 6) | (in[1] & 0x3F);
+      *out++ = (cp <= 0xFF) ? (unsigned char)cp : (unsigned char)'?';
+      in += 2;
+    }
+    else if ((*in & 0xF0) == 0xE0
+             && (in[1] & 0xC0) == 0x80
+             && (in[2] & 0xC0) == 0x80)
+    {
+      /* 3-byte sequence: U+0800 .. U+FFFF — outside Latin-1 */
+      *out++ = '?';
+      in += 3;
+    }
+    else if ((*in & 0xF8) == 0xF0
+             && (in[1] & 0xC0) == 0x80
+             && (in[2] & 0xC0) == 0x80
+             && (in[3] & 0xC0) == 0x80)
+    {
+      /* 4-byte sequence: U+10000 and above — outside Latin-1 */
+      *out++ = '?';
+      in += 4;
+    }
+    else
+    {
+      /* Not valid UTF-8 — pass the byte through unchanged so that a
+       * legacy file that was never re-encoded still works. */
+      *out++ = *in++;
+    }
+  }
+  *out = '\0';
+}
+
+
+/*
+ * Convert an ISO-8859-1 encoded string into UTF-8 in a caller-provided
+ * buffer.  Each byte >= 0x80 expands to a 2-byte UTF-8 sequence; ASCII
+ * bytes pass through unchanged.  Output is always NUL-terminated as long
+ * as dst_size >= 1; the result is truncated cleanly on a codepoint
+ * boundary if dst_size is too small.
+ */
+void latin1_to_utf8(const char *src, char *dst, size_t dst_size)
+{
+  size_t src_i = 0;
+  size_t dst_i = 0;
+
+  if (dst_size == 0)
+  {
+    return;
+  }
+
+  while (src[src_i] != '\0' && dst_i + 1 < dst_size)
+  {
+    unsigned char ch = (unsigned char)src[src_i++];
+
+    if (ch < 0x80)
+    {
+      dst[dst_i++] = (char)ch;
+    }
+    else
+    {
+      if (dst_i + 2 >= dst_size)
+      {
+        break;
+      }
+
+      dst[dst_i++] = (char)(0xC0 | (ch >> 6));
+      dst[dst_i++] = (char)(0x80 | (ch & 0x3F));
+    }
+  }
+
+  dst[dst_i] = '\0';
+}

--- a/src/encoding.h
+++ b/src/encoding.h
@@ -1,7 +1,6 @@
 /*
  *
  * XASTIR, Amateur Station Tracking and Information Reporting
- * Copyright (C) 1999,2000  Frank Giannandrea
  * Copyright (C) 2000-2026 The Xastir Group
  *
  * This program is free software; you can redistribute it and/or
@@ -21,20 +20,12 @@
  * Look at the README for more information on the program.
  */
 
-#ifndef XASTIR_LANG_H
-#define XASTIR_LANG_H
+#ifndef XASTIR_ENCODING_H
+#define XASTIR_ENCODING_H
 
-#include "encoding.h"
+#include <stddef.h>
 
-#define MAX_LANG_LINE_SIZE 800
-#define MAX_LANG_CODE 10
-#define MAX_LANG_ENTRIES 3000
-#define MAX_LANG_BUFFER 30000
+extern void utf8_to_latin1_inplace(char *buf);
+extern void latin1_to_utf8(const char *src, char *dst, size_t dst_size);
 
-extern int load_language_file(char *filename);
-extern char *langcode(char *code);
-extern char langcode_hotkey(char *code);
-
-
-
-#endif  /* XASTIR_LANG_H */
+#endif  /* XASTIR_ENCODING_H */

--- a/src/lang.c
+++ b/src/lang.c
@@ -50,65 +50,6 @@
 
 
 
-/*
- * Convert a UTF-8 encoded string to ISO-8859-1 in-place.
- * Characters in the range U+0080..U+00FF are preserved as their single-byte
- * Latin-1 equivalents.  Any codepoint above U+00FF (not representable in
- * Latin-1) is replaced with '?'.  Invalid UTF-8 byte sequences are passed
- * through as-is so that legacy ISO-8859-1 files that were never re-encoded
- * continue to work unchanged.
- *
- * Because every multi-byte UTF-8 sequence is longer than its decoded form,
- * the output is always <= the input length, making in-place conversion safe.
- */
-void utf8_to_latin1_inplace(char *buf)
-{
-  unsigned char *in  = (unsigned char *)buf;
-  unsigned char *out = (unsigned char *)buf;
-
-  while (*in)
-  {
-    if (*in < 0x80)
-    {
-      /* Plain ASCII byte — copy as-is */
-      *out++ = *in++;
-    }
-    else if ((*in & 0xE0) == 0xC0 && (in[1] & 0xC0) == 0x80)
-    {
-      /* 2-byte sequence: U+0080 .. U+07FF */
-      unsigned int cp = (unsigned int)((*in & 0x1F) << 6) | (in[1] & 0x3F);
-      *out++ = (cp <= 0xFF) ? (unsigned char)cp : (unsigned char)'?';
-      in += 2;
-    }
-    else if ((*in & 0xF0) == 0xE0
-             && (in[1] & 0xC0) == 0x80
-             && (in[2] & 0xC0) == 0x80)
-    {
-      /* 3-byte sequence: U+0800 .. U+FFFF — outside Latin-1 */
-      *out++ = '?';
-      in += 3;
-    }
-    else if ((*in & 0xF8) == 0xF0
-             && (in[1] & 0xC0) == 0x80
-             && (in[2] & 0xC0) == 0x80
-             && (in[3] & 0xC0) == 0x80)
-    {
-      /* 4-byte sequence: U+10000 and above — outside Latin-1 */
-      *out++ = '?';
-      in += 4;
-    }
-    else
-    {
-      /* Not valid UTF-8 — pass the byte through unchanged so that a
-       * legacy file that was never re-encoded still works. */
-      *out++ = *in++;
-    }
-  }
-  *out = '\0';
-}
-
-
-
 char lang_code[MAX_LANG_ENTRIES][MAX_LANG_CODE+1];
 char *lang_code_ptr[MAX_LANG_ENTRIES];
 char lang_buffer[MAX_LANG_BUFFER];

--- a/src/main.c
+++ b/src/main.c
@@ -1112,6 +1112,7 @@ int log_igate;                  /* toggle to allow igate logging */
 int log_wx;                     /* toggle to allow wx logging */
 int log_message_data;           /* toggle to allow message logging */
 int log_wx_alert_data;          /* toggle to allow wx alert logging */
+int traffic_utf8_enabled = 1;   /* toggle UTF-8 parse/send for APRS messages */
 
 
 int snapshots_enabled = 0;      // toggle to allow creating .png snapshots on a regular basis

--- a/src/main.c
+++ b/src/main.c
@@ -801,6 +801,7 @@ Widget new_bulletin_popup_enable;
 Widget zero_bulletin_popup_enable;
 Widget warn_about_mouse_modifiers_enable;
 Widget my_trail_diff_color_enable;
+Widget traffic_utf8_enable;
 Widget load_predefined_objects_menu_from_file_enable;
 #ifdef USE_COMBO_BOX
   Widget load_predefined_objects_menu_from_file; // combo box widget
@@ -24658,6 +24659,7 @@ void Configure_defaults_change_data(Widget widget, XtPointer clientData, XtPoint
 
   pop_up_new_bulletins = (int)XmToggleButtonGetState(new_bulletin_popup_enable);
   view_zero_distance_bulletins = (int)XmToggleButtonGetState(zero_bulletin_popup_enable);
+  traffic_utf8_enabled = (int)XmToggleButtonGetState(traffic_utf8_enable);
 
   // user interface refers to all my trails in one color
   // my trail diff color as 0 means my trails in one color, so select
@@ -25134,6 +25136,22 @@ void Configure_defaults( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPoint
                                  XmNfontList, fontlist1,
                                  NULL);
 
+    // Parse and send APRS message traffic as UTF-8
+    traffic_utf8_enable = XtVaCreateManagedWidget(langcode("WPUPCFD034"),
+                          xmToggleButtonWidgetClass,
+                          my_form,
+                          XmNtopAttachment, XmATTACH_WIDGET,
+                          XmNtopWidget, my_trail_diff_color_enable,
+                          XmNbottomAttachment, XmATTACH_NONE,
+                          XmNleftAttachment, XmATTACH_FORM,
+                          XmNleftOffset, 10,
+                          XmNrightAttachment, XmATTACH_NONE,
+                          XmNnavigationType, XmTAB_GROUP,
+                          MY_FOREGROUND_COLOR,
+                          MY_BACKGROUND_COLOR,
+                          XmNfontList, fontlist1,
+                          NULL);
+
 
     // Check box to load predefined (SAR/Event) objects menu from a file or not.
     xastir_snprintf(loadfrom,
@@ -25150,7 +25168,7 @@ void Configure_defaults( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPoint
         xmToggleButtonWidgetClass,
         my_form,
         XmNtopAttachment, XmATTACH_WIDGET,
-        XmNtopWidget, zero_bulletin_popup_enable,
+        XmNtopWidget, traffic_utf8_enable,
         XmNtopOffset,5,
         XmNbottomAttachment, XmATTACH_NONE,
         XmNleftAttachment, XmATTACH_FORM,
@@ -25176,7 +25194,7 @@ void Configure_defaults( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPoint
         xmComboBoxWidgetClass,
         my_form,
         XmNtopAttachment, XmATTACH_WIDGET,
-        XmNtopWidget, zero_bulletin_popup_enable,
+        XmNtopWidget, traffic_utf8_enable,
         XmNtopOffset, 5,
         XmNbottomAttachment, XmATTACH_NONE,
         XmNleftAttachment, XmATTACH_WIDGET,
@@ -25230,7 +25248,7 @@ void Configure_defaults( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPoint
     ++ac;
     XtSetArg(al[ac], XmNtopAttachment, XmATTACH_WIDGET);
     ++ac;
-    XtSetArg(al[ac], XmNtopWidget, zero_bulletin_popup_enable);
+    XtSetArg(al[ac], XmNtopWidget, traffic_utf8_enable);
     ++ac;
     XtSetArg(al[ac], XmNmarginWidth, 0);
     ++ac;
@@ -25466,6 +25484,10 @@ void Configure_defaults( Widget UNUSED(w), XtPointer UNUSED(clientData), XtPoint
     {
       XmToggleButtonSetState(zero_bulletin_popup_enable,FALSE,FALSE);
     }
+
+    XmToggleButtonSetState(traffic_utf8_enable,
+                           traffic_utf8_enabled ? TRUE : FALSE,
+                           FALSE);
 
     if(warn_about_mouse_modifiers)
     {

--- a/src/main.h
+++ b/src/main.h
@@ -276,6 +276,7 @@ extern int log_net_data;
 extern int log_message_data;
 extern int log_wx_alert_data;
 extern int log_wx;
+extern int traffic_utf8_enabled;
 extern int snapshots_enabled;
 extern int kmlsnapshots_enabled;
 extern char user_dir[];

--- a/src/messages.c
+++ b/src/messages.c
@@ -75,6 +75,40 @@ Message_Window mw[MAX_MESSAGE_WINDOWS+1];   // Send Message widgets
 Message_transmit message_pool[MAX_OUTGOING_MESSAGES+1]; // Transmit message queue
 
 
+static void latin1_to_utf8(const char *src, char *dst, size_t dst_size)
+{
+  size_t src_i = 0;
+  size_t dst_i = 0;
+
+  if (dst_size == 0)
+  {
+    return;
+  }
+
+  while (src[src_i] != '\0' && dst_i + 1 < dst_size)
+  {
+    unsigned char ch = (unsigned char)src[src_i++];
+
+    if (ch < 0x80)
+    {
+      dst[dst_i++] = (char)ch;
+    }
+    else
+    {
+      if (dst_i + 2 >= dst_size)
+      {
+        break;
+      }
+
+      dst[dst_i++] = (char)(0xC0 | (ch >> 6));
+      dst[dst_i++] = (char)(0x80 | (ch & 0x3F));
+    }
+  }
+
+  dst[dst_i] = '\0';
+}
+
+
 
 
 
@@ -708,6 +742,8 @@ void output_message(char *from, char *to, char *message, char *path)
 {
   int ok,i,j;
   char message_out[MAX_MESSAGE_OUTPUT_LENGTH+1+5+1]; // +'{' +msg_id +terminator
+  char message_utf8[(MAX_MESSAGE_LENGTH*2)+1];
+  const char *message_bytes;
   int last_space, message_ptr, space_loc;
   int wait_on_first_ack;
   int error;
@@ -715,6 +751,21 @@ void output_message(char *from, char *to, char *message, char *path)
 
 
 //fprintf(stderr,"output_message:%s\n", message);
+
+  if (message == NULL)
+  {
+    return;
+  }
+
+  if (traffic_utf8_enabled)
+  {
+    latin1_to_utf8(message, message_utf8, sizeof(message_utf8));
+    message_bytes = message_utf8;
+  }
+  else
+  {
+    message_bytes = message;
+  }
 
   message_ptr=0;
   last_space=0;
@@ -730,7 +781,7 @@ void output_message(char *from, char *to, char *message, char *path)
   // a chunk at a time, size of chunk to correspond to max APRS
   // message line length.
   //
-  while (!error && (message_ptr < (int)strlen(message)))
+  while (!error && (message_ptr < (int)strlen(message_bytes)))
   {
     ok=0;
     space_loc=0;
@@ -742,10 +793,10 @@ void output_message(char *from, char *to, char *message, char *path)
     for (j=0; j<MAX_MESSAGE_OUTPUT_LENGTH; j++)
     {
 
-      if(message[j+message_ptr] != '\0')
+      if(message_bytes[j+message_ptr] != '\0')
       {
 
-        if(message[j+message_ptr]==' ')
+        if(message_bytes[j+message_ptr]==' ')
         {
           last_space=j+message_ptr+1;
           space_loc=j;
@@ -753,7 +804,7 @@ void output_message(char *from, char *to, char *message, char *path)
 
         if (j!=MAX_MESSAGE_OUTPUT_LENGTH)
         {
-          message_out[j]=message[j+message_ptr];
+          message_out[j]=message_bytes[j+message_ptr];
           message_out[j+1] = '\0';
         }
         else
@@ -772,7 +823,7 @@ void output_message(char *from, char *to, char *message, char *path)
       else
       {
         j=MAX_MESSAGE_OUTPUT_LENGTH+1;
-        last_space=strlen(message)+1;
+        last_space=strlen(message_bytes)+1;
       }
     }
 

--- a/src/messages.c
+++ b/src/messages.c
@@ -54,6 +54,7 @@
 #include "util.h"
 #include "interface.h"
 #include "xa_config.h"
+#include "encoding.h"
 
 // Must be last include file
 #include "leak_detection.h"
@@ -73,40 +74,6 @@ char auto_reply_message[100];
 Message_Window mw[MAX_MESSAGE_WINDOWS+1];   // Send Message widgets
 
 Message_transmit message_pool[MAX_OUTGOING_MESSAGES+1]; // Transmit message queue
-
-
-static void latin1_to_utf8(const char *src, char *dst, size_t dst_size)
-{
-  size_t src_i = 0;
-  size_t dst_i = 0;
-
-  if (dst_size == 0)
-  {
-    return;
-  }
-
-  while (src[src_i] != '\0' && dst_i + 1 < dst_size)
-  {
-    unsigned char ch = (unsigned char)src[src_i++];
-
-    if (ch < 0x80)
-    {
-      dst[dst_i++] = (char)ch;
-    }
-    else
-    {
-      if (dst_i + 2 >= dst_size)
-      {
-        break;
-      }
-
-      dst[dst_i++] = (char)(0xC0 | (ch >> 6));
-      dst[dst_i++] = (char)(0x80 | (ch & 0x3F));
-    }
-  }
-
-  dst[dst_i] = '\0';
-}
 
 
 

--- a/src/xa_config.c
+++ b/src/xa_config.c
@@ -1036,6 +1036,7 @@ void save_data(void)
     store_int (fout, "LOG_WX", log_wx);
     store_int (fout, "LOG_MESSAGE", log_message_data);
     store_int (fout, "LOG_WX_ALERT", log_wx_alert_data);
+    store_int (fout, "TRAFFIC_UTF8", traffic_utf8_enabled);
     store_string (fout, "LOGFILE_IGATE", LOGFILE_IGATE);
     store_string (fout, "LOGFILE_NET", LOGFILE_NET);
     store_string (fout, "LOGFILE_WX", LOGFILE_WX);
@@ -2397,6 +2398,8 @@ void load_data_or_default(void)
                     sizeof(LOGFILE_WX_ALERT),
                     "%s",
                     "logs/wx_alert.log");
+
+  traffic_utf8_enabled = get_int ("TRAFFIC_UTF8", 0,1,1);
 
   // SNAPSHOTS
   snapshots_enabled = get_int ("SNAPSHOTS_ENABLED", 0,1,0);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,7 +24,7 @@ test_interface_helpers_SOURCES = test_interface_helpers.c
 test_interface_helpers_CPPFLAGS = -I$(top_srcdir)/src
 
 
-test_db_SOURCES = test_db.c test_db_stubs.c $(top_srcdir)/src/db.c
+test_db_SOURCES = test_db.c test_db_stubs.c $(top_srcdir)/src/db.c $(top_srcdir)/src/encoding.c
 test_db_CPPFLAGS = $(CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir)/src -I$(top_builddir)
 #test_db_LDADD = -L$(top_builddir)/src/rtree -lrtree
 
@@ -40,7 +40,7 @@ test_output_my_aprs_data_LDADD = -lpthread
 test_util_SOURCES = test_util.c test_util_stubs.c $(top_srcdir)/src/util.c
 test_util_CPPFLAGS = $(CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir)/src -I$(top_builddir)
 
-test_objects_SOURCES = test_objects.c test_objects_stubs.c $(top_srcdir)/src/objects.c $(top_srcdir)/src/util.c $(top_srcdir)/src/object_utils.c $(top_srcdir)/src/db.c
+test_objects_SOURCES = test_objects.c test_objects_stubs.c $(top_srcdir)/src/objects.c $(top_srcdir)/src/util.c $(top_srcdir)/src/object_utils.c $(top_srcdir)/src/db.c $(top_srcdir)/src/encoding.c
 test_objects_CPPFLAGS = $(CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir)/src -I$(top_builddir)
 
 # Nominatim tests (conditional on HAVE_NOMINATIM)

--- a/tests/test_db_stubs.c
+++ b/tests/test_db_stubs.c
@@ -31,7 +31,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <string.h>
 #include "tests/test_framework.h"
 
 #define MAX_CALLSIGN 9       // Objects are up to 9 chars
@@ -58,13 +57,7 @@ int wait_to_redraw = 0;
 STUB_IMPL(alert_build_list)
 STUB_IMPL(alert_match)
 STUB_IMPL(alert_on_alert_list)
-void all_messages(char from, char *call_sign, char *from_call, char *message)
-{
-    (void)from;
-    (void)call_sign;
-    (void)from_call;
-    (void)message;
-}
+STUB_IMPL(all_messages)
 STUB_IMPL(bulletin_message_check)
 STUB_IMPL(draw_area)
 STUB_IMPL(draw_labeled_area)
@@ -98,13 +91,7 @@ STUB_IMPL(decode_U2000_L)
 STUB_IMPL(decode_U2000_P)
 STUB_IMPL(disown_object_item)
 STUB_IMPL(display_station)
-double distance_from_my_station(char *call_sign, char *course_deg, int english_units)
-{
-    (void)call_sign;
-    (void)course_deg;
-    (void)english_units;
-    return 0.0;
-}
+STUB_IMPL(distance_from_my_station)
 STUB_IMPL(draw_trail)
 STUB_IMPL(end_critical_section)
 STUB_IMPL(filecreate)
@@ -112,13 +99,7 @@ STUB_IMPL(fill_in_new_alert_entries)
 STUB_IMPL(get_iso_datetime)
 STUB_IMPL(get_send_message_path)
 STUB_IMPL(get_tactical_from_hash)
-char *get_time(char *time_here)
-{
-    if (time_here != NULL) {
-        strcpy(time_here, "00/00/00 00:00");
-    }
-    return time_here;
-}
+STUB_IMPL(get_time)
 STUB_IMPL(get_timestamp)
 STUB_IMPL(get_user_base_dir)
 STUB_IMPL(get_w3cdtf_datetime)
@@ -139,59 +120,12 @@ STUB_IMPL(popup_message)
 STUB_IMPL(popup_message_always)
 STUB_IMPL(port_write_string)
 STUB_IMPL(position_defined)
-void remove_leading_spaces(char *data)
-{
-    char *src = data;
-    char *dest = data;
-
-    if (data == NULL) {
-        return;
-    }
-
-    while (*src == ' ') {
-        src++;
-    }
-
-    while (*src != '\0') {
-        *dest++ = *src++;
-    }
-
-    *dest = '\0';
-}
-
-void remove_trailing_asterisk(char *data)
-{
-    size_t len;
-
-    if (data == NULL) {
-        return;
-    }
-
-    len = strlen(data);
-    if (len > 0 && data[len - 1] == '*') {
-        data[len - 1] = '\0';
-    }
-}
-
-void remove_trailing_spaces(char *data)
-{
-    size_t len;
-
-    if (data == NULL) {
-        return;
-    }
-
-    len = strlen(data);
-    while (len > 0 && data[len - 1] == ' ') {
-        data[--len] = '\0';
-    }
-}
+STUB_IMPL(remove_leading_spaces)
+STUB_IMPL(remove_trailing_asterisk)
+STUB_IMPL(remove_trailing_spaces)
 STUB_IMPL(SayText)
 STUB_IMPL(spell_it_out)
-time_t sec_now(void)
-{
-    return (time_t)1000;
-}
+STUB_IMPL(sec_now)
 STUB_IMPL(send_agwpe_packet)
 STUB_IMPL(send_ax25_frame)
 STUB_IMPL(stations_types)

--- a/tests/test_db_stubs.c
+++ b/tests/test_db_stubs.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <string.h>
 #include "tests/test_framework.h"
 
 #define MAX_CALLSIGN 9       // Objects are up to 9 chars
@@ -48,6 +49,7 @@ int track_station_on = 0;
 char tracking_station_call[100] = "";
 int trail_segment_distance = 0;
 int trail_segment_time = 0;
+int traffic_utf8_enabled = 1;
 int transmit_disable = 0;
 int transmit_now = 0;
 int wait_to_redraw = 0;
@@ -56,7 +58,13 @@ int wait_to_redraw = 0;
 STUB_IMPL(alert_build_list)
 STUB_IMPL(alert_match)
 STUB_IMPL(alert_on_alert_list)
-STUB_IMPL(all_messages)
+void all_messages(char from, char *call_sign, char *from_call, char *message)
+{
+    (void)from;
+    (void)call_sign;
+    (void)from_call;
+    (void)message;
+}
 STUB_IMPL(bulletin_message_check)
 STUB_IMPL(draw_area)
 STUB_IMPL(draw_labeled_area)
@@ -90,7 +98,13 @@ STUB_IMPL(decode_U2000_L)
 STUB_IMPL(decode_U2000_P)
 STUB_IMPL(disown_object_item)
 STUB_IMPL(display_station)
-STUB_IMPL(distance_from_my_station)
+double distance_from_my_station(char *call_sign, char *course_deg, int english_units)
+{
+    (void)call_sign;
+    (void)course_deg;
+    (void)english_units;
+    return 0.0;
+}
 STUB_IMPL(draw_trail)
 STUB_IMPL(end_critical_section)
 STUB_IMPL(filecreate)
@@ -98,7 +112,13 @@ STUB_IMPL(fill_in_new_alert_entries)
 STUB_IMPL(get_iso_datetime)
 STUB_IMPL(get_send_message_path)
 STUB_IMPL(get_tactical_from_hash)
-STUB_IMPL(get_time)
+char *get_time(char *time_here)
+{
+    if (time_here != NULL) {
+        strcpy(time_here, "00/00/00 00:00");
+    }
+    return time_here;
+}
 STUB_IMPL(get_timestamp)
 STUB_IMPL(get_user_base_dir)
 STUB_IMPL(get_w3cdtf_datetime)
@@ -119,12 +139,59 @@ STUB_IMPL(popup_message)
 STUB_IMPL(popup_message_always)
 STUB_IMPL(port_write_string)
 STUB_IMPL(position_defined)
-STUB_IMPL(remove_leading_spaces)
-STUB_IMPL(remove_trailing_asterisk)
-STUB_IMPL(remove_trailing_spaces)
+void remove_leading_spaces(char *data)
+{
+    char *src = data;
+    char *dest = data;
+
+    if (data == NULL) {
+        return;
+    }
+
+    while (*src == ' ') {
+        src++;
+    }
+
+    while (*src != '\0') {
+        *dest++ = *src++;
+    }
+
+    *dest = '\0';
+}
+
+void remove_trailing_asterisk(char *data)
+{
+    size_t len;
+
+    if (data == NULL) {
+        return;
+    }
+
+    len = strlen(data);
+    if (len > 0 && data[len - 1] == '*') {
+        data[len - 1] = '\0';
+    }
+}
+
+void remove_trailing_spaces(char *data)
+{
+    size_t len;
+
+    if (data == NULL) {
+        return;
+    }
+
+    len = strlen(data);
+    while (len > 0 && data[len - 1] == ' ') {
+        data[--len] = '\0';
+    }
+}
 STUB_IMPL(SayText)
 STUB_IMPL(spell_it_out)
-STUB_IMPL(sec_now)
+time_t sec_now(void)
+{
+    return (time_t)1000;
+}
 STUB_IMPL(send_agwpe_packet)
 STUB_IMPL(send_ax25_frame)
 STUB_IMPL(stations_types)

--- a/tests/test_objects_stubs.c
+++ b/tests/test_objects_stubs.c
@@ -59,6 +59,7 @@ int track_station_on = 0;
 char tracking_station_call[100] = "";
 int trail_segment_distance = 0;
 int trail_segment_time = 0;
+int traffic_utf8_enabled = 1;
 int transmit_now = 0;
 int wait_to_redraw = 0;
 void *da=NULL;


### PR DESCRIPTION
## Summary
This PR adds configurable UTF-8 handling for APRS message traffic to improve interoperability with modern clients such as APRSdroid.

It introduces a global config option that controls both:
- incoming message normalization for display in legacy Motif/Latin-1 UI paths, and
- outgoing message encoding so transmitted payloads can be UTF-8.

Closes: #380

## What changed
- Added global runtime/config variable `traffic_utf8_enabled`.
- Persisted setting in `xastir.cnf` as `TRAFFIC_UTF8` (load/save).
- Gated incoming conversion in message ingest/display code paths.
- Gated outgoing conversion in message output path.
- Updated unit-test stubs to include the new global symbol used by `db.c` test links.

## Behavior
- `TRAFFIC_UTF8=1` (default):
  - Incoming: normalize UTF-8 message text for Latin-1 UI display.
  - Outgoing: encode Latin-1 UI input to UTF-8 before transmit.
- `TRAFFIC_UTF8=0`:
  - Preserve legacy byte behavior (no UTF-8 parse/send conversions).

## Limitations
- This is not full Unicode UI support.
- Scope is Western European language compatibility (Latin-1 range).
- No emoji support.
- No CJK support.
- Characters outside Latin-1 are replaced during UI normalization.

## Validation
- Full build/install script completed successfully (`./build.sh`, exit 0).
- Addressed unit-test link dependencies by adding stub definitions for the new global.
