### PR TITLE
Fix misparsed weather alerts

### DIFF
--- a/src/alert.c
+++ b/src/alert.c
@@ -1327,7 +1327,7 @@ void alert_build_list(Message *fill)
     // alerts with up to five alerts per message.  This doesn't
     // handle filling in the title for compressed alerts though.
     ret = sscanf(fill->message_line,
-                 "%20[^,],%20[^,],%32[^,],%32[^,],%32[^,],%32[^,],%32[^,]",
+                 "%20[^,],%30[^,],%32[^,],%32[^,],%32[^,],%32[^,],%32[^,]",
                  entry.activity,      // 191700z
                  entry.alert_tag,     // WIND
                  &title[0][0],        // CA_Z007
@@ -1343,7 +1343,7 @@ void alert_build_list(Message *fill)
     }
     // Force a termination for each
     entry.activity[20]  = '\0';
-    entry.alert_tag[20] = '\0';
+    entry.alert_tag[30] = '\0';
     title[0][TITLE_SIZE]        = '\0';
     title[1][TITLE_SIZE]        = '\0';
     title[2][TITLE_SIZE]        = '\0';
@@ -1386,7 +1386,7 @@ void alert_build_list(Message *fill)
       // a really long new message and add it to the queue,
       // in which case we'd exit from this routine as soon as
       // it was submitted.
-      ret = sscanf(fill->message_line, "%20[^,],%20[^,],%255[^, ]",
+      ret = sscanf(fill->message_line, "%20[^,],%30[^,],%255[^, ]",
                    entry.activity,
                    entry.alert_tag,
                    compressed_wx);     // Stick the long string in here
@@ -1769,7 +1769,7 @@ void alert_build_list(Message *fill)
       // a really long new message and add it to the queue,
       // in which case we'd exit from this routine as soon as
       // it was submitted.
-      ret = sscanf(fill->message_line, "%20[^,],%20[^,],%255[^, ]",
+      ret = sscanf(fill->message_line, "%20[^,],%30[^,],%255[^, ]",
                    entry.activity,
                    entry.alert_tag,
                    compressed_wx);     // Stick the long string in here
@@ -2135,7 +2135,7 @@ void alert_build_list(Message *fill)
     }
 
     // Terminate the strings
-    entry.activity[20] = entry.alert_tag[20] = '\0';
+    entry.activity[20] = entry.alert_tag[30] = '\0';
 
     // If the expire time is missing, shift fields to the right
     // by one field.  Evidently we can have an alert come across
@@ -2170,7 +2170,7 @@ void alert_build_list(Message *fill)
                       sizeof(entry.alert_tag),
                       "%s",
                       entry.activity);
-      entry.alert_tag[20] = '\0';
+      entry.alert_tag[30] = '\0';
 
       // Shouldn't we clear out entry.activity in this
       // case???  We've determined it's not a date/time value.

--- a/src/alert.h
+++ b/src/alert.h
@@ -60,7 +60,7 @@ typedef struct
   double top_boundary, left_boundary, bottom_boundary, right_boundary;
   time_t expiration;  // In local time (secs since epoch)
   char activity[21];
-  char alert_tag[21];
+  char alert_tag[31];
   char title[33];
   char alert_level;
   char from[10];


### PR DESCRIPTION
Since the code that handles weather alerts was written, the format of 
weather alerts has deviated from the standards that were in place back 
then.   Notably, the type of alert is no longer selected from a tiny set of 
standard abbreviations, and different weather offices issue them with 
very different formats.

Notably among these is the now-common use of the alert type "Special 
Marine Warning".   This alert type exceeds the length of the structure
field we'd been reserving for the text, and the sscanf that parses the
data fails to parse fields longer than 20 characters.

This commit expands the char array for the alert type and changes the 
sscanf format to account for longer alert types.

Prior to this commit, xastir would report failure to parse alerts, having 
only scanned 2 fields out of an expected 3.

After this commit, these alerts are parsed correctly and no warnings 
are spewed to the console.

Closes #388