### PR TITLE
Fix always-false DOS map label colour check

### DIFF
--- a/src/map_dos.c
+++ b/src/map_dos.c
@@ -1660,7 +1660,7 @@ process:
             // Would be good to take another look at this later.
           }
 
-          if (label_text_color < '1' && label_text_color > '9')
+          if (label_text_color < '1' || label_text_color > '9')
           {
             label_text_color = '0';  // Default to black
           }


### PR DESCRIPTION
### Problem
The check that clamps an out-of-range DOS map label text colour to black
(`src/map_dos.c`) used a logical AND:

```c
if (label_text_color < '1' && label_text_color > '9')
```

A single character can never be both `< '1'` and `> '9'`, so the
condition is always false and the "default to black" fallback never
executes. Invalid colour bytes are used unclamped.

The surrounding comment ("should be 1-9, others should default to
black") shows the intent is to catch values *outside* the range, which
requires OR.

### Fix
Change `&&` to `||`.

### Testing
Full `make` builds the `xastir` binary with 0 errors. A standalone test
confirms the original condition never clamps, while the fixed condition
clamps all invalid bytes to `'0'` and leaves valid `'1'`–`'9'`
unchanged.