### PR TITLE
Bound sscanf field widths in GEO file parsing

### DIFF
--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -718,7 +718,7 @@ void draw_geo_image_map (Widget w,
       (void)get_line (f, line, MAX_FILENAME);
       if (strncasecmp (line, "FILENAME", 8) == 0)
       {
-        if (1 != sscanf (line + 9, "%s", fileimg))
+        if (1 != sscanf (line + 9, "%2000s", fileimg))
         {
           fprintf(stderr,"draw_geo_image_map:sscanf parsing error\n");
         }
@@ -740,7 +740,7 @@ void draw_geo_image_map (Widget w,
         }
       }
       if (strncasecmp (line, "URL", 3) == 0)
-        if (1 != sscanf (line + 4, "%s", fileimg))
+        if (1 != sscanf (line + 4, "%2000s", fileimg))
         {
           fprintf(stderr,"draw_geo_image_map:sscanf parsing error\n");
         }
@@ -814,7 +814,7 @@ void draw_geo_image_map (Widget w,
         OSMserver_flag = 1;
         if (strlen(line) > 13)
         {
-          if (1 != sscanf (line + 13, "%s", OSMstyle))
+          if (1 != sscanf (line + 13, "%999s", OSMstyle))
           {
             fprintf(stderr,"draw_geo_image_map:sscanf parsing error for OSM style.\n");
           }
@@ -826,7 +826,7 @@ void draw_geo_image_map (Widget w,
         OSMserver_flag = 2;
         if (strlen(line) > 14)
         {
-          if (1 != sscanf (line + 14, "%s", OSMstyle))
+          if (1 != sscanf (line + 14, "%999s", OSMstyle))
           {
             fprintf(stderr,"draw_geo_image_map:sscanf parsing error for OSM style.\n");
           }
@@ -877,7 +877,7 @@ void draw_geo_image_map (Widget w,
         {
           if (strlen(line) > 9)
           {
-            if (1 != sscanf (line + 9, "%s", tileCache))
+            if (1 != sscanf (line + 9, "%2000s", tileCache))
             {
               fprintf(stderr,"draw_geo_image_map:sscanf parsing error for TILE_DIR\n");
             }
@@ -888,7 +888,7 @@ void draw_geo_image_map (Widget w,
         {
           if (strlen(line) > 9)
           {
-            if (1 != sscanf (line + 9, "%s", OSMtileExt))
+            if (1 != sscanf (line + 9, "%9s", OSMtileExt))
             {
               fprintf(stderr,"draw_geo_image_map:sscanf parsing error for TILE_EXT\n");
             }


### PR DESCRIPTION
While reading through `map_geo.c` I noticed that `draw_geo_image_map()`
  extracts tokens from GEO file lines with a bare `%s` and no field width.

  Each line is read with `get_line(f, line, MAX_FILENAME)`, so `line[]` can
  hold up to 1999 characters. Six `sscanf()` calls then copy a token out of
  that line into buffers that are smaller than the longest possible token:

  | buffer | size | read from |
  | --- | --- | --- |
  | `OSMtileExt[MAX_OSMEXT]` | 10 bytes | `line + 9` (TILE_EXT) |
  | `OSMstyle[MAX_OSMSTYLE]` | 1000 bytes | `line + 13`, `line + 14` |

  So a GEO file with a long `TILE_EXT` or `OSMSTATICMAP` / `OSM_TILED_MAP`
  token overflows these stack buffers.

  `fileimg[]` and `tileCache[]` are `MAX_FILENAME+1` and happen to be large
  enough today, but only because of the size of `line[]` rather than their
  own, so I bounded those too.

  The widths match the destination buffers and follow the style already used
  a few lines above for `DATUM` (`"%8s"`) and `PROJECTION` (`"%256s"`).

  ### Verification

  I reproduced the `TILE_EXT` case in a standalone program using the same
  buffer sizes and the same read path. With the current code AddressSanitizer
  reports:

  ```
  ERROR: AddressSanitizer: stack-buffer-overflow
  WRITE of size 1501 at 0x... thread T0
      #0 scanf_common
    This frame has 3 object(s):
      [32, 42) 'OSMtileExt'
  ```

  With the widths added it runs clean and the token is truncated at 9 and 999
  characters as expected.

  I also built the full tree (bootstrap/configure/make) with no new warnings.
  The two remaining warnings in this file are pre-existing and are at line
  1138, not at any of the lines I touched.

  `make check` passes locally as well (all 252 tests successful), though the
  suite does not currently cover `map_geo.c`, so that is a regression check
  rather than direct coverage of this change.