### PR TITLE
Fix RGB mask shift on non-standard X visuals

### DIFF
--- a/src/color.c
+++ b/src/color.c
@@ -41,7 +41,7 @@
 
 static color_load color_choice[MAX_COLORS];
 static int colors_loaded;
-static int rm, gm, bm; // rgb masks
+static unsigned int rm, gm, bm; // rgb masks
 static int rs, gs, bs; // rgb shifts
 int visual_depth;
 
@@ -226,7 +226,7 @@ void setup_visual_info(Display* dpy, int scr)
             bm = vp->blue_mask;
             for (j = 31; j >= 0; j--)
             {
-              if (rm >= (1 << j))
+              if (rm >= (1U << j))
               {
                 rs = j - 15;
                 break;
@@ -234,7 +234,7 @@ void setup_visual_info(Display* dpy, int scr)
             }
             for (j = 31; j >= 0; j--)
             {
-              if (gm >= (1 << j))
+              if (gm >= (1U << j))
               {
                 gs = j - 15;
                 break;
@@ -242,7 +242,7 @@ void setup_visual_info(Display* dpy, int scr)
             }
             for (j = 31; j >= 0; j--)
             {
-              if (bm >= (1 << j))
+              if (bm >= (1U << j))
               {
                 bs = j - 15;
                 break;


### PR DESCRIPTION
While reading `color.c` I noticed that `setup_visual_info()` finds the
high bit of each colour mask like this:

```c
for (j = 31; j >= 0; j--)
    if (rm >= (1 << j)) { rs = j - 15; break; }
```

`1 << 31` overflows a signed `int` and evaluates to `INT_MIN`, so
`rm >= (1 << j)` is true on the very first iteration (`j == 31`) for
every possible mask. The loop always breaks immediately and `rs`, `gs`,
`bs` are always set to `16`, never to the actual position of the mask's
high bit.

Those shifts are used to pack pixels for the `RGB_OTHER` visual type,
so colours come out wrong on TrueColor/DirectColor visuals whose masks
are not one of the three common layouts (`RGB_565`, `RGB_555`,
`RGB_888`) handled earlier in the function.

`1U << j` does the shift in unsigned arithmetic, which is well defined
and lets the comparison recover the mask's high bit correctly. I made
`rm`, `gm`, `bm` unsigned to match, so the comparison stays unsigned and
no `-Wsign-compare` warning is introduced.

### Verification

I reproduced the loop in a standalone program with the real code shape
(`static int` masks, `1U << j`) and compared against a reference that
finds the true high bit:

```
mask            OLD    NEW    exp
0x000000ff       16     -8     -8
0x00ff0000       16      8      8
0x3ff00000       16     14     14
0xffc00000       16     16     16
0x7fffffff       16     15     15
OK: NEW == reference for all masks
```

The old code returns 16 for everything; the fixed code matches the
reference, including masks with bit 31 set.

Full tree builds with no new warnings and `make check` passes (all 260
tests). This visual type isn't exercised by the test suite, so that's a
regression check rather than direct coverage.

Single file, 4 lines changed.