### PR TITLE
Initialize PostGIS connection handle to NULL, not a bogus malloc

### DIFF
--- a/src/db_gis.c
+++ b/src/db_gis.c
@@ -629,10 +629,8 @@ int initAConnection(Connection *connection, int x)
   connection->interface_number = x;  // so we can reference port_data[] from a connection
   // without knowing the connection's position in
   // connections[]
-  // malloc for the PGconn will cause segfault on trying to
-  // open the connection
 #ifdef HAVE_POSTGIS
-  connection->phandle = (PGconn*)malloc(sizeof(PGconn*));
+  connection->phandle = NULL;
 #endif /* HAVE_POSTGIS */
 #ifdef HAVE_MYSQL
   //connection->mhandle = (MYSQL)malloc(sizeof(MYSQL));


### PR DESCRIPTION
connection->phandle was initialized with malloc(sizeof(PGconn*)) --
allocating only the size of a pointer (8 bytes), not the actual
(opaque) PGconn structure, and producing a non-NULL value regardless
of whether a real connection ever succeeds.

Every other use of phandle in this file (closeConnection,
pingConnection, checkConnection, etc.) gates on "phandle != NULL" to
decide whether a connection is open before passing it to libpq
functions like PQstatus(), PQexec(), and PQfinish(). Since the
malloc'd placeholder is never NULL, and openConnection() only
overwrites phandle on a successful connection, a failed connection
attempt leaves phandle pointing at 8 bytes of unrelated heap memory
that later code treats as a valid, connected PGconn -- passing it
into libpq internals, which is undefined behavior.

Initialize phandle to NULL instead, matching the sentinel every call
site already checks for.

Found via cppcheck (pointerSize warning) plus a manual trace of
every phandle use in the file. HAVE_POSTGIS is not enabled in this
build or in CI, so this path isn't covered by the test suite.