### PR TITLE
Fix uninitialized config paths on save failure

### DIFF
--- a/src/xa_config.c
+++ b/src/xa_config.c
@@ -545,6 +545,20 @@ void save_data(void)
   get_user_base_dir(CONFIG_FILE_TMP, config_file_tmp,
                     sizeof(config_file_tmp));
 
+  // Fill in the config and backup file paths up front.  These must be
+  // initialized before the fopen() below so that the error/recovery
+  // path (the "else" branch when fopen() fails) doesn't reference
+  // uninitialized buffers when logging and renaming files.
+  get_user_base_dir(CONFIG_FILE, config_file, sizeof(config_file));
+  get_user_base_dir(CONFIG_FILE_BAK1, config_file_bak1,
+                    sizeof(config_file_bak1));
+  get_user_base_dir(CONFIG_FILE_BAK2, config_file_bak2,
+                    sizeof(config_file_bak2));
+  get_user_base_dir(CONFIG_FILE_BAK3, config_file_bak3,
+                    sizeof(config_file_bak3));
+  get_user_base_dir(CONFIG_FILE_BAK4, config_file_bak4,
+                    sizeof(config_file_bak4));
+
   // Save to the new config file
   fout = fopen (config_file_tmp, "a");
   if (fout != NULL)
@@ -1205,21 +1219,6 @@ void save_data(void)
 
     // Close the config_file_tmp file, we're done writing it.
     (void)fclose (fout);
-
-
-    get_user_base_dir(CONFIG_FILE, config_file, sizeof(config_file));
-
-    get_user_base_dir(CONFIG_FILE_BAK1, config_file_bak1,
-                      sizeof(config_file_bak1));
-
-    get_user_base_dir(CONFIG_FILE_BAK2, config_file_bak2,
-                      sizeof(config_file_bak2));
-
-    get_user_base_dir(CONFIG_FILE_BAK3, config_file_bak3,
-                      sizeof(config_file_bak3));
-
-    get_user_base_dir(CONFIG_FILE_BAK4,config_file_bak4,
-                      sizeof(config_file_bak4));
 
 
     //


### PR DESCRIPTION
### Problem
In `save_data()` (`src/xa_config.c`), the buffers `config_file` and
`config_file_bak1..4` are only populated (via `get_user_base_dir()`)
**inside** the `if (fout != NULL)` block. When `fopen()` of the temp
config file fails (disk full, permission denied, read-only home, …),
execution falls into the `else` branch, which then uses those buffers
uninitialized:

- `fprintf(stderr, "...%s\n", config_file);`
- `rename(config_file_bak1, config_file);`

This is undefined behaviour: the recovery code that is meant to restore
the previous configuration operates on uninitialized stack contents as
pathnames, so it can fail silently or rename unintended files.

### Fix
Move the `get_user_base_dir()` calls that build these paths ahead of the
`fopen()`, so both the success path and the error/recovery path see
valid pathnames. No behavioural change on the normal path.

### Testing
`./bootstrap.sh && ./configure && make` builds cleanly (0 errors);
`xa_config.o` compiles without new warnings. cppcheck no longer reports
the `uninitvar` warnings at the affected lines.