### PR TITLE
Add copy_token() and use it in GEO file parsing

### DIFF
--- a/src/map_geo.c
+++ b/src/map_geo.c
@@ -718,9 +718,9 @@ void draw_geo_image_map (Widget w,
       (void)get_line (f, line, MAX_FILENAME);
       if (strncasecmp (line, "FILENAME", 8) == 0)
       {
-        if (1 != sscanf (line + 9, "%s", fileimg))
+        if (0 == copy_token(fileimg, sizeof(fileimg), line + 9))
         {
-          fprintf(stderr,"draw_geo_image_map:sscanf parsing error\n");
+          fprintf(stderr,"draw_geo_image_map:parsing error\n");
         }
         if (fileimg[0] != '/' )   // not absolute path
         {
@@ -740,9 +740,9 @@ void draw_geo_image_map (Widget w,
         }
       }
       if (strncasecmp (line, "URL", 3) == 0)
-        if (1 != sscanf (line + 4, "%s", fileimg))
+        if (0 == copy_token(fileimg, sizeof(fileimg), line + 4))
         {
-          fprintf(stderr,"draw_geo_image_map:sscanf parsing error\n");
+          fprintf(stderr,"draw_geo_image_map:parsing error\n");
         }
 
       if (n_tp < 2)       // Only take the first two tiepoints
@@ -771,16 +771,16 @@ void draw_geo_image_map (Widget w,
         }
 
       if (strncasecmp (line, "DATUM", 5) == 0)
-        if (1 != sscanf (line + 6, "%8s",geo_datum))
+        if (0 == copy_token(geo_datum, sizeof(geo_datum), line + 6))
         {
-          fprintf(stderr,"draw_geo_image_map:sscanf parsing error\n");
+          fprintf(stderr,"draw_geo_image_map:parsing error\n");
         }
 
       if (strncasecmp (line, "PROJECTION", 10) == 0)
         // Ignores leading and trailing space (nice!)
-        if (1 != sscanf (line + 11, "%256s",geo_projection))
+        if (0 == copy_token(geo_projection, sizeof(geo_projection), line + 11))
         {
-          fprintf(stderr,"draw_geo_image_map:sscanf parsing error\n");
+          fprintf(stderr,"draw_geo_image_map:parsing error\n");
         }
 
       if (strncasecmp (line, "TERRASERVER-URBAN", 17) == 0)
@@ -814,9 +814,9 @@ void draw_geo_image_map (Widget w,
         OSMserver_flag = 1;
         if (strlen(line) > 13)
         {
-          if (1 != sscanf (line + 13, "%s", OSMstyle))
+          if (0 == copy_token(OSMstyle, sizeof(OSMstyle), line + 13))
           {
-            fprintf(stderr,"draw_geo_image_map:sscanf parsing error for OSM style.\n");
+            fprintf(stderr,"draw_geo_image_map:parsing error for OSM style.\n");
           }
         }
       }
@@ -826,9 +826,9 @@ void draw_geo_image_map (Widget w,
         OSMserver_flag = 2;
         if (strlen(line) > 14)
         {
-          if (1 != sscanf (line + 14, "%s", OSMstyle))
+          if (0 == copy_token(OSMstyle, sizeof(OSMstyle), line + 14))
           {
-            fprintf(stderr,"draw_geo_image_map:sscanf parsing error for OSM style.\n");
+            fprintf(stderr,"draw_geo_image_map:parsing error for OSM style.\n");
           }
         }
       }
@@ -877,9 +877,9 @@ void draw_geo_image_map (Widget w,
         {
           if (strlen(line) > 9)
           {
-            if (1 != sscanf (line + 9, "%s", tileCache))
+            if (0 == copy_token(tileCache, sizeof(tileCache), line + 9))
             {
-              fprintf(stderr,"draw_geo_image_map:sscanf parsing error for TILE_DIR\n");
+              fprintf(stderr,"draw_geo_image_map:parsing error for TILE_DIR\n");
             }
           }
         }
@@ -888,9 +888,9 @@ void draw_geo_image_map (Widget w,
         {
           if (strlen(line) > 9)
           {
-            if (1 != sscanf (line + 9, "%s", OSMtileExt))
+            if (0 == copy_token(OSMtileExt, sizeof(OSMtileExt), line + 9))
             {
-              fprintf(stderr,"draw_geo_image_map:sscanf parsing error for TILE_EXT\n");
+              fprintf(stderr,"draw_geo_image_map:parsing error for TILE_EXT\n");
             }
           }
         }

--- a/src/util.c
+++ b/src/util.c
@@ -315,6 +315,66 @@ char *remove_trailing_spaces(char *data)
 
 
 
+// copy_token()
+//
+// Copies the first whitespace-delimited token of src into dest,
+// skipping any leading whitespace and stopping at the first trailing
+// whitespace character or at the end of the string.  This matches what
+// sscanf() does for a "%s" conversion, but the destination size is
+// passed in rather than being written into a format string.
+//
+// dest is always NUL terminated when dest_size is non-zero, and never
+// more than dest_size bytes are written.
+//
+// Returns the length of the token that was found, which is the length
+// that would have been needed to hold it in full.  A return value of 0
+// means no token was found.  A return value of dest_size or greater
+// means the token was truncated to fit.
+//
+int copy_token(char *dest, size_t dest_size, const char *src)
+{
+  const char *start;
+  size_t length;
+
+  if ( (dest == NULL) || (dest_size == 0) )
+  {
+    return(0);
+  }
+
+  dest[0] = '\0';
+
+  if (src == NULL)
+  {
+    return(0);
+  }
+
+  start = src;
+  while (isspace((int)(unsigned char)*start))
+  {
+    start++;
+  }
+
+  length = 0;
+  while ( (start[length] != '\0')
+          && !isspace((int)(unsigned char)start[length]) )
+  {
+    length++;
+  }
+
+  if (length == 0)
+  {
+    return(0);
+  }
+
+  xastir_snprintf(dest, dest_size, "%.*s", (int)length, start);
+
+  return((int)length);
+}
+
+
+
+
+
 char *remove_trailing_asterisk(char *data)
 {
   int datalen;

--- a/src/util.h
+++ b/src/util.h
@@ -74,6 +74,7 @@ extern char *remove_leading_spaces(char *data);
 extern char *remove_trailing_spaces(char *data);
 extern char *remove_trailing_asterisk(char *data);
 extern char *remove_trailing_dash_zero(char *data);
+extern int copy_token(char *dest, size_t dest_size, const char *src);
 extern void get_timestamp(char *timestring);
 extern int get_iso_datetime(time_t aTime, char *timestring, int nowIfNotSet, int nowIfInvalid);
 extern int get_w3cdtf_datetime(time_t aTime, char *timestring,int nowIfNotSet, int nowIfInvalid);

--- a/tests/test_util.c
+++ b/tests/test_util.c
@@ -326,6 +326,107 @@ int test_short_filename_for_status_trunc(void)
   TEST_PASS("short_filename_for_status");
 }
 
+int test_copy_token_plain(void)
+{
+  char dest[16];
+  int len;
+
+  len = copy_token(dest, sizeof(dest), "png");
+
+  TEST_ASSERT_STR_EQ("png", dest, "Plain token copied unchanged");
+  TEST_ASSERT(len == 3, "Return value is the token length");
+  TEST_PASS("copy_token");
+}
+
+int test_copy_token_leading_space(void)
+{
+  char dest[16];
+
+  copy_token(dest, sizeof(dest), "    png");
+
+  TEST_ASSERT_STR_EQ("png", dest, "Leading whitespace is skipped");
+  TEST_PASS("copy_token");
+}
+
+int test_copy_token_stops_at_space(void)
+{
+  char dest[16];
+  int len;
+
+  len = copy_token(dest, sizeof(dest), "  png   and more");
+
+  TEST_ASSERT_STR_EQ("png", dest, "Copy stops at the first trailing whitespace");
+  TEST_ASSERT(len == 3, "Return value covers only the first token");
+  TEST_PASS("copy_token");
+}
+
+int test_copy_token_exact_fit(void)
+{
+  char dest[4];
+  int len;
+
+  len = copy_token(dest, sizeof(dest), "png");
+
+  TEST_ASSERT_STR_EQ("png", dest, "Token that exactly fills the buffer is not truncated");
+  TEST_ASSERT(len < (int)sizeof(dest), "Exact fit is not reported as truncation");
+  TEST_PASS("copy_token");
+}
+
+int test_copy_token_truncates(void)
+{
+  char dest[4];
+  char canary[8];
+  int len;
+
+  memset(canary, 'x', sizeof(canary));
+
+  len = copy_token(dest, sizeof(dest), "abcdefghij");
+
+  TEST_ASSERT_STR_EQ("abc", dest, "Oversized token is truncated to fit the buffer");
+  TEST_ASSERT(len == 10, "Return value is the full length the token would have needed");
+  TEST_ASSERT(len >= (int)sizeof(dest), "Truncation is detectable from the return value");
+  TEST_ASSERT(canary[0] == 'x', "Neighbouring storage is untouched");
+  TEST_PASS("copy_token");
+}
+
+int test_copy_token_empty(void)
+{
+  char dest[16];
+  int len;
+
+  len = copy_token(dest, sizeof(dest), "");
+
+  TEST_ASSERT_STR_EQ("", dest, "Empty input yields an empty string");
+  TEST_ASSERT(len == 0, "Empty input reports no token");
+  TEST_PASS("copy_token");
+}
+
+int test_copy_token_whitespace_only(void)
+{
+  char dest[16];
+  int len;
+
+  len = copy_token(dest, sizeof(dest), "     ");
+
+  TEST_ASSERT_STR_EQ("", dest, "Whitespace-only input yields an empty string");
+  TEST_ASSERT(len == 0, "Whitespace-only input reports no token");
+  TEST_PASS("copy_token");
+}
+
+int test_copy_token_null_source(void)
+{
+  char dest[16];
+  int len;
+
+  len = copy_token(dest, sizeof(dest), NULL);
+
+  TEST_ASSERT_STR_EQ("", dest, "NULL source yields an empty string");
+  TEST_ASSERT(len == 0, "NULL source reports no token");
+  TEST_ASSERT(copy_token(NULL, sizeof(dest), "png") == 0, "NULL destination is rejected");
+  TEST_ASSERT(copy_token(dest, 0, "png") == 0, "Zero destination size is rejected");
+  TEST_PASS("copy_token");
+}
+
 /* Test runner */
 typedef struct {
     const char *name;
@@ -351,6 +452,14 @@ int main(int argc, char *argv[])
     {"convert_xastir_to_screen_coordinates", test_convert_xastir_to_screen_coordinates},
     {"short_filename_for_status_notrunc",test_short_filename_for_status_notrunc},
     {"short_filename_for_status_trunc",test_short_filename_for_status_trunc},
+    {"copy_token_plain",test_copy_token_plain},
+    {"copy_token_leading_space",test_copy_token_leading_space},
+    {"copy_token_stops_at_space",test_copy_token_stops_at_space},
+    {"copy_token_exact_fit",test_copy_token_exact_fit},
+    {"copy_token_truncates",test_copy_token_truncates},
+    {"copy_token_empty",test_copy_token_empty},
+    {"copy_token_whitespace_only",test_copy_token_whitespace_only},
+    {"copy_token_null_source",test_copy_token_null_source},
     {NULL,NULL}
   };
 

--- a/tests/util_tests.at
+++ b/tests/util_tests.at
@@ -104,3 +104,52 @@ AT_KEYWORDS([util short_filename_for_status])
 AT_CHECK(["$abs_top_builddir/tests/test_util" short_filename_for_status_trunc], [0], [PASS: short_filename_for_status
 ])
 AT_CLEANUP
+
+AT_BANNER([tests of whitespace-delimited token copy])
+AT_SETUP([copy_token: plain token copied unchanged])
+AT_KEYWORDS([util copy_token])
+AT_CHECK(["$abs_top_builddir/tests/test_util" copy_token_plain], [0], [PASS: copy_token
+])
+AT_CLEANUP
+
+AT_SETUP([copy_token: leading whitespace skipped])
+AT_KEYWORDS([util copy_token])
+AT_CHECK(["$abs_top_builddir/tests/test_util" copy_token_leading_space], [0], [PASS: copy_token
+])
+AT_CLEANUP
+
+AT_SETUP([copy_token: copy stops at trailing whitespace])
+AT_KEYWORDS([util copy_token])
+AT_CHECK(["$abs_top_builddir/tests/test_util" copy_token_stops_at_space], [0], [PASS: copy_token
+])
+AT_CLEANUP
+
+AT_SETUP([copy_token: token exactly filling the buffer])
+AT_KEYWORDS([util copy_token])
+AT_CHECK(["$abs_top_builddir/tests/test_util" copy_token_exact_fit], [0], [PASS: copy_token
+])
+AT_CLEANUP
+
+AT_SETUP([copy_token: oversized token truncated and reported])
+AT_KEYWORDS([util copy_token])
+AT_CHECK(["$abs_top_builddir/tests/test_util" copy_token_truncates], [0], [PASS: copy_token
+])
+AT_CLEANUP
+
+AT_SETUP([copy_token: empty input])
+AT_KEYWORDS([util copy_token])
+AT_CHECK(["$abs_top_builddir/tests/test_util" copy_token_empty], [0], [PASS: copy_token
+])
+AT_CLEANUP
+
+AT_SETUP([copy_token: whitespace-only input])
+AT_KEYWORDS([util copy_token])
+AT_CHECK(["$abs_top_builddir/tests/test_util" copy_token_whitespace_only], [0], [PASS: copy_token
+])
+AT_CLEANUP
+
+AT_SETUP([copy_token: NULL and zero-size arguments])
+AT_KEYWORDS([util copy_token])
+AT_CHECK(["$abs_top_builddir/tests/test_util" copy_token_null_source], [0], [PASS: copy_token
+])
+AT_CLEANUP


### PR DESCRIPTION
Fixes #396. This replaces #395 with the cleaner approach.

### The helper

New function in `util.c`:

```c
int copy_token(char *dest, size_t dest_size, const char *src);
```

It skips leading whitespace, copies up to the next whitespace character
or end of string, always NUL terminates, and never writes more than
`dest_size` bytes. The copy itself is done with `xastir_snprintf()` as
you suggested, so termination is guaranteed and there is no `strncpy()`
edge case to worry about.

The return value is the length the token would have needed, so callers
can tell the two failure modes apart:

* `0` means no token was found
* `>= dest_size` means the token was truncated

Call sites pass `sizeof(dest)`, so the `#define` values stay
authoritative and no buffer size is written into a format string.

### Call sites

All eight string token extractions in `draw_geo_image_map()` now use it.
That includes the `DATUM` and `PROJECTION` reads, which were already
bounded with `"%8s"` and `"%256s"` but had the same hard coded length
problem. After this change there is no buffer size in any format string
in the file.

The `sscanf()` calls doing numeric conversions (`%d`, `%f`, `%lu`) are
unchanged, since that is what `sscanf()` is actually for.

I also dropped the word "sscanf" from the diagnostics at the converted
sites, since it no longer describes what happens there. The four
diagnostics that share the same wording but still belong to real
`sscanf()` calls were left alone.

### Tests

Eight new cases in `tests/util_tests.at`, covering valid and malformed
input as you asked:

| case | behaviour |
| --- | --- |
| plain token | copied unchanged |
| leading whitespace | skipped |
| trailing whitespace | copy stops at it |
| exact buffer fit | not reported as truncation |
| oversized token | truncated, full length returned |
| empty input | returns 0 |
| whitespace-only input | returns 0 |
| NULL / zero size | rejected without crashing |

`make check` goes from 252 to 260 tests, all passing. I also rebuilt
`tests/test_util` with `-fsanitize=address` and ran the eight cases
against the real function; the truncation case pushes a 10 character
token into a 4 byte buffer and ASan reports nothing.

Full tree builds clean with no new warnings.