### PR TITLE
Fix out-of-bounds read in digipeat path rebuild

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -16328,14 +16328,17 @@ void relay_digipeat(char *call, char *path, char *info, int port)
                   Substring[1]);
 
   ii = 2;
-  while ( (Substring[ii] != NULL)
-          && (ii < MAX_RELAY_SUBSTRINGS) )
+  // Test the array index before dereferencing Substring[ii] so we
+  // never read one element past the end of the array (Substring[] has
+  // MAX_RELAY_SUBSTRINGS entries, valid indices 0..MAX_RELAY_SUBSTRINGS-1).
+  while ( (ii < MAX_RELAY_SUBSTRINGS)
+          && (Substring[ii] != NULL) )
   {
     strncat(new_path,
             Substring[ii],
             sizeof(new_path) - 1 - strlen(new_path));
     ii++;
-    if (Substring[ii] != NULL)  // Add a comma if more to come
+    if ((ii < MAX_RELAY_SUBSTRINGS) && Substring[ii] != NULL) // Add a comma if more to come
       strncat(new_path,
               ",",
               sizeof(new_path) - 1 - strlen(new_path));


### PR DESCRIPTION
### Problem
The loop that reassembles the digipeater path in the RELAY/WIDE1-1
substitution code (`src/db.c`) tested the array element before the
bound:

```c
while ( (Substring[ii] != NULL) && (ii < MAX_RELAY_SUBSTRINGS) )
```

`&&` short-circuits left-to-right, so `Substring[ii]` is dereferenced
first. When `ii` reaches `MAX_RELAY_SUBSTRINGS`, the code reads
`Substring[MAX_RELAY_SUBSTRINGS]` — one element past the end of the
array. The inner "add a comma" check had the same problem after `ii++`.

`Substring[]` is filled by `split_string()` from the **path field of
received packets**, so this out-of-bounds read is reachable from network
input.

### Fix
Test the index before dereferencing in both the loop condition and the
inner check.

### Testing
Builds cleanly (0 errors, no new warnings). A standalone reproduction
compiled with `-fsanitize=address` reports a stack-buffer-overflow READ
for the original loop and runs clean with the fix.