### PR TITLE
Expire and prune stale entries from wx alert log cache

### DIFF
--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -176,7 +176,9 @@ void load_wx_alerts_from_log_working_sub(time_t time_now, char *filename)
   int file_age;
   int expire_limit;   // In seconds
   char line[MAX_LINE_SIZE+1];
+  char tmp_filename[MAX_FILENAME];
   FILE *f;
+  FILE *ftmp;
 
 
   expire_limit = 60 * 60 * 24 * 15;   // 15 days
@@ -194,7 +196,8 @@ void load_wx_alerts_from_log_working_sub(time_t time_now, char *filename)
 
   if ( file_age > expire_limit)
   {
-//        fprintf(stderr,"Old file: %s, skipping...\n", filename);
+    fprintf(stderr,"Old wx alert log file, removing: %s\n", filename);
+    (void)remove(filename);
     return;
   }
 
@@ -225,6 +228,13 @@ void load_wx_alerts_from_log_working_sub(time_t time_now, char *filename)
     return;
   }
 
+  xastir_snprintf(tmp_filename, sizeof(tmp_filename), "%s.tmp", filename);
+  ftmp = fopen(tmp_filename, "w");
+  if (!ftmp)
+  {
+    fprintf(stderr,"Couldn't create %s, wx alert log won't be pruned\n", tmp_filename);
+  }
+
   while (!feof(f))    // Read until end of file
   {
 
@@ -241,6 +251,7 @@ restart_sync:
     {
       time_t line_stamp;
       int line_age;
+      char timestamp_line[MAX_LINE_SIZE+1];
 
       if (strlen(line) < 3)   // Line is too short, skip
       {
@@ -255,12 +266,19 @@ restart_sync:
       {
         // Age is good, read next line and process it
 
+        xastir_snprintf(timestamp_line, sizeof(timestamp_line), "%s", line);
+
         (void)fetch_file_line(f, line);
 
         if (line[0] != '#')   // It's a packet, not a timestamp line
         {
 //fprintf(stderr,"%s\n",line);
           decode_ax25_line(line,'F',-1, 1);   // Decode the packet
+
+          if (ftmp)
+          {
+            fprintf(ftmp, "%s\n%s\n", timestamp_line, line);
+          }
         }
         else
         {
@@ -272,6 +290,16 @@ restart_sync:
   if (feof(f))   // Close file if at the end
   {
     (void)fclose(f);
+  }
+
+  if (ftmp)
+  {
+    (void)fclose(ftmp);
+    if (rename(tmp_filename, filename) != 0)
+    {
+      fprintf(stderr,"Couldn't replace %s with pruned copy\n", filename);
+      (void)remove(tmp_filename);
+    }
   }
 }
 

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -68,7 +68,7 @@ char *fetch_file_line(FILE *f, char *line)
 
       if (pos < MAX_LINE_SIZE)
       {
-        if (cin != (char)13)    // CR
+        if (cin != (char)13 && cin != (char)10)    // CR or LF
         {
           line[pos++] = cin;
         }
@@ -76,7 +76,7 @@ char *fetch_file_line(FILE *f, char *line)
 
       if (cin == (char)10)   // Found LF as EOL char
       {
-        line[pos++] = '\0'; // Always add a terminating zero after last char
+        line[pos] = '\0'; // Always add a terminating zero after last char
         pos = 0;          // start next line
         return(line);
       }
@@ -272,12 +272,16 @@ restart_sync:
 
         if (line[0] != '#')   // It's a packet, not a timestamp line
         {
+          char packet_line[MAX_LINE_SIZE+1];
+
+          xastir_snprintf(packet_line, sizeof(packet_line), "%s", line);
+
 //fprintf(stderr,"%s\n",line);
-          decode_ax25_line(line,'F',-1, 1);   // Decode the packet
+          decode_ax25_line(line,'F',-1, 1);   // Decode the packet, mutates line
 
           if (ftmp)
           {
-            fprintf(ftmp, "%s\n%s\n", timestamp_line, line);
+            fprintf(ftmp, "%s\n%s\n", timestamp_line, packet_line);
           }
         }
         else

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,7 +4,7 @@
 TESTSUITE = $(srcdir)/testsuite
 AUTOTEST = $(AUTOM4TE) --language=autotest
 
-TESTSUITE_AT = testsuite.at interface_helpers.at db_tests.at object_utils_tests.at output_my_aprs_data_tests.at util_tests.at objects_tests.at
+TESTSUITE_AT = testsuite.at interface_helpers.at db_tests.at object_utils_tests.at output_my_aprs_data_tests.at util_tests.at objects_tests.at log_utils_tests.at
 
 if HAVE_NOMINATIM
 TESTSUITE_AT += nominatim_tests.at
@@ -13,7 +13,7 @@ endif
 EXTRA_DIST = $(TESTSUITE_AT) $(TESTSUITE) package.m4 atlocal.in nominatim_tests.at
 
 # Test programs
-check_PROGRAMS = test_interface_helpers test_db test_object_utils test_output_my_aprs_data test_util test_objects
+check_PROGRAMS = test_interface_helpers test_db test_object_utils test_output_my_aprs_data test_util test_objects test_log_utils
 
 # Conditionally add nominatim test program
 if HAVE_NOMINATIM
@@ -42,6 +42,9 @@ test_util_CPPFLAGS = $(CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir)/src -I$(top_bui
 
 test_objects_SOURCES = test_objects.c test_objects_stubs.c $(top_srcdir)/src/objects.c $(top_srcdir)/src/util.c $(top_srcdir)/src/object_utils.c $(top_srcdir)/src/db.c $(top_srcdir)/src/encoding.c
 test_objects_CPPFLAGS = $(CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir)/src -I$(top_builddir)
+
+test_log_utils_SOURCES = test_log_utils.c test_log_utils_stubs.c $(top_srcdir)/src/log_utils.c $(top_srcdir)/src/util.c
+test_log_utils_CPPFLAGS = $(CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir)/src -I$(top_builddir)
 
 # Nominatim tests (conditional on HAVE_NOMINATIM)
 if HAVE_NOMINATIM

--- a/tests/log_utils_tests.at
+++ b/tests/log_utils_tests.at
@@ -1,0 +1,28 @@
+# Autotest tests for log_utils.c Functions
+# Tests for the wx alert log cache pruning
+
+AT_BANNER([wx alert log pruning])
+
+AT_SETUP([load_wx_alerts_from_log_working_sub: whole file removed when too old])
+AT_KEYWORDS([log_utils wx_alert])
+AT_CHECK(["$abs_top_builddir/tests/test_log_utils" prune_whole_file_removed_when_too_old], [0], [PASS: load_wx_alerts_from_log_working_sub: whole-file expiration
+], [ignore])
+AT_CLEANUP
+
+AT_SETUP([load_wx_alerts_from_log_working_sub: stale entry pruned, fresh entry kept])
+AT_KEYWORDS([log_utils wx_alert])
+AT_CHECK(["$abs_top_builddir/tests/test_log_utils" prune_stale_entry_removed_fresh_entry_kept], [0], [PASS: load_wx_alerts_from_log_working_sub: prunes stale entries, keeps fresh ones
+])
+AT_CLEANUP
+
+AT_SETUP([load_wx_alerts_from_log_working_sub: all current entries kept])
+AT_KEYWORDS([log_utils wx_alert])
+AT_CHECK(["$abs_top_builddir/tests/test_log_utils" prune_keeps_all_fresh_entries], [0], [PASS: load_wx_alerts_from_log_working_sub: keeps all current entries
+])
+AT_CLEANUP
+
+AT_SETUP([load_wx_alerts_from_log_working_sub: missing file handled gracefully])
+AT_KEYWORDS([log_utils wx_alert])
+AT_CHECK(["$abs_top_builddir/tests/test_log_utils" prune_missing_file_is_a_noop], [0], [PASS: load_wx_alerts_from_log_working_sub: missing file handled gracefully
+])
+AT_CLEANUP

--- a/tests/log_utils_tests.at
+++ b/tests/log_utils_tests.at
@@ -21,6 +21,12 @@ AT_CHECK(["$abs_top_builddir/tests/test_log_utils" prune_keeps_all_fresh_entries
 ])
 AT_CLEANUP
 
+AT_SETUP([load_wx_alerts_from_log_working_sub: preserves full packet content across pruning])
+AT_KEYWORDS([log_utils wx_alert])
+AT_CHECK(["$abs_top_builddir/tests/test_log_utils" prune_preserves_full_packet_content], [0], [PASS: load_wx_alerts_from_log_working_sub: preserves full packet content across pruning
+])
+AT_CLEANUP
+
 AT_SETUP([load_wx_alerts_from_log_working_sub: missing file handled gracefully])
 AT_KEYWORDS([log_utils wx_alert])
 AT_CHECK(["$abs_top_builddir/tests/test_log_utils" prune_missing_file_is_a_noop], [0], [PASS: load_wx_alerts_from_log_working_sub: missing file handled gracefully

--- a/tests/test_log_utils.c
+++ b/tests/test_log_utils.c
@@ -109,7 +109,7 @@ int test_prune_stale_entry_removed_fresh_entry_kept(void)
 
   test_path(path, sizeof(path), "mixed");
   snprintf(content, sizeof(content),
-           "# %ld\nOLDPACKET\n# %ld\nFRESHPACKET\n",
+           "# %ld\nOLDCALL>APRS::NWS-WARN :old alert\n# %ld\nCRPFLS>APRS::NWS-WARN :261030z,FLOOD,TXC283{P00AA\n",
            (long)(now - (20 * ONE_DAY)),
            (long)(now - 3600));
   write_file(path, content);
@@ -117,8 +117,9 @@ int test_prune_stale_entry_removed_fresh_entry_kept(void)
   load_wx_alerts_from_log_working_sub(now, path);
 
   TEST_ASSERT(file_exists(path), "log file with a current entry should remain");
-  TEST_ASSERT(!file_contains(path, "OLDPACKET"), "expired entry should be pruned");
-  TEST_ASSERT(file_contains(path, "FRESHPACKET"), "current entry should be kept");
+  TEST_ASSERT(!file_contains(path, "OLDCALL"), "expired entry should be pruned");
+  TEST_ASSERT(file_contains(path, "CRPFLS>APRS::NWS-WARN :261030z,FLOOD,TXC283{P00AA"),
+              "current entry should be kept intact, not truncated");
 
   unlink(path);
   TEST_PASS("load_wx_alerts_from_log_working_sub: prunes stale entries, keeps fresh ones");
@@ -132,7 +133,7 @@ int test_prune_keeps_all_fresh_entries(void)
 
   test_path(path, sizeof(path), "allfresh");
   snprintf(content, sizeof(content),
-           "# %ld\nPACKETONE\n# %ld\nPACKETTWO\n",
+           "# %ld\nCRPFLS>APRS::NWS-WARN :first alert\n# %ld\nLBFSVR>APRS::NWS-WARN :second alert\n",
            (long)(now - 3600),
            (long)(now - 7200));
   write_file(path, content);
@@ -140,11 +141,38 @@ int test_prune_keeps_all_fresh_entries(void)
   load_wx_alerts_from_log_working_sub(now, path);
 
   TEST_ASSERT(file_exists(path), "log file should remain");
-  TEST_ASSERT(file_contains(path, "PACKETONE"), "current entry one should be kept");
-  TEST_ASSERT(file_contains(path, "PACKETTWO"), "current entry two should be kept");
+  TEST_ASSERT(file_contains(path, "CRPFLS>APRS::NWS-WARN :first alert"), "current entry one should be kept intact");
+  TEST_ASSERT(file_contains(path, "LBFSVR>APRS::NWS-WARN :second alert"), "current entry two should be kept intact");
 
   unlink(path);
   TEST_PASS("load_wx_alerts_from_log_working_sub: keeps all current entries");
+}
+
+// decode_ax25_line() tokenizes its argument in place with strtok(),
+// truncating the buffer at the first '>'.  Regression test for a
+// bug where the pruned file was written from that same,
+// now-truncated buffer instead of a pristine copy of the line.
+int test_prune_preserves_full_packet_content(void)
+{
+  char path[256];
+  char content[512];
+  time_t now = time(NULL);
+
+  test_path(path, sizeof(path), "fullcontent");
+  snprintf(content, sizeof(content),
+           "# %ld\nCRPFLS>APRS::NWS-WARN :261030z,FLOOD,TXC283{P00AA\n",
+           (long)(now - 3600));
+  write_file(path, content);
+
+  load_wx_alerts_from_log_working_sub(now, path);
+
+  TEST_ASSERT(!file_contains(path, "\n\nCRPFLS\n"),
+              "packet line must not be truncated down to just the callsign");
+  TEST_ASSERT(file_contains(path, "CRPFLS>APRS::NWS-WARN :261030z,FLOOD,TXC283{P00AA"),
+              "full packet content must survive pruning");
+
+  unlink(path);
+  TEST_PASS("load_wx_alerts_from_log_working_sub: preserves full packet content across pruning");
 }
 
 int test_prune_missing_file_is_a_noop(void)
@@ -173,6 +201,7 @@ int main(int argc, char *argv[])
     {"prune_whole_file_removed_when_too_old", test_prune_whole_file_removed_when_too_old},
     {"prune_stale_entry_removed_fresh_entry_kept", test_prune_stale_entry_removed_fresh_entry_kept},
     {"prune_keeps_all_fresh_entries", test_prune_keeps_all_fresh_entries},
+    {"prune_preserves_full_packet_content", test_prune_preserves_full_packet_content},
     {"prune_missing_file_is_a_noop", test_prune_missing_file_is_a_noop},
     {NULL, NULL}
   };

--- a/tests/test_log_utils.c
+++ b/tests/test_log_utils.c
@@ -1,0 +1,203 @@
+/*
+ *
+ * XASTIR, Amateur Station Tracking and Information Reporting
+ * Copyright (C) 2025-2026 The Xastir Group
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * Look at the README for more information on the program.
+ */
+
+/*
+ * Test program for the wx alert log pruning in log_utils.c
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "tests/test_framework.h"
+
+#define ONE_DAY (60 * 60 * 24)
+
+// Not part of a public header, only used internally by
+// load_wx_alerts_from_log().  Declared here so we can test it
+// directly with a caller-supplied "now" and filename.
+extern void load_wx_alerts_from_log_working_sub(time_t time_now, char *filename);
+
+static void test_path(char *buf, size_t buf_size, const char *suffix)
+{
+  snprintf(buf, buf_size, "/tmp/xastir_test_wxalert_%d_%s.log",
+           (int)getpid(), suffix);
+}
+
+static int file_exists(const char *path)
+{
+  return(access(path, F_OK) == 0);
+}
+
+static int file_contains(const char *path, const char *needle)
+{
+  FILE *f;
+  char buf[4096];
+  size_t n;
+  int found = 0;
+
+  f = fopen(path, "r");
+  if (!f)
+  {
+    return(0);
+  }
+  n = fread(buf, 1, sizeof(buf) - 1, f);
+  buf[n] = '\0';
+  if (strstr(buf, needle) != NULL)
+  {
+    found = 1;
+  }
+  fclose(f);
+  return(found);
+}
+
+static void write_file(const char *path, const char *content)
+{
+  FILE *f = fopen(path, "w");
+  fwrite(content, 1, strlen(content), f);
+  fclose(f);
+}
+
+int test_prune_whole_file_removed_when_too_old(void)
+{
+  char path[256];
+  char content[256];
+  time_t now = time(NULL);
+
+  test_path(path, sizeof(path), "whole");
+  snprintf(content, sizeof(content), "# %ld\nSOMEPACKET\n", (long)(now - 3600));
+  write_file(path, content);
+
+  // File itself was just created (ctime == now), but tell the
+  // function that "now" is 20 days later, well past the 15 day
+  // expiration window.
+  load_wx_alerts_from_log_working_sub(now + (20 * ONE_DAY), path);
+
+  TEST_ASSERT(!file_exists(path), "expired log file should be removed");
+  TEST_PASS("load_wx_alerts_from_log_working_sub: whole-file expiration");
+}
+
+int test_prune_stale_entry_removed_fresh_entry_kept(void)
+{
+  char path[256];
+  char content[512];
+  time_t now = time(NULL);
+
+  test_path(path, sizeof(path), "mixed");
+  snprintf(content, sizeof(content),
+           "# %ld\nOLDPACKET\n# %ld\nFRESHPACKET\n",
+           (long)(now - (20 * ONE_DAY)),
+           (long)(now - 3600));
+  write_file(path, content);
+
+  load_wx_alerts_from_log_working_sub(now, path);
+
+  TEST_ASSERT(file_exists(path), "log file with a current entry should remain");
+  TEST_ASSERT(!file_contains(path, "OLDPACKET"), "expired entry should be pruned");
+  TEST_ASSERT(file_contains(path, "FRESHPACKET"), "current entry should be kept");
+
+  unlink(path);
+  TEST_PASS("load_wx_alerts_from_log_working_sub: prunes stale entries, keeps fresh ones");
+}
+
+int test_prune_keeps_all_fresh_entries(void)
+{
+  char path[256];
+  char content[512];
+  time_t now = time(NULL);
+
+  test_path(path, sizeof(path), "allfresh");
+  snprintf(content, sizeof(content),
+           "# %ld\nPACKETONE\n# %ld\nPACKETTWO\n",
+           (long)(now - 3600),
+           (long)(now - 7200));
+  write_file(path, content);
+
+  load_wx_alerts_from_log_working_sub(now, path);
+
+  TEST_ASSERT(file_exists(path), "log file should remain");
+  TEST_ASSERT(file_contains(path, "PACKETONE"), "current entry one should be kept");
+  TEST_ASSERT(file_contains(path, "PACKETTWO"), "current entry two should be kept");
+
+  unlink(path);
+  TEST_PASS("load_wx_alerts_from_log_working_sub: keeps all current entries");
+}
+
+int test_prune_missing_file_is_a_noop(void)
+{
+  char path[256];
+
+  test_path(path, sizeof(path), "missing");
+  unlink(path);   // Make sure it really doesn't exist
+
+  load_wx_alerts_from_log_working_sub(time(NULL), path);
+
+  TEST_ASSERT(!file_exists(path), "missing file should stay missing, not be created");
+  TEST_PASS("load_wx_alerts_from_log_working_sub: missing file handled gracefully");
+}
+
+typedef struct
+{
+  const char *name;
+  int (*func)(void);
+} test_case_t;
+
+int main(int argc, char *argv[])
+{
+  test_case_t tests[] =
+  {
+    {"prune_whole_file_removed_when_too_old", test_prune_whole_file_removed_when_too_old},
+    {"prune_stale_entry_removed_fresh_entry_kept", test_prune_stale_entry_removed_fresh_entry_kept},
+    {"prune_keeps_all_fresh_entries", test_prune_keeps_all_fresh_entries},
+    {"prune_missing_file_is_a_noop", test_prune_missing_file_is_a_noop},
+    {NULL, NULL}
+  };
+
+  if (argc < 2)
+  {
+    fprintf(stderr, "Usage: %s <test name>\n", argv[0]);
+    fprintf(stderr, "Available tests: \n");
+    for (int i = 0; tests[i].name != NULL; i++)
+    {
+      fprintf(stderr, "  %s\n", tests[i].name);
+    }
+    return 1;
+  }
+
+  const char *test_name = argv[1];
+
+  for (int i = 0; tests[i].name != NULL; i++)
+  {
+    if (strcmp(test_name, tests[i].name) == 0)
+    {
+      return tests[i].func();
+    }
+  }
+
+  fprintf(stderr, "Unknown test: %s\n", test_name);
+  return 1;
+}

--- a/tests/test_log_utils_stubs.c
+++ b/tests/test_log_utils_stubs.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <sys/types.h>
 #include "globals.h"
 #include "tests/test_framework.h"
 
@@ -68,3 +69,6 @@ long SE_corner_longitude, SE_corner_latitude;
 char dangerous_operation[200];
 char my_long[MAX_LONG], my_lat[MAX_LAT];
 long screen_height, screen_width;
+char LOGFILE_WX_ALERT[400];
+uid_t euid;
+gid_t egid;

--- a/tests/test_log_utils_stubs.c
+++ b/tests/test_log_utils_stubs.c
@@ -1,0 +1,70 @@
+/*
+ *
+ * XASTIR, Amateur Station Tracking and Information Reporting
+ * Copyright (C) 2025-2026 The Xastir Group
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * Look at the README for more information on the program.
+ */
+
+/*
+ * Stub implementations for symbols referenced by log_utils.o and
+ * util.o but not exercised by the unit tests.
+ *
+ * These stubs allow us to link with the real log_utils.o and util.o
+ * for testing without pulling in the entire Xastir codebase.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "globals.h"
+#include "tests/test_framework.h"
+
+STUB_IMPL(langcode);
+STUB_IMPL(ll_to_utm_ups);
+STUB_IMPL(utm_ups_to_ll);
+STUB_IMPL(search_station_name);
+STUB_IMPL(fill_in_new_alert_entries);
+
+int decode_ax25_line(char *line, char from, int port, int dbadd)
+{
+  (void)line;
+  (void)from;
+  (void)port;
+  (void)dbadd;
+  return(1);
+}
+
+char *get_user_base_dir(char *dir, char *dest, size_t dest_size)
+{
+  (void)dir;
+  if (dest != NULL && dest_size > 0)
+  {
+    dest[0] = '\0';
+  }
+  return(dest);
+}
+
+// global variables referenced but unused:
+int debug_level=0;
+long scale_x, scale_y;
+long center_longitude, center_latitude;
+long NW_corner_longitude, NW_corner_latitude;
+long SE_corner_longitude, SE_corner_latitude;
+char dangerous_operation[200];
+char my_long[MAX_LONG], my_lat[MAX_LAT];
+long screen_height, screen_width;

--- a/tests/test_log_utils_stubs.c
+++ b/tests/test_log_utils_stubs.c
@@ -30,6 +30,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 #include <sys/types.h>
 #include "globals.h"
@@ -41,12 +42,16 @@ STUB_IMPL(utm_ups_to_ll);
 STUB_IMPL(search_station_name);
 STUB_IMPL(fill_in_new_alert_entries);
 
+// The real decode_ax25_line() tokenizes its "line" argument in
+// place with strtok(), truncating it at the first '>'. Mimic that
+// destructive behavior here so tests catch callers who read "line"
+// again afterward expecting it to still be intact.
 int decode_ax25_line(char *line, char from, int port, int dbadd)
 {
-  (void)line;
   (void)from;
   (void)port;
   (void)dbadd;
+  (void)strtok(line, ">");
   return(1);
 }
 

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -24,6 +24,9 @@ m4_include([util_tests.at])
 # Include basic objects function tests
 m4_include([objects_tests.at])
 
+# Include wx alert log pruning tests
+m4_include([log_utils_tests.at])
+
 # Include nominatim geocoding tests (conditionally compiled if HAVE_NOMINATIM)
 m4_ifdef([HAVE_NOMINATIM], [
 m4_include([nominatim_tests.at])


### PR DESCRIPTION
Fixes #125.

load_wx_alerts_from_log_working_sub() already skipped log files and individual entries older than the 15 day expiration window when loading, but never removed anything from disk: a fully expired log file was left in place forever, and expired entries mixed into an otherwise-current file were skipped on load but never dropped, so they accumulated indefinitely between size-triggered rotations.

Now a fully expired file is removed outright, and files within the window are rewritten to keep only entries that are still current.

Adds a unit test suite (test_log_utils) covering whole-file removal, pruning of stale entries while keeping fresh ones, keeping all entries when nothing has expired, and handling a missing file.